### PR TITLE
feat(password): add password protection for groups (#2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,11 +25,14 @@ anon-spliit is a privacy-focused fork of Spliit. All user data is **end-to-end e
 
 ### Key Files
 ```
-src/lib/crypto.ts              # Core crypto utilities
+src/lib/crypto.ts              # Core crypto utilities (PBKDF2, key derivation, password generation)
 src/lib/encrypt-helpers.ts     # Encryption/decryption helpers
+src/lib/totals.ts              # Stats calculation utilities
 src/lib/hooks/useBalances.ts   # Client-side balance calculation with decryption
-src/components/encryption-provider.tsx  # React context for encryption
+src/components/encryption-provider.tsx  # React context for encryption (handles password protection)
+src/components/password-prompt.tsx      # Password entry component with rate limiting
 src/lib/hooks/use-group-url.ts # URL navigation with key preservation
+src/app/groups/[groupId]/stats/totals.tsx  # Client-side stats with decryption
 ```
 
 ## Development Rules
@@ -119,15 +122,16 @@ src/lib/hooks/use-group-url.ts # URL navigation with key preservation
 - [x] All financial data fully encrypted (amount, originalAmount, shares)
 
 #### Issue #2: Password Protection
-**Status**: TODO
+**Status**: DONE
 **Priority**: HIGH
 **Link**: https://github.com/sora-grayscale/spliit/issues/2
 
-- Password-based key derivation (PBKDF2)
-- Password prompt on first access
-- Store password hint (optional)
-- Combine with URL key or replace it
-- Rate limiting for brute force protection
+- [x] Password-based key derivation (PBKDF2)
+- [x] Password prompt on first access
+- [x] Store password hint (optional, encrypted)
+- [x] Combine with URL key (double encryption)
+- [x] Rate limiting for brute force protection
+- [x] Secure password generation button
 
 ### Priority: LOW
 
@@ -165,6 +169,17 @@ src/lib/hooks/use-group-url.ts # URL navigation with key preservation
 - Proper attribution to original project
 
 ### Completed
+
+#### Password Protection (Issue #2) - DONE
+- [x] Schema: passwordSalt, passwordHint added to Group
+- [x] PBKDF2 key derivation (100,000 iterations)
+- [x] Password prompt component with rate limiting
+- [x] Secure password generation utility
+- [x] URL key + password key combination (XOR)
+- [x] EncryptionProvider handles password-protected groups
+- [x] Group creation form with optional password field
+- [x] Share button uses urlKey (not combined key) for correct sharing
+- [x] Stats calculation moved to client-side (works with encrypted data)
 
 #### Amount Encryption (Issue #3) - DONE
 - [x] Schema: amount, originalAmount, shares changed to String

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -485,5 +485,35 @@
       "help": "Ask the person who shared this group with you to send the complete link including the encryption key.",
       "backToGroups": "Back to Groups"
     }
+  },
+  "PasswordPrompt": {
+    "title": "Password Protected",
+    "description": "This group is password protected. Enter the password to unlock.",
+    "label": "Password",
+    "placeholder": "Enter password",
+    "hint": "Hint",
+    "unlock": "Unlock",
+    "unlocking": "Unlocking...",
+    "errors": {
+      "empty": "Please enter a password",
+      "invalid": "Invalid password. Please try again.",
+      "tooManyAttempts": "Too many attempts. Please wait before trying again."
+    }
+  },
+  "PasswordField": {
+    "title": "Password Protection",
+    "description": "Add a password to require both the link and password to access this group.",
+    "label": "Password (optional)",
+    "placeholder": "Enter password",
+    "hintLabel": "Password hint (optional)",
+    "hintPlaceholder": "e.g., Trip name",
+    "generate": "Generate",
+    "show": "Show",
+    "hide": "Hide",
+    "strength": {
+      "weak": "Weak password",
+      "medium": "Medium password",
+      "strong": "Strong password"
+    }
   }
 }

--- a/messages/ja-JP.json
+++ b/messages/ja-JP.json
@@ -476,5 +476,43 @@
     "other": {
       "heading": "その他の通貨"
     }
+  },
+  "Encryption": {
+    "required": {
+      "title": "暗号化されたグループ",
+      "description": "このグループはエンドツーエンド暗号化されています。アクセスするには暗号化キーを含む特別なリンクが必要です。",
+      "help": "このグループを共有した人に、暗号化キーを含む完全なリンクを送ってもらってください。",
+      "backToGroups": "グループ一覧に戻る"
+    }
+  },
+  "PasswordPrompt": {
+    "title": "パスワード保護",
+    "description": "このグループはパスワードで保護されています。パスワードを入力してください。",
+    "label": "パスワード",
+    "placeholder": "パスワードを入力",
+    "hint": "ヒント",
+    "unlock": "解除",
+    "unlocking": "解除中...",
+    "errors": {
+      "empty": "パスワードを入力してください",
+      "invalid": "パスワードが正しくありません。再度お試しください。",
+      "tooManyAttempts": "試行回数が多すぎます。しばらくしてから再度お試しください。"
+    }
+  },
+  "PasswordField": {
+    "title": "パスワード保護",
+    "description": "パスワードを追加して、リンクとパスワードの両方を必要にします。",
+    "label": "パスワード（任意）",
+    "placeholder": "パスワードを入力",
+    "hintLabel": "パスワードヒント（任意）",
+    "hintPlaceholder": "例: 旅行の名前",
+    "generate": "生成",
+    "show": "表示",
+    "hide": "非表示",
+    "strength": {
+      "weak": "弱いパスワード",
+      "medium": "普通のパスワード",
+      "strong": "強いパスワード"
+    }
   }
 }

--- a/prisma/migrations/20260112062338_password_protection/migration.sql
+++ b/prisma/migrations/20260112062338_password_protection/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "Group" ADD COLUMN     "passwordHint" TEXT,
+ADD COLUMN     "passwordSalt" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -22,6 +22,9 @@ model Group {
   activities   Activity[]
   createdAt    DateTime      @default(now())
   deletedAt    DateTime?
+  // Password protection (Issue #2)
+  passwordSalt String?       // Salt for PBKDF2 key derivation (base64 encoded)
+  passwordHint String?       // Encrypted password hint
 }
 
 model Participant {

--- a/src/app/groups/[groupId]/layout.client.tsx
+++ b/src/app/groups/[groupId]/layout.client.tsx
@@ -155,8 +155,26 @@ export function GroupLayoutClient({
   groupId,
   children,
 }: PropsWithChildren<{ groupId: string }>) {
+  // Fetch group data to check for password protection
+  const { data: groupData, isLoading: isGroupLoading } = trpc.groups.get.useQuery({
+    groupId,
+  })
+
+  // Wait for group data to check for password protection
+  if (isGroupLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-[60vh]">
+        <div className="animate-pulse text-muted-foreground">Loading...</div>
+      </div>
+    )
+  }
+
   return (
-    <EncryptionProvider>
+    <EncryptionProvider
+      passwordSalt={groupData?.group?.passwordSalt}
+      passwordHint={groupData?.group?.passwordHint}
+      encryptedGroupName={groupData?.group?.name}
+    >
       <GroupLayoutInner groupId={groupId}>{children}</GroupLayoutInner>
     </EncryptionProvider>
   )

--- a/src/app/groups/[groupId]/share-button.tsx
+++ b/src/app/groups/[groupId]/share-button.tsx
@@ -21,12 +21,11 @@ type Props = {
 export function ShareButton({ group }: Props) {
   const t = useTranslations('Share')
   const baseUrl = useBaseUrl()
-  const { encryptionKey } = useEncryption()
+  const { getUrlKeyBase64 } = useEncryption()
 
-  // Build URL with encryption key hash if available
-  const keyHash = encryptionKey
-    ? `#${btoa(String.fromCharCode(...Array.from(encryptionKey)))}`
-    : ''
+  // Build URL with URL key hash if available (use urlKey for sharing, not combined key)
+  const urlKeyBase64 = getUrlKeyBase64()
+  const keyHash = urlKeyBase64 ? `#${urlKeyBase64}` : ''
   const url = baseUrl && `${baseUrl}/groups/${group.id}/expenses?ref=share${keyHash}`
 
   return (

--- a/src/app/groups/create/create-group.tsx
+++ b/src/app/groups/create/create-group.tsx
@@ -1,11 +1,22 @@
 'use client'
 
 import { GroupForm } from '@/components/group-form'
-import { generateMasterKey, keyToBase64 } from '@/lib/crypto'
+import {
+  combineKeys,
+  deriveKeyFromPassword,
+  encrypt,
+  generateMasterKey,
+  generateSalt,
+  keyToBase64,
+} from '@/lib/crypto'
 import { encryptGroupFormValues } from '@/lib/encrypt-helpers'
 import { GroupFormValues } from '@/lib/schemas'
 import { trpc } from '@/trpc/client'
 import { useRouter } from 'next/navigation'
+
+// Storage key prefixes (must match encryption-provider.tsx)
+const STORAGE_KEY_PREFIX = 'spliit-e2ee-key-'
+const SESSION_PWD_KEY_PREFIX = 'spliit-pwd-key-'
 
 export const CreateGroup = () => {
   const { mutateAsync } = trpc.groups.create.useMutation()
@@ -16,22 +27,84 @@ export const CreateGroup = () => {
     <GroupForm
       onSubmit={async (groupFormValues) => {
         // Generate encryption key for the new group
-        const encryptionKey = generateMasterKey()
-        const keyBase64 = keyToBase64(encryptionKey)
+        const urlKey = generateMasterKey()
+        let encryptionKey = urlKey
+        let passwordSalt: string | undefined
+        let encryptedPasswordHint: string | undefined
+        let passwordKeyBase64: string | undefined
+
+        // If password is set, combine URL key with password-derived key
+        if (groupFormValues.password) {
+          const salt = generateSalt()
+          passwordSalt = keyToBase64(salt)
+
+          // Derive key from password
+          const passwordKey = await deriveKeyFromPassword(
+            groupFormValues.password,
+            salt
+          )
+          passwordKeyBase64 = keyToBase64(passwordKey)
+
+          // Combine keys using XOR for double encryption
+          encryptionKey = combineKeys(urlKey, passwordKey)
+
+          // Encrypt password hint if provided
+          if (groupFormValues.passwordHint) {
+            encryptedPasswordHint = await encrypt(
+              groupFormValues.passwordHint,
+              urlKey // Use URL key to encrypt hint (so it can be shown before password entry)
+            )
+          }
+        }
+
+        const keyBase64 = keyToBase64(urlKey)
+        const combinedKeyBase64 = keyToBase64(encryptionKey)
+
+        // Prepare values for encryption (remove password field, add salt)
+        const { password, passwordHint, ...valuesWithoutPassword } = groupFormValues
+        const valuesForEncryption = {
+          ...valuesWithoutPassword,
+          passwordSalt,
+          passwordHint: encryptedPasswordHint,
+        }
 
         // Encrypt group data before sending to server
         const encryptedValues = await encryptGroupFormValues(
-          groupFormValues,
+          valuesForEncryption,
           encryptionKey
         )
 
+        // Add password protection fields (not included by encryptGroupFormValues)
+        const groupFormValuesWithPassword = {
+          ...encryptedValues,
+          passwordSalt,
+          passwordHint: encryptedPasswordHint,
+        }
+
         // Send encrypted data to server
         const { groupId } = await mutateAsync({
-          groupFormValues: encryptedValues as GroupFormValues,
+          groupFormValues: groupFormValuesWithPassword as GroupFormValues,
         })
         await utils.groups.invalidate()
 
-        // Redirect with encryption key in URL fragment
+        // Save keys to storage BEFORE redirect so EncryptionProvider can find them
+        // This is done after group creation succeeds to avoid storing keys for failed creations
+        try {
+          // Save the combined key to localStorage (persistent)
+          localStorage.setItem(`${STORAGE_KEY_PREFIX}${groupId}`, combinedKeyBase64)
+
+          // If password was used, also save password-derived key to sessionStorage
+          // This allows EncryptionProvider to verify the key combination
+          if (passwordKeyBase64) {
+            sessionStorage.setItem(`${SESSION_PWD_KEY_PREFIX}${groupId}`, passwordKeyBase64)
+          }
+        } catch (error) {
+          // Storage might be unavailable (private browsing, etc.)
+          // Continue anyway - user will need to re-enter password if needed
+          console.warn('Failed to save encryption keys to storage:', error)
+        }
+
+        // Redirect with URL key in fragment
         router.push(`/groups/${groupId}#${keyBase64}`)
       }}
     />

--- a/src/components/encryption-provider.tsx
+++ b/src/components/encryption-provider.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { PasswordPrompt } from '@/components/password-prompt'
 import {
   base64ToKey,
   decrypt,
@@ -23,6 +24,8 @@ import {
 
 // localStorage key prefix for encryption keys
 const STORAGE_KEY_PREFIX = 'spliit-e2ee-key-'
+// sessionStorage key prefix for password-derived keys
+const SESSION_PWD_KEY_PREFIX = 'spliit-pwd-key-'
 
 /**
  * Extract groupId from current URL path
@@ -68,6 +71,8 @@ function loadKeyFromStorage(groupId: string): Uint8Array | null {
 interface EncryptionContextValue {
   /** The encryption key (null if not available) */
   encryptionKey: Uint8Array | null
+  /** The URL key for sharing (same as encryptionKey for non-password groups) */
+  urlKey: Uint8Array | null
   /** Whether the key is still being loaded from URL */
   isLoading: boolean
   /** Error message if key is invalid */
@@ -76,8 +81,12 @@ interface EncryptionContextValue {
   hasKey: boolean
   /** Whether the group requires encryption but key is missing */
   needsKey: boolean
+  /** Whether the group requires password entry */
+  needsPassword: boolean
   /** Get the key as base64 string */
   getKeyBase64: () => string | null
+  /** Get the URL key as base64 string (for sharing) */
+  getUrlKeyBase64: () => string | null
   /** Encrypt a string */
   encryptString: (data: string) => Promise<string>
   /** Decrypt a string */
@@ -98,127 +107,258 @@ interface EncryptionProviderProps {
   children: ReactNode
   /** If true, generate a new key if none exists in URL */
   generateIfMissing?: boolean
+  /** Password salt for password-protected groups (base64 encoded) */
+  passwordSalt?: string | null
+  /** Encrypted password hint */
+  passwordHint?: string | null
+  /** Encrypted group name for password verification */
+  encryptedGroupName?: string | null
 }
 
 export function EncryptionProvider({
   children,
   generateIfMissing = false,
+  passwordSalt,
+  passwordHint,
+  encryptedGroupName,
 }: EncryptionProviderProps) {
   const [encryptionKey, setEncryptionKey] = useState<Uint8Array | null>(null)
+  const [urlKey, setUrlKey] = useState<Uint8Array | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [needsKey, setNeedsKey] = useState(false)
+  const [needsPassword, setNeedsPassword] = useState(false)
+  const [decryptedHint, setDecryptedHint] = useState<string | null>(null)
 
-  // Function to read key from URL hash and save to localStorage
-  const readKeyFromHash = useCallback(() => {
-    if (typeof window === 'undefined') return false
+  // Function to read URL key from hash
+  const readUrlKeyFromHash = useCallback(() => {
+    if (typeof window === 'undefined') return null
 
     const hash = window.location.hash.slice(1)
-    const groupId = getGroupIdFromPath()
+    if (!hash) return null
 
-    if (hash) {
-      try {
-        const key = base64ToKey(hash)
-        if (key.length === 16) {
-          // Save to localStorage for future access
-          if (groupId) {
-            saveKeyToStorage(groupId, key)
-          }
-          // Only update if key changed
-          setEncryptionKey((current) => {
-            if (current && keyToBase64(current) === keyToBase64(key)) {
-              return current
-            }
-            return key
-          })
-          setError(null)
-          setNeedsKey(false)
-          return true
-        } else {
-          setError('Invalid encryption key length')
-        }
-      } catch {
-        setError('Invalid encryption key format')
+    try {
+      const key = base64ToKey(hash)
+      if (key.length === 16) {
+        return key
       }
+    } catch {
+      // Invalid key format
     }
-    return false
+    return null
   }, [])
 
-  // Function to restore key from localStorage and update URL
-  const restoreKeyFromStorage = useCallback(() => {
-    if (typeof window === 'undefined') return false
+  // Function to restore URL key from localStorage
+  const restoreUrlKeyFromStorage = useCallback(() => {
+    if (typeof window === 'undefined') return null
 
     const groupId = getGroupIdFromPath()
-    if (!groupId) return false
+    if (!groupId) return null
 
-    const key = loadKeyFromStorage(groupId)
-    if (key) {
-      setEncryptionKey(key)
-      setError(null)
-      setNeedsKey(false)
-
-      // Update URL with key hash (without triggering navigation)
-      const keyBase64 = keyToBase64(key)
-      const newUrl = `${window.location.pathname}${window.location.search}#${keyBase64}`
-      window.history.replaceState(null, '', newUrl)
-      return true
-    }
-    return false
+    // For password-protected groups, we need to check if we have the combined key
+    // and extract the URL key from session storage
+    const savedKey = loadKeyFromStorage(groupId)
+    return savedKey
   }, [])
+
+  // Function to get password-derived key from session storage
+  const getSessionPasswordKey = useCallback(() => {
+    if (typeof window === 'undefined') return null
+
+    const groupId = getGroupIdFromPath()
+    if (!groupId) return null
+
+    try {
+      const keyBase64 = sessionStorage.getItem(`${SESSION_PWD_KEY_PREFIX}${groupId}`)
+      if (keyBase64) {
+        return base64ToKey(keyBase64)
+      }
+    } catch {
+      // Session storage not available or invalid key
+    }
+    return null
+  }, [])
+
+  // Handle password entry success
+  const handlePasswordSuccess = useCallback(
+    (combinedKey: Uint8Array) => {
+      setEncryptionKey(combinedKey)
+      setNeedsPassword(false)
+      setError(null)
+    },
+    []
+  )
 
   // Read key from URL fragment on mount and handle missing key
   useEffect(() => {
     if (typeof window === 'undefined') return
 
-    // First try to read from URL hash
-    let hasKey = readKeyFromHash()
-
-    // If no key in URL, try to restore from localStorage
-    if (!hasKey) {
-      hasKey = restoreKeyFromStorage()
-    }
-
-    // If still no key and we should generate one
-    if (!hasKey && generateIfMissing) {
-      const newKey = generateMasterKey()
-      setEncryptionKey(newKey)
-      setError(null)
-      setNeedsKey(false)
-
-      // Save to localStorage
+    const initializeKey = async () => {
       const groupId = getGroupIdFromPath()
-      if (groupId) {
-        saveKeyToStorage(groupId, newKey)
+
+      // For password-protected groups, check if we have a session password key
+      // If yes, we can try to use the stored combined key directly
+      const sessionPwdKey = passwordSalt ? getSessionPasswordKey() : null
+
+      // First try to read URL key from hash
+      const hashUrlKey = readUrlKeyFromHash()
+
+      // Also check localStorage for saved key
+      const storedKey = restoreUrlKeyFromStorage()
+
+      // CASE 1: Password-protected group with session password key
+      // The stored key is already the combined key, use it directly
+      if (passwordSalt && sessionPwdKey && storedKey) {
+        setEncryptionKey(storedKey)
+        setNeedsPassword(false)
+        setNeedsKey(false)
+
+        // Update URL with the URL key from hash if available
+        if (hashUrlKey) {
+          setUrlKey(hashUrlKey)
+        }
+
+        setIsLoading(false)
+        return
       }
 
-      // Update URL without navigation
-      const base64Key = keyToBase64(newKey)
-      const newUrl = `${window.location.pathname}${window.location.search}#${base64Key}`
-      window.history.replaceState(null, '', newUrl)
+      // CASE 1.5: Password-protected group, just redirected from creation
+      // We have both URL key in hash AND combined key in localStorage
+      // This happens immediately after group creation before session expires
+      if (passwordSalt && hashUrlKey && storedKey) {
+        setEncryptionKey(storedKey)
+        setUrlKey(hashUrlKey)
+        setNeedsPassword(false)
+        setNeedsKey(false)
+        setIsLoading(false)
+        return
+      }
+
+      // CASE 2: Password-protected group but no session password key
+      // We need the URL key to derive the combined key after password entry
+      if (passwordSalt) {
+        const urlKeyToUse = hashUrlKey || null
+        if (urlKeyToUse) {
+          setUrlKey(urlKeyToUse)
+          setNeedsPassword(true)
+          setNeedsKey(false)
+
+          // Decrypt password hint if available
+          if (passwordHint) {
+            try {
+              const hint = await decrypt(passwordHint, urlKeyToUse)
+              setDecryptedHint(hint)
+            } catch {
+              // Failed to decrypt hint
+            }
+          }
+        } else {
+          // No URL key available, need key
+          setNeedsKey(true)
+        }
+
+        setIsLoading(false)
+        return
+      }
+
+      // CASE 3: Non-password group
+      let currentKey = hashUrlKey
+
+      if (!currentKey) {
+        currentKey = storedKey
+
+        // If we have a key from storage, update the URL
+        if (currentKey) {
+          const keyBase64 = keyToBase64(currentKey)
+          const newUrl = `${window.location.pathname}${window.location.search}#${keyBase64}`
+          window.history.replaceState(null, '', newUrl)
+        }
+      } else {
+        // Save URL key to localStorage
+        if (groupId) {
+          saveKeyToStorage(groupId, currentKey)
+        }
+      }
+
+      // If still no key and we should generate one
+      if (!currentKey && generateIfMissing) {
+        currentKey = generateMasterKey()
+        setError(null)
+
+        // Save to localStorage
+        if (groupId) {
+          saveKeyToStorage(groupId, currentKey)
+        }
+
+        // Update URL without navigation
+        const base64Key = keyToBase64(currentKey)
+        const newUrl = `${window.location.pathname}${window.location.search}#${base64Key}`
+        window.history.replaceState(null, '', newUrl)
+      }
+
+      if (currentKey) {
+        setEncryptionKey(currentKey)
+        setUrlKey(currentKey)
+        setNeedsKey(false)
+      } else {
+        setNeedsKey(true)
+      }
+
+      setIsLoading(false)
     }
 
-    setIsLoading(false)
+    initializeKey()
 
-    // Listen for hash changes
-    const handleHashChange = () => {
-      readKeyFromHash()
+    // Listen for hash changes (mainly for non-password groups)
+    const handleHashChange = async () => {
+      // For password-protected groups, don't auto-process hash changes
+      if (passwordSalt) return
+
+      const newUrlKey = readUrlKeyFromHash()
+      if (newUrlKey) {
+        setUrlKey(newUrlKey)
+        setEncryptionKey(newUrlKey)
+        const groupId = getGroupIdFromPath()
+        if (groupId) {
+          saveKeyToStorage(groupId, newUrlKey)
+        }
+      }
     }
 
     window.addEventListener('hashchange', handleHashChange)
     return () => window.removeEventListener('hashchange', handleHashChange)
-  }, [generateIfMissing, readKeyFromHash, restoreKeyFromStorage])
+  }, [generateIfMissing, passwordSalt, passwordHint, readUrlKeyFromHash, restoreUrlKeyFromStorage, getSessionPasswordKey])
 
   // Also check hash periodically in case hashchange event didn't fire
+  // This is mainly for non-password groups
   useEffect(() => {
     if (typeof window === 'undefined') return
+    // Skip for password-protected groups - handled by main initialization
+    if (passwordSalt) return
 
     const checkHash = () => {
       const hash = window.location.hash.slice(1)
       if (hash && !encryptionKey) {
-        readKeyFromHash()
+        const newUrlKey = readUrlKeyFromHash()
+        if (newUrlKey) {
+          setUrlKey(newUrlKey)
+          setEncryptionKey(newUrlKey)
+          const groupId = getGroupIdFromPath()
+          if (groupId) {
+            saveKeyToStorage(groupId, newUrlKey)
+          }
+        }
       } else if (!hash && !encryptionKey) {
         // Try to restore from localStorage
-        restoreKeyFromStorage()
+        const restoredKey = restoreUrlKeyFromStorage()
+        if (restoredKey) {
+          setUrlKey(restoredKey)
+          setEncryptionKey(restoredKey)
+          // Update URL with key
+          const keyBase64 = keyToBase64(restoredKey)
+          const newUrl = `${window.location.pathname}${window.location.search}#${keyBase64}`
+          window.history.replaceState(null, '', newUrl)
+        }
       }
     }
 
@@ -228,12 +368,17 @@ export function EncryptionProvider({
     // Check again after a short delay (for navigation timing)
     const timer = setTimeout(checkHash, 100)
     return () => clearTimeout(timer)
-  }, [encryptionKey, readKeyFromHash, restoreKeyFromStorage])
+  }, [encryptionKey, passwordSalt, readUrlKeyFromHash, restoreUrlKeyFromStorage])
 
   const getKeyBase64 = useCallback(() => {
     if (!encryptionKey) return null
     return keyToBase64(encryptionKey)
   }, [encryptionKey])
+
+  const getUrlKeyBase64 = useCallback(() => {
+    if (!urlKey) return null
+    return keyToBase64(urlKey)
+  }, [urlKey])
 
   const encryptString = useCallback(
     async (data: string) => {
@@ -286,11 +431,14 @@ export function EncryptionProvider({
   const value = useMemo<EncryptionContextValue>(
     () => ({
       encryptionKey,
+      urlKey,
       isLoading,
       error,
       hasKey: encryptionKey !== null,
       needsKey,
+      needsPassword,
       getKeyBase64,
+      getUrlKeyBase64,
       encryptString,
       decryptString,
       encryptNum,
@@ -300,10 +448,13 @@ export function EncryptionProvider({
     }),
     [
       encryptionKey,
+      urlKey,
       isLoading,
       error,
       needsKey,
+      needsPassword,
       getKeyBase64,
+      getUrlKeyBase64,
       encryptString,
       decryptString,
       encryptNum,
@@ -313,9 +464,23 @@ export function EncryptionProvider({
     ]
   )
 
+  // Get groupId for password prompt
+  const groupId = typeof window !== 'undefined' ? getGroupIdFromPath() : null
+
   return (
     <EncryptionContext.Provider value={value}>
-      {children}
+      {needsPassword && passwordSalt && urlKey && groupId ? (
+        <PasswordPrompt
+          groupId={groupId}
+          passwordSalt={passwordSalt}
+          passwordHint={decryptedHint}
+          urlKey={urlKey}
+          encryptedGroupName={encryptedGroupName}
+          onSuccess={handlePasswordSuccess}
+        />
+      ) : (
+        children
+      )}
     </EncryptionContext.Provider>
   )
 }
@@ -337,6 +502,10 @@ export function useRequireEncryption() {
 
   if (encryption.isLoading) {
     return { ...encryption, status: 'loading' as const }
+  }
+
+  if (encryption.needsPassword) {
+    return { ...encryption, status: 'needs-password' as const }
   }
 
   if (!encryption.hasKey) {

--- a/src/components/password-prompt.tsx
+++ b/src/components/password-prompt.tsx
@@ -1,0 +1,214 @@
+'use client'
+
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { base64ToKey, combineKeys, decrypt, deriveKeyFromPassword, keyToBase64 } from '@/lib/crypto'
+import { AlertCircle, Eye, EyeOff, KeyRound, Loader2 } from 'lucide-react'
+import { useTranslations } from 'next-intl'
+import { useState } from 'react'
+
+// Rate limiting for brute force protection
+const RATE_LIMIT_ATTEMPTS = 5
+const RATE_LIMIT_WINDOW_MS = 60000 // 1 minute
+const LOCKOUT_DURATION_MS = 300000 // 5 minutes
+
+interface PasswordPromptProps {
+  groupId: string
+  passwordSalt: string
+  passwordHint?: string | null
+  urlKey: Uint8Array | null
+  encryptedGroupName?: string | null
+  onSuccess: (combinedKey: Uint8Array) => void
+}
+
+export function PasswordPrompt({
+  groupId,
+  passwordSalt,
+  passwordHint,
+  urlKey,
+  encryptedGroupName,
+  onSuccess,
+}: PasswordPromptProps) {
+  const t = useTranslations('PasswordPrompt')
+  const [password, setPassword] = useState('')
+  const [showPassword, setShowPassword] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [attempts, setAttempts] = useState<number[]>([])
+  const [lockedUntil, setLockedUntil] = useState<number | null>(null)
+
+  // Check rate limit
+  const isRateLimited = () => {
+    const now = Date.now()
+
+    // Check if currently locked out
+    if (lockedUntil && now < lockedUntil) {
+      return true
+    }
+
+    // Clean old attempts
+    const recentAttempts = attempts.filter(
+      (time) => now - time < RATE_LIMIT_WINDOW_MS
+    )
+    setAttempts(recentAttempts)
+
+    return recentAttempts.length >= RATE_LIMIT_ATTEMPTS
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    if (!password.trim()) {
+      setError(t('errors.empty'))
+      return
+    }
+
+    // Check rate limit
+    if (isRateLimited()) {
+      const now = Date.now()
+      if (!lockedUntil || now >= lockedUntil) {
+        // Start lockout
+        setLockedUntil(now + LOCKOUT_DURATION_MS)
+      }
+      setError(t('errors.tooManyAttempts'))
+      return
+    }
+
+    setIsLoading(true)
+    setError(null)
+
+    try {
+      // Decode salt from base64
+      const salt = base64ToKey(passwordSalt)
+
+      // Derive key from password
+      const passwordKey = await deriveKeyFromPassword(password, salt)
+
+      // Combine with URL key if present, or use password key alone
+      const finalKey = urlKey ? combineKeys(urlKey, passwordKey) : passwordKey
+
+      // Verify the password by attempting to decrypt the group name
+      if (encryptedGroupName) {
+        try {
+          await decrypt(encryptedGroupName, finalKey)
+        } catch {
+          // Decryption failed - wrong password
+          setAttempts((prev) => [...prev, Date.now()])
+          setError(t('errors.invalid'))
+          setPassword('')
+          setIsLoading(false)
+          return
+        }
+      }
+
+      // Save to localStorage for this group
+      const keyBase64 = keyToBase64(finalKey)
+      localStorage.setItem(`spliit-e2ee-key-${groupId}`, keyBase64)
+
+      // Also save password-derived key separately for session
+      sessionStorage.setItem(`spliit-pwd-key-${groupId}`, keyToBase64(passwordKey))
+
+      onSuccess(finalKey)
+    } catch (err) {
+      // Record failed attempt
+      setAttempts((prev) => [...prev, Date.now()])
+      setError(t('errors.invalid'))
+      setPassword('')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const remainingLockoutTime = lockedUntil
+    ? Math.max(0, Math.ceil((lockedUntil - Date.now()) / 1000))
+    : 0
+
+  return (
+    <div className="flex items-center justify-center min-h-[60vh]">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <div className="mx-auto mb-4 w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center">
+            <KeyRound className="w-6 h-6 text-primary" />
+          </div>
+          <CardTitle>{t('title')}</CardTitle>
+          <CardDescription>{t('description')}</CardDescription>
+        </CardHeader>
+        <form onSubmit={handleSubmit}>
+          <CardContent className="space-y-4">
+            {passwordHint && (
+              <div className="text-sm text-muted-foreground bg-muted p-3 rounded-md">
+                <span className="font-medium">{t('hint')}:</span> {passwordHint}
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="password">{t('label')}</Label>
+              <div className="relative">
+                <Input
+                  id="password"
+                  type={showPassword ? 'text' : 'password'}
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder={t('placeholder')}
+                  disabled={isLoading || remainingLockoutTime > 0}
+                  autoFocus
+                  className="pr-10"
+                />
+                <button
+                  type="button"
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+                  onClick={() => setShowPassword(!showPassword)}
+                >
+                  {showPassword ? (
+                    <EyeOff className="w-4 h-4" />
+                  ) : (
+                    <Eye className="w-4 h-4" />
+                  )}
+                </button>
+              </div>
+            </div>
+
+            {error && (
+              <div className="flex items-center gap-2 text-sm text-destructive">
+                <AlertCircle className="w-4 h-4" />
+                {error}
+                {remainingLockoutTime > 0 && (
+                  <span>
+                    {' '}
+                    ({Math.floor(remainingLockoutTime / 60)}:
+                    {(remainingLockoutTime % 60).toString().padStart(2, '0')})
+                  </span>
+                )}
+              </div>
+            )}
+          </CardContent>
+          <CardFooter>
+            <Button
+              type="submit"
+              className="w-full"
+              disabled={isLoading || remainingLockoutTime > 0}
+            >
+              {isLoading ? (
+                <>
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                  {t('unlocking')}
+                </>
+              ) : (
+                t('unlock')
+              )}
+            </Button>
+          </CardFooter>
+        </form>
+      </Card>
+    </div>
+  )
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -20,6 +20,9 @@ export async function createGroup(groupFormValues: GroupFormValues) {
       information: groupFormValues.information,
       currency: groupFormValues.currency,
       currencyCode: groupFormValues.currencyCode,
+      // Password protection (Issue #2)
+      passwordSalt: groupFormValues.passwordSalt,
+      passwordHint: groupFormValues.passwordHint,
       participants: {
         createMany: {
           data: groupFormValues.participants.map(({ name }) => ({

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -209,3 +209,6 @@ export function useEncryptionKey() {
     getKeyBase64,
   }
 }
+
+// Re-export from hooks directory
+export { useBalances } from './hooks/useBalances'

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -17,6 +17,10 @@ export const groupFormSchema = z
         }),
       )
       .min(1),
+    // Password protection (Issue #2)
+    password: z.string().optional(), // Used only during creation, not stored
+    passwordHint: z.string().max(100, 'max100').optional(),
+    passwordSalt: z.string().optional(), // Base64 encoded salt, stored in DB
   })
   .superRefine(({ participants }, ctx) => {
     participants.forEach((participant, i) => {


### PR DESCRIPTION
## Summary
- Add optional password protection when creating groups with PBKDF2 key derivation (100,000 iterations)
- Implement XOR key combination (URL key + password-derived key) for enhanced dual-layer encryption
- Add password prompt component with rate limiting (5 attempts/min, 5 min lockout)
- Fix share URL generation to use URL key instead of combined key
- Move stats calculation to client-side for encrypted data support

## Security Features
- Rate limiting prevents brute force attacks
- Password verification via group name decryption attempt
- Session storage for password-derived key
- localStorage for combined encryption key
- Secure password generation button

## Database Changes
- Added `passwordSalt` field to groups table
- Added `passwordHint` field to groups table

## Key Files Changed
- **prisma/schema.prisma**: Added passwordSalt and passwordHint fields
- **src/lib/crypto.ts**: PBKDF2 key derivation, key combination utilities
- **src/components/password-prompt.tsx**: Password entry with rate limiting
- **src/components/group-form.tsx**: Password field with generate button
- **src/components/encryption-provider.tsx**: Password-protected group handling
- **src/app/groups/[groupId]/share-button.tsx**: Fixed URL key usage for sharing
- **src/app/groups/[groupId]/stats/totals.tsx**: Client-side stats calculation

## Test plan
- [x] Create a new group with password protection enabled
- [x] Verify password hint is displayed on the password prompt
- [x] Verify correct password unlocks the group
- [x] Verify incorrect password shows error and does not unlock
- [x] Verify rate limiting kicks in after 5 failed attempts
- [x] Share the group link and verify recipient needs the password
- [x] Verify stats calculation works correctly with encrypted expenses

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)