### PR TITLE
feat(e2ee): encrypt currency fields for complete E2EE (#22)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,13 +24,13 @@
 - **Zero-knowledge server**: The server never sees unencrypted data
 - **URL fragment key storage**: Encryption key in `#<base64key>` format (never sent to server)
 - **localStorage persistence**: Keys saved per-group for convenience
-- **Everything encrypted**: Group names, participant names, expense titles, notes, amounts, categories
+- **Everything encrypted**: Group names, participant names, expense titles, notes, amounts, categories, currency
 
 ### Key Files
 
 ```
 src/lib/crypto.ts              # Core crypto utilities (PBKDF2, key derivation, password generation)
-src/lib/encrypt-helpers.ts     # Encryption/decryption helpers (amount, category, title, notes)
+src/lib/encrypt-helpers.ts     # Encryption/decryption helpers (amount, category, currency, title, notes)
 src/lib/totals.ts              # Stats calculation utilities
 src/lib/hooks/useBalances.ts   # Client-side balance calculation with decryption
 src/lib/auto-delete.ts         # Auto-delete inactive groups (Issue #10)
@@ -297,10 +297,18 @@ src/__tests__/private-instance.test.ts    # Private instance mode tests
 - [x] decryptExpense: decrypts categoryId (handles legacy plain number/string values)
 - [x] CategoryIcon: Static CATEGORY_MAP for categoryId to grouping/name lookup
 - [x] getCategoryInfo helper function for category metadata
-- [x] Updated all components using CategoryIcon (expense-card, category-selector, etc.)
-- [x] CSV/JSON export updated to use categoryId
-- [x] Migration: 20260112225207_encrypt_category_for_e2ee
-- [x] Tests for category encryption and backward compatibility (111 total tests passing)
+
+#### Currency Encryption (Issue #22) - DONE
+
+- [x] Group.currency: encrypted (e.g., "$", "€", "¥")
+- [x] Group.currencyCode: encrypted (e.g., "USD", "EUR", "JPY")
+- [x] Expense.originalCurrency: encrypted (for multi-currency expenses)
+- [x] encryptGroupFormValues: encrypts currency and currencyCode
+- [x] decryptGroup: decrypts currency/currencyCode (handles legacy plain values)
+- [x] encryptExpenseFormValues: encrypts originalCurrency
+- [x] decryptExpense: decrypts originalCurrency (handles legacy plain values)
+- [x] Backward compatibility for unencrypted legacy data
+- [x] Tests for currency encryption (117 total tests passing)
 
 ## Security Considerations
 

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -7,8 +7,9 @@ export const groupFormSchema = z
   .object({
     name: z.string().min(2, 'min2').max(50, 'max50'),
     information: z.string().optional(),
-    currency: z.string().min(1, 'min1').max(5, 'max5'),
-    currencyCode: z.union([z.string().length(3).nullish(), z.literal('')]), // ISO-4217 currency code
+    // Currency fields can be encrypted strings (Issue #22)
+    currency: z.string().min(1, 'min1'), // No max - encrypted strings are longer
+    currencyCode: z.union([z.string().nullish(), z.literal('')]), // ISO-4217 code or encrypted string
     participants: z
       .array(
         z.object({


### PR DESCRIPTION
## Summary
- Encrypt `Group.currency` (e.g., "$", "€", "¥")
- Encrypt `Group.currencyCode` (e.g., "USD", "EUR", "JPY")
- Encrypt `Expense.originalCurrency` (for multi-currency expenses)
- Backward compatibility for legacy unencrypted data

## Changes
- `encryptGroupFormValues`: Now encrypts currency and currencyCode
- `decryptGroup`: Now decrypts currency/currencyCode (handles legacy plain values)
- `encryptExpenseFormValues`: Now encrypts originalCurrency
- `decryptExpense`: Now decrypts originalCurrency (handles legacy plain values)

## Test plan
- [x] Tests pass (117 tests)
- [x] TypeScript type check passes
- [x] Currency symbols tested: $, €, ¥, £, ₩
- [x] Currency codes tested: USD, EUR, JPY, GBP
- [x] Backward compatibility with unencrypted legacy data

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)