### PR TITLE
feat(private-instance): add private instance mode with admin authentication (#4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,10 @@ NEXT_PUBLIC_DEFAULT_CURRENCY_CODE=""
 AUTO_DELETE_INACTIVE_DAYS=90    # Days of inactivity before auto-deletion (0 to disable)
 DELETE_GRACE_PERIOD_DAYS=7      # Days before permanent deletion after soft-delete
 CRON_SECRET=""                   # Secret for authenticating cron requests
+
+# Private Instance Mode (Issue #4)
+PRIVATE_INSTANCE=false          # Enable private instance mode (true/false)
+ADMIN_EMAIL=""                   # Initial admin email (required if PRIVATE_INSTANCE=true)
+ADMIN_PASSWORD=""                # Initial admin password (required if PRIVATE_INSTANCE=true)
+NEXTAUTH_SECRET=""               # Secret for NextAuth.js (generate with: openssl rand -base64 32)
+NEXTAUTH_URL="http://localhost:3000"  # Base URL for NextAuth.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,11 @@ src/components/password-prompt.tsx      # Password entry component with rate lim
 src/lib/hooks/use-group-url.ts # URL navigation with key preservation
 src/app/groups/[groupId]/stats/totals.tsx  # Client-side stats with decryption
 src/app/api/cron/auto-delete/route.ts  # Cron endpoint for auto-deletion
+src/lib/auth.ts                    # NextAuth.js configuration (Issue #4)
+src/middleware.ts                  # Route protection middleware (Issue #4)
+src/app/admin/                     # Admin dashboard (Issue #4)
+src/components/auth-provider.tsx   # NextAuth SessionProvider wrapper
+src/components/user-menu.tsx       # User dropdown menu component
 ```
 
 ## Development Rules
@@ -143,15 +148,17 @@ src/app/api/cron/auto-delete/route.ts  # Cron endpoint for auto-deletion
 ### Priority: LOW
 
 #### Issue #4: Private Instance Mode
-**Status**: TODO
+**Status**: DONE
 **Priority**: LOW
 **Link**: https://github.com/sora-grayscale/spliit/issues/4
 
-- Admin user with authentication
-- Whitelist-based access control
-- Shared users can view but not create groups
-- No auth required for shared group access
-- Self-hosted friendly
+- [x] Admin user with NextAuth.js authentication (Credentials provider)
+- [x] Initial admin creation via environment variables (ADMIN_EMAIL, ADMIN_PASSWORD)
+- [x] Whitelist-based access control (email-based)
+- [x] Admin dashboard for user management
+- [x] No auth required for shared group access (/groups/[groupId])
+- [x] PRIVATE_INSTANCE=false maintains current public behavior
+- [x] Self-hosted friendly
 
 #### Issue #5: Docker/Podman Deployment
 **Status**: TODO
@@ -223,6 +230,19 @@ src/app/api/cron/auto-delete/route.ts  # Cron endpoint for auto-deletion
 - [x] localStorage key persistence
 - [x] Error screen for missing encryption key
 
+#### Private Instance Mode (Issue #4) - DONE
+- [x] Prisma schema: Admin and WhitelistUser models
+- [x] NextAuth.js v5 (beta) with Credentials provider
+- [x] JWT-based session strategy
+- [x] bcryptjs password hashing (12 rounds)
+- [x] Middleware-based route protection
+- [x] Sign in/error pages
+- [x] Admin dashboard with stats and user management
+- [x] Whitelist user CRUD API endpoints
+- [x] Admin initialization API (/api/admin/init)
+- [x] UserMenu component in header (shows when authenticated)
+- [x] AuthProvider wrapper in layout
+
 ## Security Considerations
 
 ### Encryption
@@ -255,10 +275,12 @@ AUTO_DELETE_INACTIVE_DAYS=90     # Days of inactivity before auto-deletion (0 to
 DELETE_GRACE_PERIOD_DAYS=7       # Days before permanent deletion after soft-delete
 CRON_SECRET=                     # Secret for authenticating cron requests
 
-# Private Instance (Issue #4) - TODO
+# Private Instance (Issue #4)
 PRIVATE_INSTANCE=false           # Enable private instance mode
-ADMIN_EMAIL=admin@example.com    # Initial admin email
-REQUIRE_AUTH=false               # Require authentication for all users
+ADMIN_EMAIL=admin@example.com    # Initial admin email (required when PRIVATE_INSTANCE=true)
+ADMIN_PASSWORD=                  # Initial admin password (required when PRIVATE_INSTANCE=true)
+NEXTAUTH_SECRET=                 # NextAuth.js secret (required when PRIVATE_INSTANCE=true)
+NEXTAUTH_URL=http://localhost:3000  # NextAuth.js URL (required in production)
 ```
 
 ## Commands

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "generate-currency-data": "ts-node -T ./src/scripts/generateCurrencyData.ts"
   },
   "dependencies": {
+    "@auth/prisma-adapter": "^2.11.1",
     "@formatjs/intl-localematcher": "^0.5.4",
     "@hookform/resolvers": "^3.3.2",
     "@json2csv/plainjs": "^7.0.6",
@@ -46,6 +47,7 @@
     "@trpc/client": "^11.0.0-rc.586",
     "@trpc/react-query": "^11.0.0-rc.586",
     "@trpc/server": "^11.0.0-rc.586",
+    "bcryptjs": "^3.0.3",
     "class-variance-authority": "^0.7.0",
     "client-only": "^0.0.1",
     "clsx": "^2.0.0",
@@ -58,6 +60,7 @@
     "nanoid": "^5.0.4",
     "negotiator": "^0.6.3",
     "next": "^16.0.7",
+    "next-auth": "5.0.0-beta.30",
     "next-intl": "^4.5.8",
     "next-s3-upload": "^0.3.4",
     "next-themes": "^0.2.1",
@@ -86,6 +89,7 @@
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^16.3.0",
     "@total-typescript/ts-reset": "^0.5.1",
+    "@types/bcryptjs": "^3.0.0",
     "@types/content-disposition": "^0.5.8",
     "@types/deepmerge": "^2.1.0",
     "@types/jest": "^29.5.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@auth/prisma-adapter':
+        specifier: ^2.11.1
+        version: 2.11.1(@prisma/client@6.19.1(prisma@6.19.1(typescript@5.9.3))(typescript@5.9.3))
       '@formatjs/intl-localematcher':
         specifier: ^0.5.4
         version: 0.5.10
@@ -74,6 +77,9 @@ importers:
       '@trpc/server':
         specifier: ^11.0.0-rc.586
         version: 11.8.1(typescript@5.9.3)
+      bcryptjs:
+        specifier: ^3.0.3
+        version: 3.0.3
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.1
@@ -110,6 +116,9 @@ importers:
       next:
         specifier: ^16.0.7
         version: 16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      next-auth:
+        specifier: 5.0.0-beta.30
+        version: 5.0.0-beta.30(next@16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
       next-intl:
         specifier: ^4.5.8
         version: 4.7.0(next@16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@5.9.3)
@@ -189,6 +198,9 @@ importers:
       '@total-typescript/ts-reset':
         specifier: ^0.5.1
         version: 0.5.1
+      '@types/bcryptjs':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@types/content-disposition':
         specifier: ^0.5.8
         version: 0.5.9
@@ -270,6 +282,39 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@auth/core@0.41.0':
+    resolution: {integrity: sha512-Wd7mHPQ/8zy6Qj7f4T46vg3aoor8fskJm6g2Zyj064oQ3+p0xNZXAV60ww0hY+MbTesfu29kK14Zk5d5JTazXQ==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^6.8.0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
+  '@auth/core@0.41.1':
+    resolution: {integrity: sha512-t9cJ2zNYAdWMacGRMT6+r4xr1uybIdmYa49calBPeTqwgAFPV/88ac9TEvCR85pvATiSPt8VaNf+Gt24JIT/uw==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      nodemailer: ^7.0.7
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
+  '@auth/prisma-adapter@2.11.1':
+    resolution: {integrity: sha512-Ke7DXP0Fy0Mlmjz/ZJLXwQash2UkA4621xCM0rMtEczr1kppLc/njCbUkHkIQ/PnmILjqSPEKeTjDPsYruvkug==}
+    peerDependencies:
+      '@prisma/client': '>=2.26.0 || >=3 || >=4 || >=5 || >=6'
 
   '@aws-crypto/crc32@5.2.0':
     resolution: {integrity: sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==}
@@ -1139,6 +1184,9 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@panva/hkdf@1.2.1':
+    resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
   '@parcel/watcher-android-arm64@2.5.4':
     resolution: {integrity: sha512-hoh0vx4v+b3BNI7Cjoy2/B0ARqcwVNrzN/n7DLq9ZB4I3lrsvhrkCViJyfTj/Qi5xM9YFiH4AmHGK6pgH1ss7g==}
@@ -2132,6 +2180,10 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/bcryptjs@3.0.0':
+    resolution: {integrity: sha512-WRZOuCuaz8UcZZE4R5HXTco2goQSI2XxjGY3hbM/xDvwmqFWd4ivooImsMx65OKM6CtNKbnZ5YL+YwAwK7c1dg==}
+    deprecated: This is a stub types definition. bcryptjs provides its own type definitions, so you do not need this installed.
+
   '@types/content-disposition@0.5.9':
     resolution: {integrity: sha512-8uYXI3Gw35MhiVYhG3s295oihrxRyytcRHjSjqnqZVDDy/xcGBRny7+Xj1Wgfhv5QzRtN2hB2dVRBUX9XW3UcQ==}
 
@@ -2540,6 +2592,10 @@ packages:
 
   baseline-browser-mapping@2.9.14:
     resolution: {integrity: sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==}
+    hasBin: true
+
+  bcryptjs@3.0.3:
+    resolution: {integrity: sha512-GlF5wPWnSa/X5LKM1o0wz0suXIINz1iHRLvTS+sLyi7XPbe5ycmYI3DlZqVGZZtDgl4DmasFg7gOB3JYbphV5g==}
     hasBin: true
 
   binary-extensions@2.3.0:
@@ -3694,6 +3750,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.1.3:
+    resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -3883,6 +3942,22 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  next-auth@5.0.0-beta.30:
+    resolution: {integrity: sha512-+c51gquM3F6nMVmoAusRJ7RIoY0K4Ts9HCCwyy/BRoe4mp3msZpOzYMyb5LAYc1wSo74PMQkGDcaghIO7W6Xjg==}
+    peerDependencies:
+      '@simplewebauthn/browser': ^9.0.1
+      '@simplewebauthn/server': ^9.0.2
+      next: ^14.0.0-0 || ^15.0.0 || ^16.0.0
+      nodemailer: ^7.0.7
+      react: ^18.2.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@simplewebauthn/browser':
+        optional: true
+      '@simplewebauthn/server':
+        optional: true
+      nodemailer:
+        optional: true
+
   next-intl-swc-plugin-extractor@4.7.0:
     resolution: {integrity: sha512-iAqflu2FWdQMWhwB0B2z52X7LmEpvnMNJXqVERZQ7bK5p9iqQLu70ur6Ka6NfiXLxfb+AeAkUX5qIciQOg+87A==}
 
@@ -3981,6 +4056,9 @@ packages:
     resolution: {integrity: sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==}
     engines: {node: ^14.16.0 || >=16.10.0}
     hasBin: true
+
+  oauth4webapi@3.8.3:
+    resolution: {integrity: sha512-pQ5BsX3QRTgnt5HxgHwgunIRaDXBdkT23tf8dfzmtTIL2LTpdmxgbpbBm0VgFWAIDlezQvQCTgnVIUmHupXHxw==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -4237,6 +4315,14 @@ packages:
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
+
+  preact-render-to-string@6.5.11:
+    resolution: {integrity: sha512-ubnauqoGczeGISiOh6RjX0/cdaF8v/oDXIjO85XALCQjwQP+SB4RDXXtvZ6yTYSjG+PC1QRP2AhPgCEsM2EvUw==}
+    peerDependencies:
+      preact: '>=10'
+
+  preact@10.24.3:
+    resolution: {integrity: sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -5010,6 +5096,31 @@ snapshots:
   '@adobe/css-tools@4.4.4': {}
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@auth/core@0.41.0':
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      jose: 6.1.3
+      oauth4webapi: 3.8.3
+      preact: 10.24.3
+      preact-render-to-string: 6.5.11(preact@10.24.3)
+
+  '@auth/core@0.41.1':
+    dependencies:
+      '@panva/hkdf': 1.2.1
+      jose: 6.1.3
+      oauth4webapi: 3.8.3
+      preact: 10.24.3
+      preact-render-to-string: 6.5.11(preact@10.24.3)
+
+  '@auth/prisma-adapter@2.11.1(@prisma/client@6.19.1(prisma@6.19.1(typescript@5.9.3))(typescript@5.9.3))':
+    dependencies:
+      '@auth/core': 0.41.1
+      '@prisma/client': 6.19.1(prisma@6.19.1(typescript@5.9.3))(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@simplewebauthn/browser'
+      - '@simplewebauthn/server'
+      - nodemailer
 
   '@aws-crypto/crc32@5.2.0':
     dependencies:
@@ -6314,6 +6425,8 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@panva/hkdf@1.2.1': {}
+
   '@parcel/watcher-android-arm64@2.5.4':
     optional: true
 
@@ -7417,6 +7530,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.5
 
+  '@types/bcryptjs@3.0.0':
+    dependencies:
+      bcryptjs: 3.0.3
+
   '@types/content-disposition@0.5.9': {}
 
   '@types/deepmerge@2.2.3':
@@ -7877,6 +7994,8 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.9.14: {}
+
+  bcryptjs@3.0.3: {}
 
   binary-extensions@2.3.0: {}
 
@@ -9371,6 +9490,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jose@6.1.3: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
@@ -9546,6 +9667,12 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  next-auth@5.0.0-beta.30(next@16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3):
+    dependencies:
+      '@auth/core': 0.41.0
+      next: 16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+
   next-intl-swc-plugin-extractor@4.7.0: {}
 
   next-intl@4.7.0(next@16.1.1(@babel/core@7.28.5)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(typescript@5.9.3):
@@ -9646,6 +9773,8 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 2.3.0
       tinyexec: 1.0.2
+
+  oauth4webapi@3.8.3: {}
 
   object-assign@4.1.1: {}
 
@@ -9892,6 +10021,12 @@ snapshots:
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  preact-render-to-string@6.5.11(preact@10.24.3):
+    dependencies:
+      preact: 10.24.3
+
+  preact@10.24.3: {}
 
   prelude-ls@1.2.1: {}
 

--- a/prisma/migrations/20260112121808_add_private_instance_tables/migration.sql
+++ b/prisma/migrations/20260112121808_add_private_instance_tables/migration.sql
@@ -1,0 +1,28 @@
+-- CreateTable
+CREATE TABLE "Admin" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "password" TEXT NOT NULL,
+    "name" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Admin_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "WhitelistUser" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "name" TEXT,
+    "addedById" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "WhitelistUser_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Admin_email_key" ON "Admin"("email");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "WhitelistUser_email_key" ON "WhitelistUser"("email");

--- a/prisma/migrations/20260112124759_add_password_features/migration.sql
+++ b/prisma/migrations/20260112124759_add_password_features/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "Admin" ADD COLUMN     "mustChangePassword" BOOLEAN NOT NULL DEFAULT false;
+
+-- AlterTable
+ALTER TABLE "WhitelistUser" ADD COLUMN     "mustChangePassword" BOOLEAN NOT NULL DEFAULT true,
+ADD COLUMN     "password" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -135,3 +135,24 @@ enum ActivityType {
   UPDATE_EXPENSE
   DELETE_EXPENSE
 }
+
+// Private Instance Mode (Issue #4)
+model Admin {
+  id                 String   @id @default(cuid())
+  email              String   @unique
+  password           String   // bcrypt hashed
+  name               String?
+  mustChangePassword Boolean  @default(false)
+  createdAt          DateTime @default(now())
+  updatedAt          DateTime @updatedAt
+}
+
+model WhitelistUser {
+  id                 String   @id @default(cuid())
+  email              String   @unique
+  password           String?  // bcrypt hashed (null until first login setup)
+  name               String?
+  mustChangePassword Boolean  @default(true) // Must change on first login
+  addedById          String   // Admin who added this user
+  createdAt          DateTime @default(now())
+}

--- a/src/__tests__/private-instance.test.ts
+++ b/src/__tests__/private-instance.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Private Instance Mode Tests (Issue #4)
+ *
+ * Tests for authentication, authorization, and security features
+ */
+
+import bcrypt from 'bcryptjs'
+
+// Test helper functions
+describe('Private Instance Mode', () => {
+  describe('Password Validation', () => {
+    it('should require minimum 8 characters for passwords', () => {
+      const shortPassword = '1234567'
+      const validPassword = '12345678'
+
+      expect(shortPassword.length).toBeLessThan(8)
+      expect(validPassword.length).toBeGreaterThanOrEqual(8)
+    })
+
+    it('should detect when new password equals current password', () => {
+      const checkPasswordsDifferent = (current: string, newPwd: string) =>
+        current !== newPwd
+
+      expect(checkPasswordsDifferent('mypassword123', 'mypassword123')).toBe(
+        false,
+      )
+      expect(checkPasswordsDifferent('mypassword123', 'newpassword456')).toBe(
+        true,
+      )
+    })
+  })
+
+  describe('Email Validation', () => {
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+    it('should accept valid email formats', () => {
+      const validEmails = [
+        'user@example.com',
+        'user.name@example.com',
+        'user+tag@example.com',
+        'user@sub.example.com',
+      ]
+
+      validEmails.forEach((email) => {
+        expect(emailRegex.test(email)).toBe(true)
+      })
+    })
+
+    it('should reject invalid email formats', () => {
+      const invalidEmails = [
+        'userexample.com',
+        'user@',
+        '@example.com',
+        'user @example.com',
+        'user@ example.com',
+        '',
+      ]
+
+      invalidEmails.forEach((email) => {
+        expect(emailRegex.test(email)).toBe(false)
+      })
+    })
+  })
+
+  describe('Password Hashing', () => {
+    it('should hash passwords with bcrypt', async () => {
+      const password = 'testpassword123'
+      const hashedPassword = await bcrypt.hash(password, 12)
+
+      expect(hashedPassword).not.toBe(password)
+      expect(hashedPassword.startsWith('$2')).toBe(true) // bcrypt prefix
+    })
+
+    it('should verify correct passwords', async () => {
+      const password = 'testpassword123'
+      const hashedPassword = await bcrypt.hash(password, 12)
+
+      const isValid = await bcrypt.compare(password, hashedPassword)
+      expect(isValid).toBe(true)
+    })
+
+    it('should reject incorrect passwords', async () => {
+      const password = 'testpassword123'
+      const wrongPassword = 'wrongpassword'
+      const hashedPassword = await bcrypt.hash(password, 12)
+
+      const isValid = await bcrypt.compare(wrongPassword, hashedPassword)
+      expect(isValid).toBe(false)
+    })
+  })
+
+  describe('Initial Password Generation', () => {
+    it('should generate passwords with sufficient entropy', () => {
+      const { randomBytes } = require('crypto')
+
+      const generateInitialPassword = (): string => {
+        return randomBytes(8).toString('base64').slice(0, 12)
+      }
+
+      const passwords = new Set<string>()
+      for (let i = 0; i < 100; i++) {
+        passwords.add(generateInitialPassword())
+      }
+
+      // All 100 passwords should be unique
+      expect(passwords.size).toBe(100)
+    })
+
+    it('should generate passwords of correct length', () => {
+      const { randomBytes } = require('crypto')
+
+      const generateInitialPassword = (): string => {
+        return randomBytes(8).toString('base64').slice(0, 12)
+      }
+
+      const password = generateInitialPassword()
+      expect(password.length).toBe(12)
+    })
+  })
+
+  describe('Route Protection Logic', () => {
+    const publicRoutes = [
+      '/auth/signin',
+      '/auth/error',
+      '/auth/change-password',
+      '/api/auth',
+      '/api/health',
+      '/api/trpc',
+    ]
+
+    const sharedRoutes = ['/groups/']
+    const adminRoutes = ['/admin']
+    const protectedRoutes = ['/groups/create']
+
+    it('should identify public routes correctly', () => {
+      const isPublicRoute = (pathname: string) =>
+        publicRoutes.some((route) => pathname.startsWith(route))
+
+      expect(isPublicRoute('/auth/signin')).toBe(true)
+      expect(isPublicRoute('/auth/error')).toBe(true)
+      expect(isPublicRoute('/api/auth/callback')).toBe(true)
+      expect(isPublicRoute('/api/health')).toBe(true)
+      expect(isPublicRoute('/groups/create')).toBe(false)
+      expect(isPublicRoute('/admin')).toBe(false)
+    })
+
+    it('should identify shared routes correctly', () => {
+      const isSharedRoute = (pathname: string) =>
+        sharedRoutes.some((route) => pathname.startsWith(route))
+
+      expect(isSharedRoute('/groups/abc123')).toBe(true)
+      expect(isSharedRoute('/groups/abc123/expenses')).toBe(true)
+      expect(isSharedRoute('/groups/create')).toBe(true) // Note: needs special handling
+      expect(isSharedRoute('/admin')).toBe(false)
+    })
+
+    it('should identify admin routes correctly', () => {
+      const isAdminRoute = (pathname: string) =>
+        adminRoutes.some((route) => pathname.startsWith(route))
+
+      expect(isAdminRoute('/admin')).toBe(true)
+      expect(isAdminRoute('/admin/users')).toBe(true)
+      expect(isAdminRoute('/groups')).toBe(false)
+    })
+
+    it('should protect /groups/create before checking shared routes', () => {
+      const pathname = '/groups/create'
+
+      // This is the correct order of checks
+      const isProtectedCreate = pathname === '/groups/create'
+      const isSharedRoute = sharedRoutes.some((route) =>
+        pathname.startsWith(route),
+      )
+
+      expect(isProtectedCreate).toBe(true)
+      expect(isSharedRoute).toBe(true) // Would match, but should check create first
+    })
+  })
+
+  describe('Session Token Handling', () => {
+    it('should check both cookie formats for session token', () => {
+      const getCookies = (cookies: Record<string, string | undefined>) => {
+        return (
+          cookies['authjs.session-token'] ||
+          cookies['__Secure-authjs.session-token']
+        )
+      }
+
+      // Regular cookie
+      expect(getCookies({ 'authjs.session-token': 'token123' })).toBe(
+        'token123',
+      )
+
+      // Secure cookie (HTTPS)
+      expect(
+        getCookies({ '__Secure-authjs.session-token': 'securetoken123' }),
+      ).toBe('securetoken123')
+
+      // No cookie
+      expect(getCookies({})).toBeUndefined()
+    })
+  })
+
+  describe('Environment Variable Handling', () => {
+    it('should correctly check PRIVATE_INSTANCE flag', () => {
+      const isPrivateInstance = (envValue: string | undefined) =>
+        envValue === 'true'
+
+      expect(isPrivateInstance('true')).toBe(true)
+      expect(isPrivateInstance('false')).toBe(false)
+      expect(isPrivateInstance(undefined)).toBe(false)
+      expect(isPrivateInstance('')).toBe(false)
+      expect(isPrivateInstance('TRUE')).toBe(false) // Case sensitive
+    })
+  })
+
+  describe('Authorization Checks', () => {
+    it('should require admin role for whitelist operations', () => {
+      const checkAdminAuth = (
+        session: { user?: { isAdmin?: boolean } } | null,
+      ) => {
+        return session?.user?.isAdmin === true
+      }
+
+      expect(checkAdminAuth({ user: { isAdmin: true } })).toBe(true)
+      expect(checkAdminAuth({ user: { isAdmin: false } })).toBe(false)
+      expect(checkAdminAuth({ user: {} })).toBe(false)
+      expect(checkAdminAuth(null)).toBe(false)
+    })
+
+    it('should require authentication for protected operations', () => {
+      const checkAuth = (session: { user?: { id?: string } } | null) => {
+        return !!session?.user?.id
+      }
+
+      expect(checkAuth({ user: { id: 'user123' } })).toBe(true)
+      expect(checkAuth({ user: {} })).toBe(false)
+      expect(checkAuth(null)).toBe(false)
+    })
+  })
+
+  describe('Password Change Guard', () => {
+    const excludedRoutes = [
+      '/auth/signin',
+      '/auth/error',
+      '/auth/change-password',
+    ]
+
+    it('should exclude auth routes from password change redirect', () => {
+      const shouldRedirect = (
+        pathname: string,
+        mustChangePassword: boolean,
+      ) => {
+        if (excludedRoutes.some((route) => pathname.startsWith(route))) {
+          return false
+        }
+        return mustChangePassword
+      }
+
+      expect(shouldRedirect('/auth/signin', true)).toBe(false)
+      expect(shouldRedirect('/auth/change-password', true)).toBe(false)
+      expect(shouldRedirect('/groups', true)).toBe(true)
+      expect(shouldRedirect('/groups', false)).toBe(false)
+    })
+  })
+
+  describe('Security: mustChangePassword Flag', () => {
+    it('should always refresh mustChangePassword from database on session update', () => {
+      // The security principle: never trust client-sent values for security-critical flags
+      // Instead, always fetch from the database
+
+      const secureApproach = (
+        _clientValue: boolean,
+        dbValue: boolean,
+      ): boolean => {
+        // Always use database value, ignore client value
+        return dbValue
+      }
+
+      // Even if client sends false (trying to bypass), DB value should be used
+      expect(secureApproach(false, true)).toBe(true)
+      expect(secureApproach(true, false)).toBe(false)
+    })
+
+    it('should not allow client to bypass password change requirement', () => {
+      // Simulating attack: client tries to send mustChangePassword: false
+      const _clientSentValue = false // Ignored in secure implementation
+      const databaseValue = true
+
+      // Secure implementation ignores client value
+      const result = databaseValue // Always from DB
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('CUID Validation', () => {
+    it('should validate CUID format', () => {
+      // CUID v2 format: starts with 'c' followed by lowercase alphanumeric
+      const cuidRegex = /^c[a-z0-9]{20,28}$/
+
+      // Valid CUIDs (examples of typical CUID format)
+      expect(cuidRegex.test('clxyz1234567890abcdefg')).toBe(true)
+      expect(cuidRegex.test('cm5abc123def456ghi789jklmno')).toBe(true)
+
+      // Invalid CUIDs
+      expect(cuidRegex.test('abc123')).toBe(false)
+      expect(cuidRegex.test('')).toBe(false)
+      expect(cuidRegex.test('x1234567890123456789012345')).toBe(false)
+      expect(cuidRegex.test('CABCDEF1234567890123456')).toBe(false) // uppercase not allowed
+    })
+  })
+})

--- a/src/app/admin/admin-dashboard.tsx
+++ b/src/app/admin/admin-dashboard.tsx
@@ -1,0 +1,500 @@
+'use client'
+
+/**
+ * Admin Dashboard Client Component (Issue #4)
+ */
+
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import {
+  Check,
+  Copy,
+  Key,
+  RotateCcw,
+  Trash2,
+  UserPlus,
+  Users,
+} from 'lucide-react'
+import { signOut } from 'next-auth/react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+
+interface AdminDashboardProps {
+  stats: {
+    groupCount: number
+    adminCount: number
+    whitelistCount: number
+  }
+  admins: Array<{
+    id: string
+    email: string
+    name: string | null
+    createdAt: string
+  }>
+  whitelistUsers: Array<{
+    id: string
+    email: string
+    name: string | null
+    createdAt: string
+  }>
+  currentUserEmail: string
+}
+
+interface UserCredentials {
+  email: string
+  initialPassword: string
+  isReset?: boolean
+}
+
+export function AdminDashboard({
+  stats,
+  admins,
+  whitelistUsers,
+  currentUserEmail,
+}: AdminDashboardProps) {
+  const router = useRouter()
+  const [newUserEmail, setNewUserEmail] = useState('')
+  const [newUserName, setNewUserName] = useState('')
+  const [isAdding, setIsAdding] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [userCredentials, setUserCredentials] =
+    useState<UserCredentials | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [resettingUserId, setResettingUserId] = useState<string | null>(null)
+
+  const handleAddUser = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsAdding(true)
+    setError(null)
+    setUserCredentials(null)
+
+    try {
+      const response = await fetch('/api/admin/whitelist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: newUserEmail, name: newUserName }),
+      })
+
+      if (!response.ok) {
+        const data = (await response.json()) as { error?: string }
+        throw new Error(data.error || 'Failed to add user')
+      }
+
+      const data = (await response.json()) as { initialPassword: string }
+
+      // Show the initial password to the admin
+      setUserCredentials({
+        email: newUserEmail,
+        initialPassword: data.initialPassword,
+      })
+
+      setNewUserEmail('')
+      setNewUserName('')
+      router.refresh()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add user')
+    } finally {
+      setIsAdding(false)
+    }
+  }
+
+  const copyCredentials = () => {
+    if (userCredentials) {
+      const text = `Email: ${userCredentials.email}\nInitial Password: ${userCredentials.initialPassword}`
+      navigator.clipboard.writeText(text)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
+  }
+
+  const handleResetPassword = async (userId: string, userEmail: string) => {
+    if (
+      !confirm(`Are you sure you want to reset the password for ${userEmail}?`)
+    )
+      return
+
+    setResettingUserId(userId)
+    setUserCredentials(null)
+
+    try {
+      const response = await fetch(`/api/admin/whitelist/${userId}`, {
+        method: 'PATCH',
+      })
+
+      if (!response.ok) {
+        const data = (await response.json()) as { error?: string }
+        throw new Error(data.error || 'Failed to reset password')
+      }
+
+      const data = (await response.json()) as { initialPassword: string }
+
+      // Show the new password to the admin
+      setUserCredentials({
+        email: userEmail,
+        initialPassword: data.initialPassword,
+        isReset: true,
+      })
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to reset password')
+    } finally {
+      setResettingUserId(null)
+    }
+  }
+
+  const handleRemoveUser = async (userId: string) => {
+    if (!confirm('Are you sure you want to remove this user?')) return
+
+    try {
+      const response = await fetch(`/api/admin/whitelist/${userId}`, {
+        method: 'DELETE',
+      })
+
+      if (!response.ok) {
+        const data = (await response.json()) as { error?: string }
+        throw new Error(data.error || 'Failed to remove user')
+      }
+
+      router.refresh()
+    } catch (err) {
+      alert(err instanceof Error ? err.message : 'Failed to remove user')
+    }
+  }
+
+  return (
+    <div className="container mx-auto max-w-6xl p-6">
+      <div className="mb-8 flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold">Admin Dashboard</h1>
+          <p className="text-muted-foreground">
+            Manage users and monitor your private instance
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" asChild>
+            <Link href="/auth/change-password">
+              <Key className="h-4 w-4 mr-2" />
+              Change Password
+            </Link>
+          </Button>
+          <Button
+            variant="outline"
+            onClick={() => signOut({ callbackUrl: '/' })}
+          >
+            Sign Out
+          </Button>
+        </div>
+      </div>
+
+      {/* Stats Cards */}
+      <div className="mb-8 grid gap-4 md:grid-cols-3">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Total Groups
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-bold">{stats.groupCount}</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Admins
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-bold">{stats.adminCount}</div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Whitelist Users
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-3xl font-bold">{stats.whitelistCount}</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Add User Form */}
+      <Card className="mb-8">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <UserPlus className="h-5 w-5" />
+            Add User to Whitelist
+          </CardTitle>
+          <CardDescription>
+            Add a user to allow them to create groups on this instance
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleAddUser} className="flex flex-wrap gap-4">
+            <div className="flex-1 space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                placeholder="user@example.com"
+                value={newUserEmail}
+                onChange={(e) => setNewUserEmail(e.target.value)}
+                required
+              />
+            </div>
+            <div className="flex-1 space-y-2">
+              <Label htmlFor="name">Name (optional)</Label>
+              <Input
+                id="name"
+                type="text"
+                placeholder="John Doe"
+                value={newUserName}
+                onChange={(e) => setNewUserName(e.target.value)}
+              />
+            </div>
+            <div className="flex items-end">
+              <Button type="submit" disabled={isAdding}>
+                {isAdding ? 'Adding...' : 'Add User'}
+              </Button>
+            </div>
+          </form>
+          {error && <p className="mt-2 text-sm text-destructive">{error}</p>}
+
+          {/* Show initial password after adding user */}
+          {userCredentials && !userCredentials.isReset && (
+            <div className="mt-4 rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-900/20">
+              <div className="flex items-start justify-between">
+                <div>
+                  <h4 className="font-semibold text-green-800 dark:text-green-400">
+                    User added successfully!
+                  </h4>
+                  <p className="mt-1 text-sm text-green-700 dark:text-green-300">
+                    Share these credentials with the user. The password will
+                    only be shown once.
+                  </p>
+                  <div className="mt-3 space-y-1 font-mono text-sm">
+                    <p>
+                      <span className="text-muted-foreground">Email:</span>{' '}
+                      <span className="font-semibold">
+                        {userCredentials.email}
+                      </span>
+                    </p>
+                    <p>
+                      <span className="text-muted-foreground">
+                        Initial Password:
+                      </span>{' '}
+                      <span className="font-semibold">
+                        {userCredentials.initialPassword}
+                      </span>
+                    </p>
+                  </div>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={copyCredentials}
+                  className="shrink-0"
+                >
+                  {copied ? (
+                    <>
+                      <Check className="h-4 w-4 mr-1" />
+                      Copied
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="h-4 w-4 mr-1" />
+                      Copy
+                    </>
+                  )}
+                </Button>
+              </div>
+              <p className="mt-3 text-xs text-muted-foreground">
+                The user will be required to change their password on first
+                login.
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Whitelist Users Table */}
+      <Card className="mb-8">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Users className="h-5 w-5" />
+            Whitelist Users
+          </CardTitle>
+          <CardDescription>
+            Users who can create groups on this instance
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {/* Show reset password result */}
+          {userCredentials && userCredentials.isReset && (
+            <div className="mb-4 rounded-lg border border-blue-200 bg-blue-50 p-4 dark:border-blue-800 dark:bg-blue-900/20">
+              <div className="flex items-start justify-between">
+                <div>
+                  <h4 className="font-semibold text-blue-800 dark:text-blue-400">
+                    Password reset successfully!
+                  </h4>
+                  <p className="mt-1 text-sm text-blue-700 dark:text-blue-300">
+                    Share the new password with the user. It will only be shown
+                    once.
+                  </p>
+                  <div className="mt-3 space-y-1 font-mono text-sm">
+                    <p>
+                      <span className="text-muted-foreground">Email:</span>{' '}
+                      <span className="font-semibold">
+                        {userCredentials.email}
+                      </span>
+                    </p>
+                    <p>
+                      <span className="text-muted-foreground">
+                        New Password:
+                      </span>{' '}
+                      <span className="font-semibold">
+                        {userCredentials.initialPassword}
+                      </span>
+                    </p>
+                  </div>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={copyCredentials}
+                  className="shrink-0"
+                >
+                  {copied ? (
+                    <>
+                      <Check className="h-4 w-4 mr-1" />
+                      Copied
+                    </>
+                  ) : (
+                    <>
+                      <Copy className="h-4 w-4 mr-1" />
+                      Copy
+                    </>
+                  )}
+                </Button>
+              </div>
+              <p className="mt-3 text-xs text-muted-foreground">
+                The user will be required to change their password on next
+                login.
+              </p>
+            </div>
+          )}
+
+          {whitelistUsers.length === 0 ? (
+            <p className="text-center text-muted-foreground py-4">
+              No whitelist users yet. Add users above.
+            </p>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Added</TableHead>
+                  <TableHead className="w-[120px]">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {whitelistUsers.map((user) => (
+                  <TableRow key={user.id}>
+                    <TableCell className="font-medium">{user.email}</TableCell>
+                    <TableCell>{user.name || '-'}</TableCell>
+                    <TableCell>
+                      {new Date(user.createdAt).toLocaleDateString()}
+                    </TableCell>
+                    <TableCell>
+                      <div className="flex gap-1">
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() =>
+                            handleResetPassword(user.id, user.email)
+                          }
+                          disabled={resettingUserId === user.id}
+                          title="Reset Password"
+                        >
+                          <RotateCcw
+                            className={`h-4 w-4 ${resettingUserId === user.id ? 'animate-spin' : ''}`}
+                          />
+                        </Button>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={() => handleRemoveUser(user.id)}
+                          title="Remove User"
+                        >
+                          <Trash2 className="h-4 w-4 text-destructive" />
+                        </Button>
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Admins Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Administrators</CardTitle>
+          <CardDescription>Users with admin privileges</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Email</TableHead>
+                <TableHead>Name</TableHead>
+                <TableHead>Created</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {admins.map((admin) => (
+                <TableRow key={admin.id}>
+                  <TableCell className="font-medium">
+                    {admin.email}
+                    {admin.email === currentUserEmail && (
+                      <span className="ml-2 text-xs text-muted-foreground">
+                        (you)
+                      </span>
+                    )}
+                  </TableCell>
+                  <TableCell>{admin.name || '-'}</TableCell>
+                  <TableCell>
+                    {new Date(admin.createdAt).toLocaleDateString()}
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,76 @@
+/**
+ * Admin Dashboard (Issue #4)
+ */
+
+import { auth, isPrivateInstance } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import { redirect } from 'next/navigation'
+import { AdminDashboard } from './admin-dashboard'
+
+export default async function AdminPage() {
+  // Check if private instance mode is enabled
+  if (!isPrivateInstance()) {
+    redirect('/')
+  }
+
+  // Check authentication
+  const session = await auth()
+  if (!session?.user) {
+    redirect('/auth/signin?callbackUrl=/admin')
+  }
+
+  // Check if user is admin
+  if (!session.user.isAdmin) {
+    redirect('/')
+  }
+
+  // Get stats
+  const [groupCount, adminCount, whitelistCount] = await Promise.all([
+    prisma.group.count({ where: { deletedAt: null } }),
+    prisma.admin.count(),
+    prisma.whitelistUser.count(),
+  ])
+
+  // Get recent admins (only select necessary fields for security)
+  const admins = await prisma.admin.findMany({
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 10,
+  })
+
+  // Get whitelist users (only select necessary fields for security)
+  const whitelistUsers = await prisma.whitelistUser.findMany({
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      createdAt: true,
+    },
+    orderBy: { createdAt: 'desc' },
+    take: 20,
+  })
+
+  return (
+    <AdminDashboard
+      stats={{
+        groupCount,
+        adminCount,
+        whitelistCount,
+      }}
+      admins={admins.map((a) => ({
+        ...a,
+        createdAt: a.createdAt.toISOString(),
+      }))}
+      whitelistUsers={whitelistUsers.map((u) => ({
+        ...u,
+        createdAt: u.createdAt.toISOString(),
+      }))}
+      currentUserEmail={session.user.email}
+    />
+  )
+}

--- a/src/app/api/admin/init/route.ts
+++ b/src/app/api/admin/init/route.ts
@@ -1,0 +1,36 @@
+/**
+ * Initialize Admin API (Issue #4)
+ * Called on first deployment to create the initial admin user
+ */
+
+import { initializeAdmin, isPrivateInstance } from '@/lib/auth'
+import { NextResponse } from 'next/server'
+
+export async function POST() {
+  try {
+    if (!isPrivateInstance()) {
+      return NextResponse.json(
+        { message: 'Private instance mode is not enabled' },
+        { status: 200 },
+      )
+    }
+
+    await initializeAdmin()
+
+    return NextResponse.json({
+      success: true,
+      message: 'Admin initialization complete',
+    })
+  } catch (error) {
+    console.error('Error initializing admin:', error)
+    return NextResponse.json(
+      { error: 'Failed to initialize admin' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function GET() {
+  // Allow GET for easier testing/calling
+  return POST()
+}

--- a/src/app/api/admin/whitelist/[userId]/route.ts
+++ b/src/app/api/admin/whitelist/[userId]/route.ts
@@ -1,0 +1,114 @@
+/**
+ * Individual Whitelist User API (Issue #4)
+ */
+
+import { auth, isPrivateInstance } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import bcrypt from 'bcryptjs'
+import { randomBytes } from 'crypto'
+import { NextResponse } from 'next/server'
+
+function generateInitialPassword(): string {
+  return randomBytes(8).toString('base64').slice(0, 12)
+}
+
+/**
+ * Reset password for a whitelist user
+ */
+export async function PATCH(
+  request: Request,
+  { params }: { params: Promise<{ userId: string }> },
+) {
+  try {
+    const { userId } = await params
+
+    // Check if private instance mode is enabled
+    if (!isPrivateInstance()) {
+      return NextResponse.json(
+        { error: 'Private instance mode is not enabled' },
+        { status: 400 },
+      )
+    }
+
+    // Check authentication
+    const session = await auth()
+    if (!session?.user?.isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    // Check if user exists
+    const user = await prisma.whitelistUser.findUnique({
+      where: { id: userId },
+    })
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    // Generate new password
+    const initialPassword = generateInitialPassword()
+    const hashedPassword = await bcrypt.hash(initialPassword, 12)
+
+    // Update user with new password
+    await prisma.whitelistUser.update({
+      where: { id: userId },
+      data: {
+        password: hashedPassword,
+        mustChangePassword: true,
+      },
+    })
+
+    return NextResponse.json({ initialPassword })
+  } catch (error) {
+    console.error('Error resetting password:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function DELETE(
+  request: Request,
+  { params }: { params: Promise<{ userId: string }> },
+) {
+  try {
+    const { userId } = await params
+
+    // Check if private instance mode is enabled
+    if (!isPrivateInstance()) {
+      return NextResponse.json(
+        { error: 'Private instance mode is not enabled' },
+        { status: 400 },
+      )
+    }
+
+    // Check authentication
+    const session = await auth()
+    if (!session?.user?.isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    // Check if user exists
+    const user = await prisma.whitelistUser.findUnique({
+      where: { id: userId },
+    })
+
+    if (!user) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    // Delete user
+    await prisma.whitelistUser.delete({
+      where: { id: userId },
+    })
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Error deleting whitelist user:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/admin/whitelist/route.ts
+++ b/src/app/api/admin/whitelist/route.ts
@@ -1,0 +1,142 @@
+/**
+ * Whitelist User Management API (Issue #4)
+ */
+
+import { auth, isPrivateInstance } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import bcrypt from 'bcryptjs'
+import { randomBytes } from 'crypto'
+import { NextResponse } from 'next/server'
+
+/**
+ * Generate a random initial password
+ */
+function generateInitialPassword(): string {
+  return randomBytes(8).toString('base64').slice(0, 12)
+}
+
+export async function POST(request: Request) {
+  try {
+    // Check if private instance mode is enabled
+    if (!isPrivateInstance()) {
+      return NextResponse.json(
+        { error: 'Private instance mode is not enabled' },
+        { status: 400 },
+      )
+    }
+
+    // Check authentication
+    const session = await auth()
+    if (!session?.user?.isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = (await request.json()) as { email?: string; name?: string }
+    const { email, name } = body
+
+    if (!email) {
+      return NextResponse.json({ error: 'Email is required' }, { status: 400 })
+    }
+
+    // Validate email format
+    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+    if (!emailRegex.test(email)) {
+      return NextResponse.json(
+        { error: 'Invalid email format' },
+        { status: 400 },
+      )
+    }
+
+    // Check if user already exists
+    const existingUser = await prisma.whitelistUser.findUnique({
+      where: { email },
+    })
+
+    if (existingUser) {
+      return NextResponse.json(
+        { error: 'User already in whitelist' },
+        { status: 400 },
+      )
+    }
+
+    // Check if email is an admin
+    const existingAdmin = await prisma.admin.findUnique({
+      where: { email },
+    })
+
+    if (existingAdmin) {
+      return NextResponse.json(
+        { error: 'User is already an admin' },
+        { status: 400 },
+      )
+    }
+
+    // Generate initial password
+    const initialPassword = generateInitialPassword()
+    const hashedPassword = await bcrypt.hash(initialPassword, 12)
+
+    // Create whitelist user with initial password
+    const user = await prisma.whitelistUser.create({
+      data: {
+        email,
+        password: hashedPassword,
+        name: name || null,
+        mustChangePassword: true,
+        addedById: session.user.id,
+      },
+    })
+
+    // Return user with initial password (only shown once!)
+    return NextResponse.json({
+      user: {
+        id: user.id,
+        email: user.email,
+        name: user.name,
+        createdAt: user.createdAt,
+      },
+      initialPassword, // This should be shown to admin to share with user
+    })
+  } catch (error) {
+    console.error('Error adding whitelist user:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 },
+    )
+  }
+}
+
+export async function GET() {
+  try {
+    // Check if private instance mode is enabled
+    if (!isPrivateInstance()) {
+      return NextResponse.json(
+        { error: 'Private instance mode is not enabled' },
+        { status: 400 },
+      )
+    }
+
+    // Check authentication
+    const session = await auth()
+    if (!session?.user?.isAdmin) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const users = await prisma.whitelistUser.findMany({
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    })
+
+    return NextResponse.json({ users })
+  } catch (error) {
+    console.error('Error fetching whitelist users:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,7 @@
+/**
+ * NextAuth.js API route handler
+ */
+
+import { handlers } from '@/lib/auth'
+
+export const { GET, POST } = handlers

--- a/src/app/api/auth/change-password/route.ts
+++ b/src/app/api/auth/change-password/route.ts
@@ -1,0 +1,107 @@
+/**
+ * Password Change API (Issue #4)
+ */
+
+import { auth } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import bcrypt from 'bcryptjs'
+import { NextResponse } from 'next/server'
+
+export async function POST(request: Request) {
+  try {
+    const session = await auth()
+
+    if (!session?.user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const body = (await request.json()) as {
+      currentPassword?: string
+      newPassword?: string
+    }
+    const { currentPassword, newPassword } = body
+
+    if (!currentPassword || !newPassword) {
+      return NextResponse.json(
+        { error: 'Current password and new password are required' },
+        { status: 400 },
+      )
+    }
+
+    if (newPassword.length < 8) {
+      return NextResponse.json(
+        { error: 'New password must be at least 8 characters' },
+        { status: 400 },
+      )
+    }
+
+    if (newPassword === currentPassword) {
+      return NextResponse.json(
+        { error: 'New password must be different from current password' },
+        { status: 400 },
+      )
+    }
+
+    const userId = session.user.id
+    const isAdmin = session.user.isAdmin
+
+    // Get user from database
+    let userPassword: string | null = null
+    if (isAdmin) {
+      const admin = await prisma.admin.findUnique({
+        where: { id: userId },
+        select: { password: true },
+      })
+      userPassword = admin?.password ?? null
+    } else {
+      const whitelistUser = await prisma.whitelistUser.findUnique({
+        where: { id: userId },
+        select: { password: true },
+      })
+      userPassword = whitelistUser?.password ?? null
+    }
+
+    if (!userPassword) {
+      return NextResponse.json({ error: 'User not found' }, { status: 404 })
+    }
+
+    // Verify current password
+    const isValidPassword = await bcrypt.compare(currentPassword, userPassword)
+    if (!isValidPassword) {
+      return NextResponse.json(
+        { error: 'Current password is incorrect' },
+        { status: 400 },
+      )
+    }
+
+    // Hash new password
+    const hashedPassword = await bcrypt.hash(newPassword, 12)
+
+    // Update password and clear mustChangePassword flag
+    if (isAdmin) {
+      await prisma.admin.update({
+        where: { id: userId },
+        data: {
+          password: hashedPassword,
+          mustChangePassword: false,
+        },
+      })
+    } else {
+      await prisma.whitelistUser.update({
+        where: { id: userId },
+        data: {
+          password: hashedPassword,
+          mustChangePassword: false,
+        },
+      })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Error changing password:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 },
+    )
+  }
+}

--- a/src/app/auth/change-password/page.tsx
+++ b/src/app/auth/change-password/page.tsx
@@ -1,0 +1,169 @@
+'use client'
+
+/**
+ * Password Change Page (Issue #4)
+ */
+
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+
+export default function ChangePasswordPage() {
+  const { data: session, update } = useSession()
+  const router = useRouter()
+
+  const [currentPassword, setCurrentPassword] = useState('')
+  const [newPassword, setNewPassword] = useState('')
+  const [confirmPassword, setConfirmPassword] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState(false)
+
+  const isForced = session?.user?.mustChangePassword
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsLoading(true)
+    setError(null)
+
+    if (newPassword !== confirmPassword) {
+      setError('New passwords do not match')
+      setIsLoading(false)
+      return
+    }
+
+    if (newPassword.length < 8) {
+      setError('New password must be at least 8 characters')
+      setIsLoading(false)
+      return
+    }
+
+    try {
+      const response = await fetch('/api/auth/change-password', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ currentPassword, newPassword }),
+      })
+
+      if (!response.ok) {
+        const data = (await response.json()) as { error?: string }
+        throw new Error(data.error || 'Failed to change password')
+      }
+
+      setSuccess(true)
+
+      // Update session to reflect mustChangePassword = false
+      // Force a full session refresh by updating with the new state
+      await update({ mustChangePassword: false })
+
+      // Redirect after success - use window.location for full page reload
+      // to ensure the session is completely refreshed
+      setTimeout(() => {
+        window.location.href = '/'
+      }, 2000)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to change password')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  if (!session?.user) {
+    return (
+      <div className="flex min-h-screen items-center justify-center p-4">
+        <Card className="w-full max-w-md">
+          <CardContent className="pt-6">
+            <p className="text-center text-muted-foreground">
+              Please sign in to change your password
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl">Change Password</CardTitle>
+          <CardDescription>
+            {isForced
+              ? 'You must change your password before continuing'
+              : 'Update your account password'}
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {success ? (
+            <div className="rounded-md bg-green-50 p-4 text-center text-green-800 dark:bg-green-900/20 dark:text-green-400">
+              Password changed successfully! Redirecting...
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              {error && (
+                <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                  {error}
+                </div>
+              )}
+
+              <div className="space-y-2">
+                <Label htmlFor="currentPassword">Current Password</Label>
+                <Input
+                  id="currentPassword"
+                  type="password"
+                  value={currentPassword}
+                  onChange={(e) => setCurrentPassword(e.target.value)}
+                  required
+                  autoComplete="current-password"
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="newPassword">New Password</Label>
+                <Input
+                  id="newPassword"
+                  type="password"
+                  value={newPassword}
+                  onChange={(e) => setNewPassword(e.target.value)}
+                  required
+                  minLength={8}
+                  autoComplete="new-password"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Must be at least 8 characters
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="confirmPassword">Confirm New Password</Label>
+                <Input
+                  id="confirmPassword"
+                  type="password"
+                  value={confirmPassword}
+                  onChange={(e) => setConfirmPassword(e.target.value)}
+                  required
+                  minLength={8}
+                  autoComplete="new-password"
+                />
+              </div>
+
+              <Button type="submit" className="w-full" disabled={isLoading}>
+                {isLoading ? 'Changing...' : 'Change Password'}
+              </Button>
+            </form>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/auth/error/page.tsx
+++ b/src/app/auth/error/page.tsx
@@ -1,0 +1,54 @@
+'use client'
+
+/**
+ * Auth Error Page
+ */
+
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import Link from 'next/link'
+import { useSearchParams } from 'next/navigation'
+
+export default function AuthErrorPage() {
+  const searchParams = useSearchParams()
+  const error = searchParams.get('error')
+
+  const getErrorMessage = (error: string | null) => {
+    switch (error) {
+      case 'Configuration':
+        return 'There is a problem with the server configuration.'
+      case 'AccessDenied':
+        return 'You do not have permission to sign in.'
+      case 'Verification':
+        return 'The verification link has expired or has already been used.'
+      case 'CredentialsSignin':
+        return 'Invalid email or password.'
+      default:
+        return 'An error occurred during authentication.'
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl text-destructive">
+            Authentication Error
+          </CardTitle>
+          <CardDescription>{getErrorMessage(error)}</CardDescription>
+        </CardHeader>
+        <CardContent className="flex justify-center">
+          <Button asChild>
+            <Link href="/auth/signin">Try Again</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+/**
+ * Sign In Page for Private Instance Mode (Issue #4)
+ */
+
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { signIn } from 'next-auth/react'
+import { useSearchParams } from 'next/navigation'
+import { useState } from 'react'
+
+export default function SignInPage() {
+  const searchParams = useSearchParams()
+  const callbackUrl = searchParams.get('callbackUrl') || '/'
+  const error = searchParams.get('error')
+
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [isLoading, setIsLoading] = useState(false)
+  const [errorMessage, setErrorMessage] = useState<string | null>(
+    error === 'CredentialsSignin' ? 'Invalid email or password' : null,
+  )
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setIsLoading(true)
+    setErrorMessage(null)
+
+    try {
+      await signIn('credentials', {
+        email,
+        password,
+        callbackUrl,
+        redirect: true,
+      })
+      // If redirect is true, this code won't be reached on success
+    } catch {
+      setErrorMessage('An error occurred. Please try again.')
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <CardTitle className="text-2xl">Sign In</CardTitle>
+          <CardDescription>
+            Sign in to access this private instance
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            {errorMessage && (
+              <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+                {errorMessage}
+              </div>
+            )}
+
+            <div className="space-y-2">
+              <Label htmlFor="email">Email</Label>
+              <Input
+                id="email"
+                type="email"
+                placeholder="admin@example.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+                autoComplete="email"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="password">Password</Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                required
+                autoComplete="current-password"
+              />
+            </div>
+
+            <Button type="submit" className="w-full" disabled={isLoading}>
+              {isLoading ? 'Signing in...' : 'Sign In'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/src/app/home-page-buttons.tsx
+++ b/src/app/home-page-buttons.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+/**
+ * Home Page Buttons for Private Instance Mode (Issue #4)
+ * Shows signin button when not authenticated, groups button when authenticated
+ */
+
+import { Button } from '@/components/ui/button'
+import { Github, LogIn } from 'lucide-react'
+import { useSession } from 'next-auth/react'
+import { useTranslations } from 'next-intl'
+import Link from 'next/link'
+
+export function HomePageButtons() {
+  const { data: session, status } = useSession()
+  const t = useTranslations()
+
+  if (status === 'loading') {
+    return (
+      <div className="flex gap-2">
+        <Button disabled>
+          <span className="animate-pulse">Loading...</span>
+        </Button>
+      </div>
+    )
+  }
+
+  if (session?.user) {
+    // Authenticated - show groups button
+    return (
+      <div className="flex gap-2">
+        <Button asChild>
+          <Link href="/groups">{t('Homepage.button.groups')}</Link>
+        </Button>
+        <Button asChild variant="secondary">
+          <Link href="https://github.com/sora-grayscale/spliit">
+            <Github className="w-4 h-4 mr-2" />
+            {t('Homepage.button.github')}
+          </Link>
+        </Button>
+      </div>
+    )
+  }
+
+  // Not authenticated - show signin button
+  return (
+    <div className="flex gap-2">
+      <Button asChild>
+        <Link href="/auth/signin">
+          <LogIn className="w-4 h-4 mr-2" />
+          Sign In
+        </Link>
+      </Button>
+      <Button asChild variant="secondary">
+        <Link href="https://github.com/sora-grayscale/spliit">
+          <Github className="w-4 h-4 mr-2" />
+          {t('Homepage.button.github')}
+        </Link>
+      </Button>
+    </div>
+  )
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,18 @@
 import { Button } from '@/components/ui/button'
+import { env } from '@/lib/env'
 import { Github } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { HeroSection } from './hero-section'
+import { HomePageButtons } from './home-page-buttons'
 
 // FIX for https://github.com/vercel/next.js/issues/58615
 // export const dynamic = 'force-dynamic'
 
 export default function HomePage() {
   const t = useTranslations()
+  const isPrivateInstance = env.PRIVATE_INSTANCE === true
+
   return (
     <main>
       <section className="py-16 md:py-24 lg:py-32">
@@ -17,17 +21,21 @@ export default function HomePage() {
             title={t.raw('Homepage.title')}
             description={t.raw('Homepage.description')}
           />
-          <div className="flex gap-2">
-            <Button asChild>
-              <Link href="/groups">{t('Homepage.button.groups')}</Link>
-            </Button>
-            <Button asChild variant="secondary">
-              <Link href="https://github.com/sora-grayscale/spliit">
-                <Github className="w-4 h-4 mr-2" />
-                {t('Homepage.button.github')}
-              </Link>
-            </Button>
-          </div>
+          {isPrivateInstance ? (
+            <HomePageButtons />
+          ) : (
+            <div className="flex gap-2">
+              <Button asChild>
+                <Link href="/groups">{t('Homepage.button.groups')}</Link>
+              </Button>
+              <Button asChild variant="secondary">
+                <Link href="https://github.com/sora-grayscale/spliit">
+                  <Github className="w-4 h-4 mr-2" />
+                  {t('Homepage.button.github')}
+                </Link>
+              </Button>
+            </div>
+          )}
         </div>
       </section>
     </main>

--- a/src/components/auth-provider.tsx
+++ b/src/components/auth-provider.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+/**
+ * Auth Provider for NextAuth.js (Issue #4)
+ * Only renders SessionProvider when PRIVATE_INSTANCE is enabled
+ */
+
+import { SessionProvider } from 'next-auth/react'
+import { type ReactNode } from 'react'
+
+interface AuthProviderProps {
+  children: ReactNode
+  enabled?: boolean
+}
+
+export function AuthProvider({ children, enabled = false }: AuthProviderProps) {
+  // Only wrap with SessionProvider if private instance mode is enabled
+  if (!enabled) {
+    return <>{children}</>
+  }
+
+  return <SessionProvider>{children}</SessionProvider>
+}

--- a/src/components/password-change-guard.tsx
+++ b/src/components/password-change-guard.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+/**
+ * Password Change Guard Component (Issue #4)
+ * Redirects users to password change page if mustChangePassword is true
+ */
+
+import { useSession } from 'next-auth/react'
+import { usePathname, useRouter } from 'next/navigation'
+import { useEffect } from 'react'
+
+interface PasswordChangeGuardProps {
+  children: React.ReactNode
+  enabled?: boolean
+}
+
+// Routes that don't require password change check
+const excludedRoutes = ['/auth/signin', '/auth/error', '/auth/change-password']
+
+export function PasswordChangeGuard({
+  children,
+  enabled = false,
+}: PasswordChangeGuardProps) {
+  // Don't render the guard content if private instance mode is not enabled
+  if (!enabled) {
+    return <>{children}</>
+  }
+
+  return <PasswordChangeGuardContent>{children}</PasswordChangeGuardContent>
+}
+
+function PasswordChangeGuardContent({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const { data: session, status } = useSession()
+  const router = useRouter()
+  const pathname = usePathname()
+
+  useEffect(() => {
+    if (status !== 'authenticated') return
+    if (excludedRoutes.some((route) => pathname.startsWith(route))) return
+
+    if (session?.user?.mustChangePassword) {
+      router.push('/auth/change-password')
+    }
+  }, [session, status, pathname, router])
+
+  return <>{children}</>
+}

--- a/src/components/user-menu.tsx
+++ b/src/components/user-menu.tsx
@@ -1,0 +1,96 @@
+'use client'
+
+/**
+ * User Menu Component for Private Instance Mode (Issue #4)
+ */
+
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Key, LogIn, LogOut, Settings, User } from 'lucide-react'
+import { signOut, useSession } from 'next-auth/react'
+import Link from 'next/link'
+
+interface UserMenuProps {
+  enabled?: boolean
+}
+
+export function UserMenu({ enabled = false }: UserMenuProps) {
+  // Don't render if private instance mode is not enabled
+  if (!enabled) {
+    return null
+  }
+
+  return <UserMenuContent />
+}
+
+function UserMenuContent() {
+  const { data: session, status } = useSession()
+
+  // Show loading state
+  if (status === 'loading') {
+    return (
+      <Button variant="ghost" size="icon" disabled>
+        <User className="h-5 w-5 animate-pulse" />
+      </Button>
+    )
+  }
+
+  // Not authenticated - show sign in button
+  if (!session?.user) {
+    return (
+      <Button variant="ghost" size="sm" asChild>
+        <Link href="/auth/signin" className="flex items-center gap-1">
+          <LogIn className="h-4 w-4" />
+          <span className="hidden sm:inline">Sign In</span>
+        </Link>
+      </Button>
+    )
+  }
+
+  // Authenticated - show user menu
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" size="icon" className="relative">
+          <User className="h-5 w-5" />
+          <span className="sr-only">User menu</span>
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <div className="px-2 py-1.5">
+          <p className="text-sm font-medium">{session.user.name || 'User'}</p>
+          <p className="text-xs text-muted-foreground">{session.user.email}</p>
+        </div>
+        <DropdownMenuSeparator />
+        {session.user.isAdmin && (
+          <DropdownMenuItem asChild>
+            <Link href="/admin" className="flex items-center">
+              <Settings className="mr-2 h-4 w-4" />
+              Admin Dashboard
+            </Link>
+          </DropdownMenuItem>
+        )}
+        <DropdownMenuItem asChild>
+          <Link href="/auth/change-password" className="flex items-center">
+            <Key className="mr-2 h-4 w-4" />
+            Change Password
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onClick={() => signOut({ callbackUrl: '/' })}
+          className="text-destructive focus:text-destructive"
+        >
+          <LogOut className="mr-2 h-4 w-4" />
+          Sign Out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,221 @@
+/**
+ * NextAuth.js configuration for Private Instance Mode (Issue #4)
+ */
+
+import { prisma } from '@/lib/prisma'
+import { PrismaAdapter } from '@auth/prisma-adapter'
+import bcrypt from 'bcryptjs'
+import NextAuth, { type NextAuthConfig } from 'next-auth'
+import Credentials from 'next-auth/providers/credentials'
+
+// Extend the session type to include our custom properties
+declare module 'next-auth' {
+  interface Session {
+    user: {
+      id: string
+      email: string
+      name?: string | null
+      isAdmin: boolean
+      mustChangePassword: boolean
+    }
+  }
+  interface User {
+    isAdmin: boolean
+    mustChangePassword: boolean
+  }
+}
+
+const authConfig: NextAuthConfig = {
+  adapter: PrismaAdapter(prisma) as NextAuthConfig['adapter'],
+  providers: [
+    Credentials({
+      name: 'credentials',
+      credentials: {
+        email: { label: 'Email', type: 'email' },
+        password: { label: 'Password', type: 'password' },
+      },
+      async authorize(credentials) {
+        if (!credentials?.email || !credentials?.password) {
+          return null
+        }
+
+        const email = credentials.email as string
+        const password = credentials.password as string
+
+        // Check if user is an admin
+        const admin = await prisma.admin.findUnique({
+          where: { email },
+        })
+
+        if (admin) {
+          const isValidPassword = await bcrypt.compare(password, admin.password)
+          if (isValidPassword) {
+            return {
+              id: admin.id,
+              email: admin.email,
+              name: admin.name,
+              isAdmin: true,
+              mustChangePassword: admin.mustChangePassword,
+            }
+          }
+        }
+
+        // Check if user is in whitelist
+        const whitelistUser = await prisma.whitelistUser.findUnique({
+          where: { email },
+        })
+
+        if (whitelistUser && whitelistUser.password) {
+          const isValidPassword = await bcrypt.compare(
+            password,
+            whitelistUser.password,
+          )
+          if (isValidPassword) {
+            return {
+              id: whitelistUser.id,
+              email: whitelistUser.email,
+              name: whitelistUser.name,
+              isAdmin: false,
+              mustChangePassword: whitelistUser.mustChangePassword,
+            }
+          }
+        }
+
+        return null
+      },
+    }),
+  ],
+  session: {
+    strategy: 'jwt',
+  },
+  callbacks: {
+    async jwt({ token, user, trigger, session: updateData }) {
+      if (user) {
+        ;(token as Record<string, unknown>).isAdmin = user.isAdmin
+        ;(token as Record<string, unknown>).mustChangePassword =
+          user.mustChangePassword
+      }
+      // Handle session update - always refresh from database for security
+      // Never trust client-sent values for security-critical flags
+      if (trigger === 'update' && token.sub) {
+        const admin = await prisma.admin.findUnique({
+          where: { id: token.sub },
+          select: { mustChangePassword: true },
+        })
+        if (admin) {
+          ;(token as Record<string, unknown>).mustChangePassword =
+            admin.mustChangePassword
+        } else {
+          const whitelistUser = await prisma.whitelistUser.findUnique({
+            where: { id: token.sub },
+            select: { mustChangePassword: true },
+          })
+          if (whitelistUser) {
+            ;(token as Record<string, unknown>).mustChangePassword =
+              whitelistUser.mustChangePassword
+          }
+        }
+      }
+      return token
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        session.user.id = token.sub as string
+        session.user.isAdmin =
+          ((token as Record<string, unknown>).isAdmin as boolean) ?? false
+        session.user.mustChangePassword =
+          ((token as Record<string, unknown>).mustChangePassword as boolean) ??
+          false
+      }
+      return session
+    },
+  },
+  pages: {
+    signIn: '/auth/signin',
+    error: '/auth/error',
+  },
+}
+
+export const { handlers, signIn, signOut, auth } = NextAuth(authConfig)
+
+/**
+ * Check if private instance mode is enabled
+ */
+export function isPrivateInstance(): boolean {
+  return process.env.PRIVATE_INSTANCE === 'true'
+}
+
+/**
+ * Initialize admin user from environment variables
+ * Call this on server startup if PRIVATE_INSTANCE is enabled
+ */
+export async function initializeAdmin(): Promise<void> {
+  if (!isPrivateInstance()) {
+    return
+  }
+
+  const adminEmail = process.env.ADMIN_EMAIL
+  const adminPassword = process.env.ADMIN_PASSWORD
+
+  if (!adminEmail || !adminPassword) {
+    console.warn(
+      'PRIVATE_INSTANCE is enabled but ADMIN_EMAIL or ADMIN_PASSWORD is not set',
+    )
+    return
+  }
+
+  // Check if admin already exists
+  const existingAdmin = await prisma.admin.findUnique({
+    where: { email: adminEmail },
+  })
+
+  if (existingAdmin) {
+    return // Admin already exists
+  }
+
+  // Create initial admin with mustChangePassword flag
+  const hashedPassword = await bcrypt.hash(adminPassword, 12)
+  await prisma.admin.create({
+    data: {
+      email: adminEmail,
+      password: hashedPassword,
+      name: 'Admin',
+      mustChangePassword: true,
+    },
+  })
+
+  console.log(`Initial admin created: ${adminEmail}`)
+}
+
+/**
+ * Check if a user is authorized to access the application
+ */
+export async function isAuthorizedUser(email: string): Promise<boolean> {
+  if (!isPrivateInstance()) {
+    return true // Public instance - everyone is authorized
+  }
+
+  // Check if admin
+  const admin = await prisma.admin.findUnique({
+    where: { email },
+  })
+  if (admin) return true
+
+  // Check if in whitelist
+  const whitelistUser = await prisma.whitelistUser.findUnique({
+    where: { email },
+  })
+  if (whitelistUser) return true
+
+  return false
+}
+
+/**
+ * Check if a user is an admin
+ */
+export async function isAdminUser(email: string): Promise<boolean> {
+  const admin = await prisma.admin.findUnique({
+    where: { email },
+  })
+  return !!admin
+}

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -13,6 +13,15 @@ const envSchema = z
     AUTO_DELETE_INACTIVE_DAYS: z.coerce.number().int().min(0).default(90),
     DELETE_GRACE_PERIOD_DAYS: z.coerce.number().int().min(1).default(7),
     CRON_SECRET: z.string().optional(),
+    // Private Instance Mode (Issue #4)
+    PRIVATE_INSTANCE: z.preprocess(
+      interpretEnvVarAsBool,
+      z.boolean().default(false),
+    ),
+    ADMIN_EMAIL: z.string().email().optional(),
+    ADMIN_PASSWORD: z.string().optional(),
+    NEXTAUTH_SECRET: z.string().optional(),
+    NEXTAUTH_URL: z.string().url().optional(),
     NEXT_PUBLIC_BASE_URL: z
       .string()
       .optional()

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,98 @@
+/**
+ * Proxy for Private Instance Mode (Issue #4)
+ * Handles authentication and access control
+ *
+ * Note: Next.js 16 renamed middleware.ts to proxy.ts
+ * https://nextjs.org/docs/messages/middleware-to-proxy
+ */
+
+import type { NextRequest } from 'next/server'
+import { NextResponse } from 'next/server'
+
+// Routes that don't require authentication even in private mode
+const publicRoutes = [
+  '/auth/signin',
+  '/auth/error',
+  '/auth/change-password',
+  '/api/auth',
+  '/api/health',
+  '/api/trpc', // tRPC routes handle their own auth
+]
+
+// Routes that are always public (shared group access)
+const sharedRoutes = ['/groups/'] // Group pages can be accessed via shared links
+
+// Admin-only routes
+const adminRoutes = ['/admin']
+
+export async function proxy(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
+  // Check if private instance mode is enabled
+  const isPrivateInstance = process.env.PRIVATE_INSTANCE === 'true'
+
+  if (!isPrivateInstance) {
+    // Public instance - allow all requests
+    return NextResponse.next()
+  }
+
+  // Check if this is a public route
+  const isPublicRoute = publicRoutes.some((route) => pathname.startsWith(route))
+  if (isPublicRoute) {
+    return NextResponse.next()
+  }
+
+  // Get session token from cookies
+  const sessionToken =
+    request.cookies.get('authjs.session-token')?.value ||
+    request.cookies.get('__Secure-authjs.session-token')?.value
+
+  // Group creation requires auth - check before sharedRoutes
+  if (pathname === '/groups/create' && !sessionToken) {
+    const signInUrl = new URL('/auth/signin', request.url)
+    signInUrl.searchParams.set('callbackUrl', pathname)
+    return NextResponse.redirect(signInUrl)
+  }
+
+  // Check if this is a shared group route (allow access without auth)
+  const isSharedRoute = sharedRoutes.some((route) => pathname.startsWith(route))
+  if (isSharedRoute) {
+    // Allow shared group access without authentication
+    // The group itself is protected by the encryption key in the URL
+    return NextResponse.next()
+  }
+
+  // Check if this is a static file or API route that should be public
+  if (
+    pathname.startsWith('/_next') ||
+    pathname.startsWith('/favicon') ||
+    pathname.startsWith('/icon') ||
+    pathname.startsWith('/apple-icon') ||
+    pathname.endsWith('.png') ||
+    pathname.endsWith('.ico') ||
+    pathname.endsWith('.svg')
+  ) {
+    return NextResponse.next()
+  }
+
+  // Check admin routes
+  if (adminRoutes.some((route) => pathname.startsWith(route))) {
+    // Admin check will be done in the page component
+    // Middleware can't easily check database
+    return NextResponse.next()
+  }
+
+  return NextResponse.next()
+}
+
+export const config = {
+  matcher: [
+    /*
+     * Match all request paths except for the ones starting with:
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    '/((?!_next/static|_next/image|favicon.ico).*)',
+  ],
+}


### PR DESCRIPTION
## Summary
- Implement Private Instance Mode with NextAuth.js authentication
- Add Admin and WhitelistUser models for user management
- Create admin dashboard for user management
- Shared group links remain accessible without authentication

## Changes
- **Prisma**: Add Admin and WhitelistUser models
- **Auth**: NextAuth.js v5 (beta) with Credentials provider, JWT sessions
- **Middleware**: Route protection for admin pages
- **UI**: Sign in page, admin dashboard, UserMenu component
- **API**: Whitelist user CRUD endpoints, admin initialization endpoint
- **Config**: New environment variables (PRIVATE_INSTANCE, ADMIN_EMAIL, ADMIN_PASSWORD, NEXTAUTH_SECRET)

## Environment Variables
```bash
PRIVATE_INSTANCE=false           # Enable private instance mode
ADMIN_EMAIL=admin@example.com    # Initial admin email
ADMIN_PASSWORD=                  # Initial admin password
NEXTAUTH_SECRET=                 # NextAuth.js secret
NEXTAUTH_URL=http://localhost:3000
```

## Test plan
- [ ] Set PRIVATE_INSTANCE=false → App works as before (public mode)
- [ ] Set PRIVATE_INSTANCE=true with ADMIN_EMAIL/PASSWORD → Admin can sign in
- [ ] Visit /admin → Shows admin dashboard with stats
- [ ] Add whitelist user → User appears in whitelist table
- [ ] Remove whitelist user → User is removed
- [ ] Shared group links (/groups/[id]) → Accessible without auth
- [ ] Non-authenticated user → Redirected to /auth/signin

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)