### PR TITLE
fix: lazy-load OpenAI client in receipt extraction

### DIFF
--- a/src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.ts
+++ b/src/app/groups/[groupId]/expenses/create-from-receipt-button-actions.ts
@@ -5,10 +5,15 @@ import { formatCategoryForAIPrompt } from '@/lib/utils'
 import OpenAI from 'openai'
 import { ChatCompletionCreateParamsNonStreaming } from 'openai/resources/index.mjs'
 
-const openai = new OpenAI({ apiKey: env.OPENAI_API_KEY })
-
 export async function extractExpenseInformationFromImage(imageUrl: string) {
   'use server'
+
+  // Lazy-load OpenAI client to avoid errors when API key is not set
+  if (!env.OPENAI_API_KEY) {
+    return { amount: null, categoryId: null, date: null, title: null }
+  }
+
+  const openai = new OpenAI({ apiKey: env.OPENAI_API_KEY })
   const categories = await getCategories()
 
   const body: ChatCompletionCreateParamsNonStreaming = {

--- a/src/app/groups/[groupId]/expenses/create-from-receipt-button.tsx
+++ b/src/app/groups/[groupId]/expenses/create-from-receipt-button.tsx
@@ -112,8 +112,12 @@ function ReceiptDialogContent() {
         console.log('Uploading image…')
         let { url } = await uploadToS3(file)
         console.log('Extracting information from receipt…')
-        const { amount, categoryId, date, title } =
-          await extractExpenseInformationFromImage(url)
+        const extractedInfo = await extractExpenseInformationFromImage(url)
+        // Handle case when OpenAI API key is not configured
+        if (extractedInfo.amount === null) {
+          throw new Error('Receipt extraction is not configured')
+        }
+        const { amount, categoryId, date, title } = extractedInfo
         const { width, height } = await getImageData(file)
         setReceiptInfo({ amount, categoryId, date, title, url, width, height })
       } catch (err) {


### PR DESCRIPTION
## Summary

Fix OPENAI_API_KEY error when API key is not configured.

## Problem

`create-from-receipt-button-actions.ts` was instantiating OpenAI client at module load time, causing errors even when the receipt extraction feature was disabled.

## Solution

Move OpenAI client instantiation inside the function and add early return when API key is not set.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>