### PR TITLE
fix(performance): replace form.watch() with useWatch in useEffect dependencies (Issue #44)

### DIFF
--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -59,7 +59,7 @@ import { useLocale, useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import { useEffect, useState } from 'react'
-import { useForm } from 'react-hook-form'
+import { useForm, useWatch } from 'react-hook-form'
 import { match } from 'ts-pattern'
 import { DeletePopup } from '../../../../components/delete-popup'
 import { extractCategoryFromTitle } from '../../../../components/expense-form-actions'
@@ -278,6 +278,31 @@ export function ExpenseForm({
             recurrenceRule: RecurrenceRule.NONE,
           },
   })
+
+  // Use useWatch for values needed in useEffect dependencies (Issue #44)
+  // This prevents infinite re-renders caused by form.watch() in dependency arrays
+  const watchedSplitMode = useWatch({
+    control: form.control,
+    name: 'splitMode',
+  })
+  const watchedAmount = useWatch({ control: form.control, name: 'amount' })
+  const watchedOriginalAmount = useWatch({
+    control: form.control,
+    name: 'originalAmount',
+  })
+  const watchedConversionRate = useWatch({
+    control: form.control,
+    name: 'conversionRate',
+  })
+  const watchedExpenseDate = useWatch({
+    control: form.control,
+    name: 'expenseDate',
+  })
+  const watchedOriginalCurrency = useWatch({
+    control: form.control,
+    name: 'originalCurrency',
+  })
+
   const [isCategoryLoading, setCategoryLoading] = useState(false)
   const activeUserId = useActiveUser(group.id)
 
@@ -315,8 +340,8 @@ export function ExpenseForm({
     'Custom',
   )
   const exchangeRate = useCurrencyRate(
-    form.watch('expenseDate'),
-    form.watch('originalCurrency') ?? '',
+    watchedExpenseDate,
+    watchedOriginalCurrency ?? '',
     groupCurrency.code,
   )
 
@@ -328,7 +353,7 @@ export function ExpenseForm({
 
   useEffect(() => {
     setManuallyEditedParticipants(new Set())
-  }, [form.watch('splitMode'), form.watch('amount')])
+  }, [watchedSplitMode, watchedAmount])
 
   useEffect(() => {
     const splitMode = form.getValues().splitMode
@@ -378,11 +403,7 @@ export function ExpenseForm({
       }
       form.setValue('paidFor', newPaidFor, { shouldValidate: true })
     }
-  }, [
-    manuallyEditedParticipants,
-    form.watch('amount'),
-    form.watch('splitMode'),
-  ])
+  }, [manuallyEditedParticipants, watchedAmount, watchedSplitMode])
 
   const [usingCustomConversionRate, setUsingCustomConversionRate] = useState(
     !!form.formState.defaultValues?.conversionRate,
@@ -417,8 +438,8 @@ export function ExpenseForm({
       }
     }
   }, [
-    form.watch('originalAmount'),
-    form.watch('conversionRate'),
+    watchedOriginalAmount,
+    watchedConversionRate,
     form.getFieldState('originalAmount').isTouched,
   ])
 


### PR DESCRIPTION
## Summary
Replace `form.watch()` with `useWatch` hook in useEffect dependency arrays to prevent infinite re-render loops.

## Problem
`form.watch()` returns a new reference on every call. When used in useEffect dependency arrays, this causes infinite re-render loops:
```typescript
// Before (BROKEN - infinite loop)
useEffect(() => {
  setManuallyEditedParticipants(new Set())
}, [form.watch('splitMode'), form.watch('amount')])
```

## Solution
Use `useWatch` hook which provides stable references:
```typescript
// After (FIXED - stable references)
const watchedSplitMode = useWatch({ control: form.control, name: 'splitMode' })
const watchedAmount = useWatch({ control: form.control, name: 'amount' })

useEffect(() => {
  setManuallyEditedParticipants(new Set())
}, [watchedSplitMode, watchedAmount])
```

## Changes
- Add `useWatch` import from react-hook-form
- Create 6 useWatch hooks for: `splitMode`, `amount`, `originalAmount`, `conversionRate`, `expenseDate`, `originalCurrency`
- Update `useCurrencyRate` call to use watched values
- Update 3 useEffect dependency arrays

## Backward Compatibility
- ✅ No API changes
- ✅ Same behavior, different implementation
- ✅ `useWatch` is the recommended approach by react-hook-form

## Note
Remaining `form.watch()` calls in render section are acceptable - they cause re-renders on value change which is expected behavior for displaying calculated values.

## Test Plan
- [x] TypeScript type check passes
- [x] ESLint passes (no new errors)
- [x] All 238 tests pass
- [x] Prettier formatting verified

Closes #44

🤖 Generated with [Claude Code](https://claude.ai/code)