### PR TITLE
refactor: migrate middleware.ts to proxy.ts for Next.js 16

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,7 @@
 /**
- * Middleware for Private Instance Mode (Issue #4)
+ * Proxy for Private Instance Mode (Issue #4)
  * Handles authentication and access control
+ * Note: Migrated from middleware.ts for Next.js 16 compatibility
  */
 
 import type { NextRequest } from 'next/server'
@@ -30,7 +31,7 @@ const sharedRoutes = ['/groups/'] // Group pages can be accessed via shared link
 // Admin-only routes
 const adminRoutes = ['/admin']
 
-export async function middleware(request: NextRequest) {
+export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl
 
   // Check if private instance mode is enabled


### PR DESCRIPTION
## Summary
- Migrate from deprecated `middleware.ts` to `proxy.ts` for Next.js 16 compatibility
- Rename `middleware()` function to `proxy()`
- No functional changes - same authentication and routing logic

## Why
Next.js 16 deprecated the `middleware` file convention in favor of `proxy`. This change eliminates the deprecation warning during builds.

## Test plan
- [x] TypeScript type check passes
- [x] ESLint passes (0 errors)
- [x] All 163 tests pass
- [x] Production build succeeds
- [x] Build shows `ƒ Proxy (Middleware)` confirming correct recognition

🤖 Generated with [Claude Code](https://claude.com/claude-code)