### PR TITLE
fix(a11y): add DrawerTitle to category and currency selectors

### DIFF
--- a/src/components/category-selector.tsx
+++ b/src/components/category-selector.tsx
@@ -9,7 +9,12 @@ import {
   CommandInput,
   CommandItem,
 } from '@/components/ui/command'
-import { Drawer, DrawerContent, DrawerTrigger } from '@/components/ui/drawer'
+import {
+  Drawer,
+  DrawerContent,
+  DrawerTitle,
+  DrawerTrigger,
+} from '@/components/ui/drawer'
 import {
   Popover,
   PopoverContent,
@@ -81,6 +86,7 @@ export function CategorySelector({
         />
       </DrawerTrigger>
       <DrawerContent className="p-0">
+        <DrawerTitle className="sr-only">Select category</DrawerTitle>
         <CategoryCommand
           categories={categories}
           onValueChange={(id) => {

--- a/src/components/currency-selector.tsx
+++ b/src/components/currency-selector.tsx
@@ -8,7 +8,12 @@ import {
   CommandInput,
   CommandItem,
 } from '@/components/ui/command'
-import { Drawer, DrawerContent, DrawerTrigger } from '@/components/ui/drawer'
+import {
+  Drawer,
+  DrawerContent,
+  DrawerTitle,
+  DrawerTrigger,
+} from '@/components/ui/drawer'
 import {
   Popover,
   PopoverContent,
@@ -81,6 +86,7 @@ export function CurrencySelector({
         />
       </DrawerTrigger>
       <DrawerContent className="p-0">
+        <DrawerTitle className="sr-only">Select currency</DrawerTitle>
         <CurrencyCommand
           currencies={currencies}
           onValueChange={(id) => {


### PR DESCRIPTION
## Summary
- Add visually hidden `DrawerTitle` components to fix Radix UI accessibility warnings
- `category-selector.tsx`: Added `<DrawerTitle className="sr-only">Select category</DrawerTitle>`
- `currency-selector.tsx`: Added `<DrawerTitle className="sr-only">Select currency</DrawerTitle>`

## Why
Radix UI's Drawer component requires a `DrawerTitle` for WCAG compliance. Without it, console warnings appear and screen reader users cannot properly identify the drawer content.

## Test plan
- [x] TypeScript type check passes
- [x] ESLint passes (0 errors)
- [x] All 163 tests pass
- [x] Production build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)