### PR TITLE
fix(security): prevent user enumeration in 2FA verify endpoint

### DIFF
--- a/src/app/api/2fa/verify/route.ts
+++ b/src/app/api/2fa/verify/route.ts
@@ -113,17 +113,11 @@ export async function POST(request: Request) {
     }
 
     // 3. Check if twoFactorEnabled is true
-    if (!user.twoFactorEnabled) {
+    // Return generic error to prevent user enumeration (Issue #42)
+    if (!user.twoFactorEnabled || !user.twoFactorSecret) {
       return NextResponse.json(
-        { error: '2FA is not enabled for this account' },
-        { status: 400 },
-      )
-    }
-
-    if (!user.twoFactorSecret) {
-      return NextResponse.json(
-        { error: '2FA secret not found' },
-        { status: 500 },
+        { error: 'Invalid email or token' },
+        { status: 401 },
       )
     }
 


### PR DESCRIPTION
## Summary

**SECURITY FIX**: Prevent user enumeration via 2FA verify endpoint.

## Problem

The 2FA verify endpoint returned different error messages that could reveal user existence:
- `'2FA is not enabled for this account'` - confirms user exists
- `'2FA secret not found'` - confirms user exists with specific state

## Solution

Return the same generic error `'Invalid email or token'` for all authentication failures:
- User not found
- 2FA not enabled
- 2FA secret not found

This prevents attackers from enumerating valid email addresses.

## Changes

`src/app/api/2fa/verify/route.ts`:
- Combine 2FA enabled and secret checks
- Return generic error (401) instead of specific errors (400, 500)

## Test plan

- [x] All 238 tests pass
- [x] Type check passes
- [x] Generic error returned for all failure cases

Closes #42

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)