### PR TITLE
feat(auto-delete): add auto-delete for inactive groups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,8 @@ POSTGRES_PRISMA_URL=postgresql://postgres:1234@localhost
 POSTGRES_URL_NON_POOLING=postgresql://postgres:1234@localhost
 
 NEXT_PUBLIC_DEFAULT_CURRENCY_CODE=""
+
+# Auto-delete settings (Issue #10)
+AUTO_DELETE_INACTIVE_DAYS=90    # Days of inactivity before auto-deletion (0 to disable)
+DELETE_GRACE_PERIOD_DAYS=7      # Days before permanent deletion after soft-delete
+CRON_SECRET=""                   # Secret for authenticating cron requests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,12 @@ src/lib/crypto.ts              # Core crypto utilities (PBKDF2, key derivation, 
 src/lib/encrypt-helpers.ts     # Encryption/decryption helpers
 src/lib/totals.ts              # Stats calculation utilities
 src/lib/hooks/useBalances.ts   # Client-side balance calculation with decryption
+src/lib/auto-delete.ts         # Auto-delete inactive groups (Issue #10)
 src/components/encryption-provider.tsx  # React context for encryption (handles password protection)
 src/components/password-prompt.tsx      # Password entry component with rate limiting
 src/lib/hooks/use-group-url.ts # URL navigation with key preservation
 src/app/groups/[groupId]/stats/totals.tsx  # Client-side stats with decryption
+src/app/api/cron/auto-delete/route.ts  # Cron endpoint for auto-deletion
 ```
 
 ## Development Rules
@@ -103,13 +105,17 @@ src/app/groups/[groupId]/stats/totals.tsx  # Client-side stats with decryption
 - [x] Share button includes encryption key in URL
 
 #### Issue #10: Auto-delete Inactive Groups
-**Status**: TODO
+**Status**: DONE
 **Priority**: LOW
 **Link**: https://github.com/sora-grayscale/spliit/issues/10
 
-- [ ] Environment variable configuration (`AUTO_DELETE_INACTIVE_DAYS`)
-- [ ] Track last activity date per group
-- [ ] Cron job to soft-delete inactive groups
+- [x] Environment variable configuration (`AUTO_DELETE_INACTIVE_DAYS`, `DELETE_GRACE_PERIOD_DAYS`, `CRON_SECRET`)
+- [x] Track last activity date per group (using Activity table)
+- [x] Cron API endpoint (`/api/cron/auto-delete`)
+- [x] Soft-delete inactive groups automatically
+- [x] Permanent deletion of groups past grace period
+- [x] Vercel Cron configuration (daily at 3:00 AM UTC)
+- [x] Unit tests for auto-delete functionality
 
 #### Issue #3: Amount Encryption (Complete E2EE)
 **Status**: DONE
@@ -241,13 +247,15 @@ src/app/groups/[groupId]/stats/totals.tsx  # Client-side stats with decryption
 
 ```bash
 # Database
-DATABASE_URL=postgresql://user:pass@host:5432/db
+POSTGRES_PRISMA_URL=postgresql://user:pass@host:5432/db
+POSTGRES_URL_NON_POOLING=postgresql://user:pass@host:5432/db
 
-# Auto-deletion (Issue #6)
-AUTO_DELETE_DAYS=90              # Days of inactivity before auto-deletion
-DELETE_GRACE_PERIOD_DAYS=7       # Days before permanent deletion
+# Auto-deletion (Issue #10)
+AUTO_DELETE_INACTIVE_DAYS=90     # Days of inactivity before auto-deletion (0 to disable)
+DELETE_GRACE_PERIOD_DAYS=7       # Days before permanent deletion after soft-delete
+CRON_SECRET=                     # Secret for authenticating cron requests
 
-# Private Instance (Issue #4)
+# Private Instance (Issue #4) - TODO
 PRIVATE_INSTANCE=false           # Enable private instance mode
 ADMIN_EMAIL=admin@example.com    # Initial admin email
 REQUIRE_AUTH=false               # Require authentication for all users

--- a/src/app/api/cron/auto-delete/route.ts
+++ b/src/app/api/cron/auto-delete/route.ts
@@ -1,0 +1,63 @@
+import {
+  autoDeleteInactiveGroups,
+  cleanupExpiredGroups,
+} from '@/lib/auto-delete'
+import { env } from '@/lib/env'
+import { NextRequest, NextResponse } from 'next/server'
+
+/**
+ * Cron endpoint for auto-deleting inactive groups
+ * - Soft-deletes groups inactive for AUTO_DELETE_INACTIVE_DAYS
+ * - Permanently deletes groups past DELETE_GRACE_PERIOD_DAYS grace period
+ *
+ * Authentication: Requires CRON_SECRET in Authorization header
+ * Usage: curl -X POST -H "Authorization: Bearer $CRON_SECRET" /api/cron/auto-delete
+ */
+export async function POST(request: NextRequest) {
+  // Verify CRON_SECRET if configured
+  if (env.CRON_SECRET) {
+    const authHeader = request.headers.get('authorization')
+    const token = authHeader?.replace('Bearer ', '')
+
+    if (token !== env.CRON_SECRET) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+  }
+
+  try {
+    const results = {
+      autoDelete: { softDeleted: 0, groupIds: [] as string[] },
+      cleanup: { permanentlyDeleted: 0, groupIds: [] as string[] },
+      timestamp: new Date().toISOString(),
+    }
+
+    // Step 1: Soft-delete inactive groups (if enabled)
+    if (env.AUTO_DELETE_INACTIVE_DAYS > 0) {
+      results.autoDelete = await autoDeleteInactiveGroups(
+        env.AUTO_DELETE_INACTIVE_DAYS,
+      )
+    }
+
+    // Step 2: Permanently delete groups past grace period
+    results.cleanup = await cleanupExpiredGroups(env.DELETE_GRACE_PERIOD_DAYS)
+
+    return NextResponse.json({
+      success: true,
+      results,
+    })
+  } catch (error) {
+    console.error('Auto-delete cron error:', error)
+    return NextResponse.json(
+      {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      },
+      { status: 500 },
+    )
+  }
+}
+
+// Also allow GET for Vercel Cron compatibility
+export async function GET(request: NextRequest) {
+  return POST(request)
+}

--- a/src/lib/auto-delete.test.ts
+++ b/src/lib/auto-delete.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Auto-delete functionality tests (Issue #10)
+ *
+ * These tests verify the auto-delete logic for inactive groups.
+ * Note: These are unit tests that mock Prisma - integration tests would require a real database.
+ */
+
+// Mock Prisma before importing modules that use it
+jest.mock('./prisma', () => ({
+  prisma: {
+    group: {
+      findMany: jest.fn(),
+      updateMany: jest.fn(),
+      deleteMany: jest.fn(),
+    },
+    activity: {
+      findFirst: jest.fn(),
+    },
+  },
+}))
+
+import {
+  autoDeleteInactiveGroups,
+  cleanupExpiredGroups,
+  getInactiveGroups,
+} from './auto-delete'
+import { prisma } from './prisma'
+
+// Get typed mock reference
+const mockGroup = prisma.group as jest.Mocked<typeof prisma.group>
+const mockActivity = prisma.activity as jest.Mocked<typeof prisma.activity>
+
+describe('Auto-delete functionality', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('getInactiveGroups', () => {
+    it('should return empty array when no groups exist', async () => {
+      ;(mockGroup.findMany as jest.Mock).mockResolvedValue([])
+
+      const result = await getInactiveGroups(90)
+
+      expect(result).toEqual([])
+      expect(mockGroup.findMany).toHaveBeenCalledWith({
+        where: { deletedAt: null },
+        select: { id: true, createdAt: true },
+      })
+    })
+
+    it('should return inactive groups based on activity', async () => {
+      const now = new Date()
+      const oldDate = new Date(now)
+      oldDate.setDate(oldDate.getDate() - 100) // 100 days ago
+
+      const recentDate = new Date(now)
+      recentDate.setDate(recentDate.getDate() - 10) // 10 days ago
+      ;(mockGroup.findMany as jest.Mock).mockResolvedValue([
+        { id: 'inactive-group', createdAt: oldDate },
+        { id: 'active-group', createdAt: oldDate },
+      ])
+
+      // First call for inactive-group - no activity
+      // Second call for active-group - recent activity
+      ;(mockActivity.findFirst as jest.Mock)
+        .mockResolvedValueOnce(null) // inactive-group has no activity
+        .mockResolvedValueOnce({ time: recentDate }) // active-group has recent activity
+
+      const result = await getInactiveGroups(90)
+
+      expect(result).toEqual(['inactive-group'])
+    })
+
+    it('should use group creation date when no activity exists', async () => {
+      const now = new Date()
+      const oldCreationDate = new Date(now)
+      oldCreationDate.setDate(oldCreationDate.getDate() - 100) // 100 days ago
+      ;(mockGroup.findMany as jest.Mock).mockResolvedValue([
+        { id: 'old-group', createdAt: oldCreationDate },
+      ])
+      ;(mockActivity.findFirst as jest.Mock).mockResolvedValue(null)
+
+      const result = await getInactiveGroups(90)
+
+      expect(result).toEqual(['old-group'])
+    })
+
+    it('should not include groups with recent activity', async () => {
+      const now = new Date()
+      const recentActivity = new Date(now)
+      recentActivity.setDate(recentActivity.getDate() - 30) // 30 days ago
+      ;(mockGroup.findMany as jest.Mock).mockResolvedValue([
+        { id: 'recent-group', createdAt: new Date('2020-01-01') },
+      ])
+      ;(mockActivity.findFirst as jest.Mock).mockResolvedValue({
+        time: recentActivity,
+      })
+
+      const result = await getInactiveGroups(90)
+
+      expect(result).toEqual([])
+    })
+  })
+
+  describe('autoDeleteInactiveGroups', () => {
+    it('should return early when inactiveDays is 0 (disabled)', async () => {
+      const result = await autoDeleteInactiveGroups(0)
+
+      expect(result).toEqual({ softDeleted: 0, groupIds: [] })
+      expect(mockGroup.findMany).not.toHaveBeenCalled()
+    })
+
+    it('should return early when inactiveDays is negative', async () => {
+      const result = await autoDeleteInactiveGroups(-1)
+
+      expect(result).toEqual({ softDeleted: 0, groupIds: [] })
+      expect(mockGroup.findMany).not.toHaveBeenCalled()
+    })
+
+    it('should soft-delete inactive groups', async () => {
+      const now = new Date()
+      const oldDate = new Date(now)
+      oldDate.setDate(oldDate.getDate() - 100)
+      ;(mockGroup.findMany as jest.Mock).mockResolvedValue([
+        { id: 'inactive-1', createdAt: oldDate },
+        { id: 'inactive-2', createdAt: oldDate },
+      ])
+      ;(mockActivity.findFirst as jest.Mock).mockResolvedValue(null)
+      ;(mockGroup.updateMany as jest.Mock).mockResolvedValue({ count: 2 })
+
+      const result = await autoDeleteInactiveGroups(90)
+
+      expect(result.softDeleted).toBe(2)
+      expect(result.groupIds).toEqual(['inactive-1', 'inactive-2'])
+      expect(mockGroup.updateMany).toHaveBeenCalledWith({
+        where: { id: { in: ['inactive-1', 'inactive-2'] } },
+        data: { deletedAt: expect.any(Date) },
+      })
+    })
+
+    it('should return 0 when no inactive groups exist', async () => {
+      ;(mockGroup.findMany as jest.Mock).mockResolvedValue([])
+
+      const result = await autoDeleteInactiveGroups(90)
+
+      expect(result).toEqual({ softDeleted: 0, groupIds: [] })
+      expect(mockGroup.updateMany).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('cleanupExpiredGroups', () => {
+    it('should permanently delete groups past grace period', async () => {
+      ;(mockGroup.findMany as jest.Mock).mockResolvedValue([
+        { id: 'expired-1' },
+        { id: 'expired-2' },
+      ])
+      ;(mockGroup.deleteMany as jest.Mock).mockResolvedValue({ count: 2 })
+
+      const result = await cleanupExpiredGroups(7) // 7-day grace period
+
+      expect(result.permanentlyDeleted).toBe(2)
+      expect(result.groupIds).toEqual(['expired-1', 'expired-2'])
+      expect(mockGroup.deleteMany).toHaveBeenCalledWith({
+        where: { id: { in: ['expired-1', 'expired-2'] } },
+      })
+    })
+
+    it('should not delete groups within grace period', async () => {
+      ;(mockGroup.findMany as jest.Mock).mockResolvedValue([])
+
+      const result = await cleanupExpiredGroups(7)
+
+      expect(result).toEqual({ permanentlyDeleted: 0, groupIds: [] })
+      expect(mockGroup.deleteMany).not.toHaveBeenCalled()
+    })
+
+    it('should query with correct cutoff date', async () => {
+      ;(mockGroup.findMany as jest.Mock).mockResolvedValue([])
+
+      await cleanupExpiredGroups(7)
+
+      expect(mockGroup.findMany).toHaveBeenCalledWith({
+        where: {
+          deletedAt: {
+            lt: expect.any(Date),
+          },
+        },
+        select: { id: true },
+      })
+
+      // Verify the cutoff date is approximately 7 days ago
+      const call = (mockGroup.findMany as jest.Mock).mock.calls[0][0]
+      const cutoffDate = call.where.deletedAt.lt as Date
+      const now = new Date()
+      const expectedCutoff = new Date(now)
+      expectedCutoff.setDate(expectedCutoff.getDate() - 7)
+
+      // Allow 1 second tolerance for test execution time
+      expect(
+        Math.abs(cutoffDate.getTime() - expectedCutoff.getTime()),
+      ).toBeLessThan(1000)
+    })
+  })
+
+  describe('Integration scenario', () => {
+    it('should handle full auto-delete cycle', async () => {
+      const now = new Date()
+
+      // Group 1: Inactive for 100 days, not deleted yet
+      const group1CreatedAt = new Date(now)
+      group1CreatedAt.setDate(group1CreatedAt.getDate() - 100)
+
+      // Group 2: Active (has recent activity)
+      const group2Activity = new Date(now)
+      group2Activity.setDate(group2Activity.getDate() - 10)
+
+      // Step 1: getInactiveGroups
+      ;(mockGroup.findMany as jest.Mock).mockResolvedValueOnce([
+        { id: 'group-1', createdAt: group1CreatedAt },
+        { id: 'group-2', createdAt: group1CreatedAt },
+      ])
+      ;(mockActivity.findFirst as jest.Mock)
+        .mockResolvedValueOnce(null) // group-1 has no activity
+        .mockResolvedValueOnce({ time: group2Activity }) // group-2 has recent activity
+
+      const inactiveGroups = await getInactiveGroups(90)
+      expect(inactiveGroups).toEqual(['group-1'])
+
+      // Step 2: autoDeleteInactiveGroups - reset mocks and set up for this call
+      ;(mockGroup.findMany as jest.Mock).mockResolvedValueOnce([
+        { id: 'group-1', createdAt: group1CreatedAt },
+      ])
+      ;(mockActivity.findFirst as jest.Mock).mockResolvedValueOnce(null)
+      ;(mockGroup.updateMany as jest.Mock).mockResolvedValue({ count: 1 })
+
+      const softDeleteResult = await autoDeleteInactiveGroups(90)
+      expect(softDeleteResult.softDeleted).toBe(1)
+
+      // Step 3: cleanupExpiredGroups
+      ;(mockGroup.findMany as jest.Mock).mockResolvedValueOnce([
+        { id: 'group-3' },
+      ])
+      ;(mockGroup.deleteMany as jest.Mock).mockResolvedValue({ count: 1 })
+
+      const cleanupResult = await cleanupExpiredGroups(7)
+      expect(cleanupResult.permanentlyDeleted).toBe(1)
+    })
+  })
+})

--- a/src/lib/auto-delete.ts
+++ b/src/lib/auto-delete.ts
@@ -1,0 +1,131 @@
+/**
+ * Auto-delete functionality for inactive groups (Issue #10)
+ *
+ * This module provides functions to automatically delete inactive groups
+ * after a configurable period of inactivity.
+ */
+
+import { prisma } from '@/lib/prisma'
+
+/**
+ * Get groups that have been inactive for more than the specified number of days
+ * Uses the Activity table to determine the last activity date
+ * @param inactiveDays Number of days of inactivity
+ * @returns Array of inactive group IDs
+ */
+export async function getInactiveGroups(
+  inactiveDays: number,
+): Promise<string[]> {
+  const cutoffDate = new Date()
+  cutoffDate.setDate(cutoffDate.getDate() - inactiveDays)
+
+  // Get all groups that are not deleted
+  const activeGroups = await prisma.group.findMany({
+    where: {
+      deletedAt: null,
+    },
+    select: {
+      id: true,
+      createdAt: true,
+    },
+  })
+
+  // For each group, check if there's any activity after the cutoff date
+  const inactiveGroupIds: string[] = []
+
+  for (const group of activeGroups) {
+    const latestActivity = await prisma.activity.findFirst({
+      where: {
+        groupId: group.id,
+      },
+      orderBy: {
+        time: 'desc',
+      },
+      select: {
+        time: true,
+      },
+    })
+
+    // Use the latest activity time, or group creation time if no activity exists
+    const lastActivityTime = latestActivity?.time ?? group.createdAt
+
+    if (lastActivityTime < cutoffDate) {
+      inactiveGroupIds.push(group.id)
+    }
+  }
+
+  return inactiveGroupIds
+}
+
+/**
+ * Soft-delete groups that have been inactive for the specified number of days
+ * @param inactiveDays Number of days of inactivity before soft-deletion
+ * @returns Number of groups soft-deleted
+ */
+export async function autoDeleteInactiveGroups(
+  inactiveDays: number,
+): Promise<{ softDeleted: number; groupIds: string[] }> {
+  if (inactiveDays <= 0) {
+    return { softDeleted: 0, groupIds: [] }
+  }
+
+  const inactiveGroupIds = await getInactiveGroups(inactiveDays)
+
+  if (inactiveGroupIds.length === 0) {
+    return { softDeleted: 0, groupIds: [] }
+  }
+
+  // Soft-delete all inactive groups
+  await prisma.group.updateMany({
+    where: {
+      id: { in: inactiveGroupIds },
+    },
+    data: {
+      deletedAt: new Date(),
+    },
+  })
+
+  return { softDeleted: inactiveGroupIds.length, groupIds: inactiveGroupIds }
+}
+
+/**
+ * Permanently delete groups that have been soft-deleted for longer than the grace period
+ * @param gracePeriodDays Number of days after soft-deletion before permanent deletion
+ * @returns Number of groups permanently deleted
+ */
+export async function cleanupExpiredGroups(
+  gracePeriodDays: number,
+): Promise<{ permanentlyDeleted: number; groupIds: string[] }> {
+  const cutoffDate = new Date()
+  cutoffDate.setDate(cutoffDate.getDate() - gracePeriodDays)
+
+  // Find groups that were soft-deleted before the cutoff date
+  const expiredGroups = await prisma.group.findMany({
+    where: {
+      deletedAt: {
+        lt: cutoffDate,
+      },
+    },
+    select: {
+      id: true,
+    },
+  })
+
+  if (expiredGroups.length === 0) {
+    return { permanentlyDeleted: 0, groupIds: [] }
+  }
+
+  const expiredGroupIds = expiredGroups.map((g) => g.id)
+
+  // Permanently delete all expired groups (cascade will handle related records)
+  await prisma.group.deleteMany({
+    where: {
+      id: { in: expiredGroupIds },
+    },
+  })
+
+  return {
+    permanentlyDeleted: expiredGroupIds.length,
+    groupIds: expiredGroupIds,
+  }
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -9,6 +9,10 @@ const envSchema = z
   .object({
     POSTGRES_URL_NON_POOLING: z.string().url(),
     POSTGRES_PRISMA_URL: z.string().url(),
+    // Auto-delete settings (Issue #10)
+    AUTO_DELETE_INACTIVE_DAYS: z.coerce.number().int().min(0).default(90),
+    DELETE_GRACE_PERIOD_DAYS: z.coerce.number().int().min(1).default(7),
+    CRON_SECRET: z.string().optional(),
     NEXT_PUBLIC_BASE_URL: z
       .string()
       .optional()

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "crons": [
+    {
+      "path": "/api/cron/auto-delete",
+      "schedule": "0 3 * * *"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
Implement auto-delete functionality for inactive groups (Issue #10).

- Add environment variable configuration for auto-deletion
- Track last activity using Activity table (no schema changes needed)
- Add Cron API endpoint for scheduled deletion
- Soft-delete inactive groups, permanently delete past grace period

## Features
- `AUTO_DELETE_INACTIVE_DAYS`: Days of inactivity before soft-deletion (default: 90, 0 to disable)
- `DELETE_GRACE_PERIOD_DAYS`: Days after soft-delete before permanent deletion (default: 7)
- `CRON_SECRET`: Secret for authenticating cron requests
- Daily cron job at 3:00 AM UTC via Vercel Cron

## Changes
- **Environment**: Added 3 new environment variables to `env.ts`
- **API**: Added `src/lib/auto-delete.ts` with deletion functions
- **Endpoint**: Added `/api/cron/auto-delete` for Vercel Cron
- **Config**: Added `vercel.json` with cron schedule
- **Tests**: Added 12 unit tests for auto-delete functionality
- **Docs**: Updated CLAUDE.md with Issue #10 completion

## Test plan
- [x] Unit tests pass (12 new tests)
- [x] TypeScript compiles without errors
- [x] Build succeeds
- [ ] Manual test: Call `/api/cron/auto-delete` endpoint

## Related Issue
Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)