### PR TITLE
feat(e2ee): encrypt category for complete E2EE (#19)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,16 +24,17 @@
 - **Zero-knowledge server**: The server never sees unencrypted data
 - **URL fragment key storage**: Encryption key in `#<base64key>` format (never sent to server)
 - **localStorage persistence**: Keys saved per-group for convenience
-- **Everything encrypted**: Group names, participant names, expense titles, notes, amounts
+- **Everything encrypted**: Group names, participant names, expense titles, notes, amounts, categories
 
 ### Key Files
 
 ```
 src/lib/crypto.ts              # Core crypto utilities (PBKDF2, key derivation, password generation)
-src/lib/encrypt-helpers.ts     # Encryption/decryption helpers
+src/lib/encrypt-helpers.ts     # Encryption/decryption helpers (amount, category, title, notes)
 src/lib/totals.ts              # Stats calculation utilities
 src/lib/hooks/useBalances.ts   # Client-side balance calculation with decryption
 src/lib/auto-delete.ts         # Auto-delete inactive groups (Issue #10)
+src/app/groups/[groupId]/expenses/category-icon.tsx  # Static category mapping for E2EE (Issue #19)
 src/components/encryption-provider.tsx  # React context for encryption (handles password protection)
 src/components/password-prompt.tsx      # Password entry component with rate limiting
 src/lib/hooks/use-group-url.ts # URL navigation with key preservation
@@ -146,6 +147,19 @@ src/__tests__/private-instance.test.ts    # Private instance mode tests
 - [x] Server stores only encrypted values (String type in DB)
 - [x] Balance calculation done client-side (useBalances hook)
 - [x] All financial data fully encrypted (amount, originalAmount, shares)
+
+#### Issue #19: Category Encryption (Complete E2EE)
+
+**Status**: DONE
+**Priority**: HIGH
+**Link**: https://github.com/sora-grayscale/spliit/issues/19
+
+- [x] Encrypt category ID on client before sending
+- [x] Decrypt on client for display
+- [x] Server stores only encrypted categoryId (String type in DB)
+- [x] Removed FK relation between Expense and Category tables
+- [x] Static category mapping in CategoryIcon component
+- [x] Backward compatibility for legacy unencrypted categoryId values
 
 #### Issue #2: Password Protection
 
@@ -274,6 +288,19 @@ src/__tests__/private-instance.test.ts    # Private instance mode tests
 - [x] UserMenu component in header (shows when authenticated)
 - [x] AuthProvider wrapper in layout (conditional on PRIVATE_INSTANCE)
 - [x] Security tests (107 total tests passing)
+
+#### Category Encryption (Issue #19) - DONE
+
+- [x] Schema: categoryId changed from Int to String (encrypted)
+- [x] Removed FK relation between Expense and Category tables
+- [x] encryptExpenseFormValues: encrypts category ID
+- [x] decryptExpense: decrypts categoryId (handles legacy plain number/string values)
+- [x] CategoryIcon: Static CATEGORY_MAP for categoryId to grouping/name lookup
+- [x] getCategoryInfo helper function for category metadata
+- [x] Updated all components using CategoryIcon (expense-card, category-selector, etc.)
+- [x] CSV/JSON export updated to use categoryId
+- [x] Migration: 20260112225207_encrypt_category_for_e2ee
+- [x] Tests for category encryption and backward compatibility (111 total tests passing)
 
 ## Security Considerations
 

--- a/prisma/migrations/20260112225207_encrypt_category_for_e2ee/migration.sql
+++ b/prisma/migrations/20260112225207_encrypt_category_for_e2ee/migration.sql
@@ -1,0 +1,6 @@
+-- DropForeignKey
+ALTER TABLE "Expense" DROP CONSTRAINT "Expense_categoryId_fkey";
+
+-- AlterTable
+ALTER TABLE "Expense" ALTER COLUMN "categoryId" SET DEFAULT '0',
+ALTER COLUMN "categoryId" SET DATA TYPE TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,7 +40,8 @@ model Category {
   id       Int       @id @default(autoincrement())
   grouping String
   name     String
-  Expense  Expense[]
+  // Note: Expense relation removed for E2EE (Issue #19)
+  // categoryId is now encrypted, so FK relation is not possible
 }
 
 model Expense {
@@ -48,8 +49,9 @@ model Expense {
   group            Group             @relation(fields: [groupId], references: [id], onDelete: Cascade)
   expenseDate      DateTime          @default(dbgenerated("CURRENT_DATE")) @db.Date
   title            String
-  category         Category?         @relation(fields: [categoryId], references: [id])
-  categoryId       Int               @default(0)
+  // Category is now stored as encrypted string for E2EE (Issue #19)
+  // Legacy data may still have integer values as strings (e.g., "0", "1")
+  categoryId       String            @default("0") // Encrypted category ID
   amount           String            // Encrypted amount (cents as string or encrypted)
   originalAmount   String?           // Encrypted original amount
   originalCurrency String?

--- a/src/app/groups/[groupId]/expenses/category-icon.tsx
+++ b/src/app/groups/[groupId]/expenses/category-icon.tsx
@@ -1,4 +1,3 @@
-import { Category } from '@prisma/client'
 import {
   Armchair,
   Baby,
@@ -43,11 +42,80 @@ import {
   Wrench,
 } from 'lucide-react'
 
+// Static category mapping for E2EE (Issue #19)
+// Since categoryId is now encrypted, we can't use the database relation
+// This mapping matches the Category table seeded in migrations
+const CATEGORY_MAP: Record<number, { grouping: string; name: string }> = {
+  0: { grouping: 'Uncategorized', name: 'General' },
+  1: { grouping: 'Uncategorized', name: 'Payment' },
+  2: { grouping: 'Entertainment', name: 'Entertainment' },
+  3: { grouping: 'Entertainment', name: 'Games' },
+  4: { grouping: 'Entertainment', name: 'Movies' },
+  5: { grouping: 'Entertainment', name: 'Music' },
+  6: { grouping: 'Entertainment', name: 'Sports' },
+  7: { grouping: 'Food and Drink', name: 'Food and Drink' },
+  8: { grouping: 'Food and Drink', name: 'Dining Out' },
+  9: { grouping: 'Food and Drink', name: 'Groceries' },
+  10: { grouping: 'Food and Drink', name: 'Liquor' },
+  11: { grouping: 'Home', name: 'Home' },
+  12: { grouping: 'Home', name: 'Electronics' },
+  13: { grouping: 'Home', name: 'Furniture' },
+  14: { grouping: 'Home', name: 'Household Supplies' },
+  15: { grouping: 'Home', name: 'Maintenance' },
+  16: { grouping: 'Home', name: 'Mortgage' },
+  17: { grouping: 'Home', name: 'Pets' },
+  18: { grouping: 'Home', name: 'Rent' },
+  19: { grouping: 'Home', name: 'Services' },
+  20: { grouping: 'Life', name: 'Childcare' },
+  21: { grouping: 'Life', name: 'Clothing' },
+  22: { grouping: 'Life', name: 'Education' },
+  23: { grouping: 'Life', name: 'Gifts' },
+  24: { grouping: 'Life', name: 'Insurance' },
+  25: { grouping: 'Life', name: 'Medical Expenses' },
+  26: { grouping: 'Life', name: 'Taxes' },
+  27: { grouping: 'Transportation', name: 'Transportation' },
+  28: { grouping: 'Transportation', name: 'Bicycle' },
+  29: { grouping: 'Transportation', name: 'Bus/Train' },
+  30: { grouping: 'Transportation', name: 'Car' },
+  31: { grouping: 'Transportation', name: 'Gas/Fuel' },
+  32: { grouping: 'Transportation', name: 'Hotel' },
+  33: { grouping: 'Transportation', name: 'Parking' },
+  34: { grouping: 'Transportation', name: 'Plane' },
+  35: { grouping: 'Transportation', name: 'Taxi' },
+  36: { grouping: 'Utilities', name: 'Utilities' },
+  37: { grouping: 'Utilities', name: 'Cleaning' },
+  38: { grouping: 'Utilities', name: 'Electricity' },
+  39: { grouping: 'Utilities', name: 'Heat/Gas' },
+  40: { grouping: 'Utilities', name: 'Trash' },
+  41: { grouping: 'Utilities', name: 'TV/Phone/Internet' },
+  42: { grouping: 'Utilities', name: 'Water' },
+}
+
+// Helper to get category info from categoryId
+export function getCategoryInfo(
+  categoryId: number | string | undefined | null,
+): {
+  grouping: string
+  name: string
+} | null {
+  if (categoryId === undefined || categoryId === null) return null
+  const id =
+    typeof categoryId === 'string' ? parseInt(categoryId, 10) : categoryId
+  // Handle NaN from invalid parseInt or invalid category IDs
+  if (isNaN(id) || id < 0 || id > 42) return null
+  return CATEGORY_MAP[id] ?? null
+}
+
 export function CategoryIcon({
-  category,
+  categoryId,
   ...props
-}: { category: Category | null } & LucideProps) {
-  const Icon = getCategoryIcon(`${category?.grouping}/${category?.name}`)
+}: { categoryId: number | string | undefined | null } & LucideProps) {
+  const category = getCategoryInfo(categoryId)
+  // If category is null/undefined or not found, use default icon
+  const categoryKey = category
+    ? `${category.grouping}/${category.name}`
+    : 'Uncategorized/General'
+  const Icon = getCategoryIcon(categoryKey)
   // eslint-disable-next-line react-hooks/static-components
   return <Icon {...props} />
 }

--- a/src/app/groups/[groupId]/expenses/create-from-receipt-button.tsx
+++ b/src/app/groups/[groupId]/expenses/create-from-receipt-button.tsx
@@ -185,7 +185,7 @@ function ReceiptDialogContent() {
                 receiptInfoCategory ? (
                   <div className="flex items-center">
                     <CategoryIcon
-                      category={receiptInfoCategory}
+                      categoryId={receiptInfoCategory.id}
                       className="inline w-4 h-4 mr-2"
                     />
                     <span className="mr-1">{receiptInfoCategory.grouping}</span>

--- a/src/app/groups/[groupId]/expenses/expense-card.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-card.tsx
@@ -76,7 +76,7 @@ export function ExpenseCard({
       }}
     >
       <CategoryIcon
-        category={expense.category}
+        categoryId={expense.categoryId}
         className="w-4 h-4 mr-2 mt-0.5 text-muted-foreground"
       />
       <div className="flex-1">

--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -670,7 +670,8 @@ export function ExpenseForm({
                   <CategorySelector
                     categories={categories}
                     defaultValue={
-                      form.watch(field.name) // may be overwritten externally
+                      // Convert to number (can be encrypted string or number from form)
+                      Number(form.watch(field.name)) || 0
                     }
                     onValueChange={field.onChange}
                     isLoading={isCategoryLoading}

--- a/src/app/groups/[groupId]/expenses/export/csv/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/csv/route.ts
@@ -1,3 +1,4 @@
+import { getCategoryInfo } from '@/app/groups/[groupId]/expenses/category-icon'
 import { getCurrency } from '@/lib/currency'
 import { formatAmountAsDecimal, getCurrencyFromGroup } from '@/lib/utils'
 import { Parser } from '@json2csv/plainjs'
@@ -38,7 +39,7 @@ export async function GET(
         select: {
           expenseDate: true,
           title: true,
-          category: { select: { name: true } },
+          categoryId: true,
           amount: true,
           originalAmount: true,
           originalCurrency: true,
@@ -115,7 +116,7 @@ export async function GET(
     return {
       date: formatDate(expense.expenseDate),
       title: expense.title,
-      categoryName: expense.category?.name || '',
+      categoryName: getCategoryInfo(expense.categoryId)?.name || '',
       currency: group.currencyCode ?? group.currency,
       amount: formatAmountAsDecimal(expenseAmount, currency),
       originalAmount: expense.originalAmount

--- a/src/app/groups/[groupId]/expenses/export/json/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/json/route.ts
@@ -19,7 +19,7 @@ export async function GET(
           createdAt: true,
           expenseDate: true,
           title: true,
-          category: { select: { grouping: true, name: true } },
+          categoryId: true, // Encrypted category ID (Issue #19 - E2EE)
           amount: true,
           originalAmount: true,
           originalCurrency: true,

--- a/src/components/category-selector.tsx
+++ b/src/components/category-selector.tsx
@@ -176,7 +176,7 @@ function CategoryLabel({ category }: { category: Category }) {
   const t = useTranslations('Categories')
   return (
     <div className="flex items-center gap-3">
-      <CategoryIcon category={category} className="w-4 h-4" />
+      <CategoryIcon categoryId={category.id} className="w-4 h-4" />
       {t(`${category.grouping}.${category.name}`)}
     </div>
   )

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -72,7 +72,7 @@ export async function createExpense(
       id: expenseId,
       groupId,
       expenseDate: expenseFormValues.expenseDate,
-      categoryId: expenseFormValues.category,
+      categoryId: String(expenseFormValues.category), // Convert to string (can be encrypted string or number)
       amount: String(expenseFormValues.amount), // Convert to string for DB storage
       originalAmount:
         expenseFormValues.originalAmount !== undefined
@@ -223,7 +223,7 @@ export async function updateExpense(
       originalCurrency: expenseFormValues.originalCurrency,
       conversionRate: expenseFormValues.conversionRate,
       title: expenseFormValues.title,
-      categoryId: expenseFormValues.category,
+      categoryId: String(expenseFormValues.category), // Convert to string (can be encrypted string or number)
       paidById: expenseFormValues.paidBy,
       splitMode: expenseFormValues.splitMode,
       recurrenceRule: expenseFormValues.recurrenceRule,
@@ -395,7 +395,7 @@ export async function getGroupExpenses(
   return prisma.expense.findMany({
     select: {
       amount: true,
-      category: true,
+      categoryId: true,
       createdAt: true,
       expenseDate: true,
       id: true,
@@ -434,7 +434,7 @@ export async function getExpense(groupId: string, expenseId: string) {
     include: {
       paidBy: true,
       paidFor: true,
-      category: true,
+      // categoryId is a scalar field (encrypted string), not a relation - automatically included
       documents: true,
       recurringExpenseLink: true,
     },
@@ -512,7 +512,7 @@ async function createRecurringExpenses() {
           include: {
             paidBy: true,
             paidFor: true,
-            category: true,
+            // categoryId is a scalar field, automatically included
             documents: true,
           },
         },
@@ -535,7 +535,7 @@ async function createRecurringExpenses() {
       )
 
       const {
-        category,
+        // category relation removed for E2EE (Issue #19) - categoryId is now a scalar field
         paidBy,
         paidFor,
         documents,
@@ -580,7 +580,7 @@ async function createRecurringExpenses() {
             include: {
               paidFor: true,
               documents: true,
-              category: true,
+              // categoryId is a scalar field, automatically included
               paidBy: true,
             },
           })

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -62,7 +62,8 @@ export const expenseFormSchema = z
   .object({
     expenseDate: z.coerce.date(),
     title: z.string({ required_error: 'titleRequired' }).min(2, 'min2'),
-    category: z.coerce.number().default(0),
+    // Category can be number (form input) or encrypted string (Issue #19 - E2EE)
+    category: z.union([z.number(), z.string()]).default(0),
     amount: z
       .union(
         [


### PR DESCRIPTION
## Summary
- Encrypt expense category ID for complete E2EE compliance
- Server no longer sees which category an expense belongs to
- Backward compatible with existing unencrypted categoryId values (plain numbers/strings)

## Changes
- **Schema**: Changed `Expense.categoryId` from `Int` to `String` in Prisma schema
- **Encryption**: Added category encryption/decryption in `encrypt-helpers.ts`
- **Components**: Updated `CategoryIcon`, `category-selector`, `expense-card`, etc. to use `categoryId` prop
- **Static mapping**: Created `CATEGORY_MAP` for client-side category lookup (since FK relation removed)
- **Migration**: `20260112225207_encrypt_category_for_e2ee`
- **Tests**: Added tests for category encryption and backward compatibility (111 total tests passing)

## Test plan
- [x] Unit tests for category encryption/decryption
- [x] Tests for backward compatibility with legacy data
- [x] Type check passes (`npx tsc --noEmit`)
- [x] All 111 tests passing (`pnpm test`)
- [ ] Manual testing: Create expense with category, verify encryption in DB
- [ ] Manual testing: Load existing expenses with legacy categoryId values

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)