### PR TITLE
feat(security): make TOTP algorithm configurable (SHA1/SHA256) (Issue #49)

### DIFF
--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -91,6 +91,13 @@ const envSchema = z
         .regex(/^[0-9a-fA-F]+$/, 'TWO_FA_ENCRYPTION_KEY must be a hex string')
         .optional(),
     ),
+    // TOTP Algorithm (Issue #49) - SHA1 for compatibility, SHA256 for better security
+    TOTP_ALGORITHM: z
+      .enum(['SHA1', 'SHA256'])
+      .default('SHA1')
+      .describe(
+        'TOTP hash algorithm (SHA1 for compatibility, SHA256 for security)',
+      ),
   })
   .superRefine((env, ctx) => {
     if (

--- a/src/lib/two-factor.ts
+++ b/src/lib/two-factor.ts
@@ -23,6 +23,11 @@ const BACKUP_CODE_COUNT = 10
 // App name for TOTP
 const APP_NAME = 'anon-spliit'
 
+// TOTP Algorithm - configurable via environment variable (Issue #49)
+// Default to SHA1 for compatibility with most authenticator apps
+// SHA256 provides better security but may not work with all apps
+const TOTP_ALGORITHM = env.TOTP_ALGORITHM || 'SHA1'
+
 // ============================================================
 // Key Management
 // ============================================================
@@ -234,7 +239,7 @@ export function generateTOTPSecret(userIdentifier: string = 'user'): {
   const totp = new OTPAuth.TOTP({
     issuer: APP_NAME,
     label: userIdentifier,
-    algorithm: 'SHA1',
+    algorithm: TOTP_ALGORITHM,
     digits: 6,
     period: 30,
   })
@@ -256,7 +261,7 @@ export function verifyTOTP(secret: string, token: string): boolean {
   try {
     const totp = new OTPAuth.TOTP({
       issuer: APP_NAME,
-      algorithm: 'SHA1',
+      algorithm: TOTP_ALGORITHM,
       digits: 6,
       period: 30,
       secret: OTPAuth.Secret.fromBase32(secret),


### PR DESCRIPTION
## Summary
Make TOTP algorithm configurable to allow SHA256 for better security while maintaining SHA1 compatibility.

## Problem
TOTP implementation hardcoded SHA-1 algorithm which has known collision vulnerabilities. While practical TOTP attacks are difficult, SHA-256 provides a better security margin.

## Solution
Add `TOTP_ALGORITHM` environment variable:
- `SHA1` (default) - For compatibility with most authenticator apps
- `SHA256` - For better security (opt-in)

## Changes
- **env.ts**: Add `TOTP_ALGORITHM` with enum validation and default value
- **two-factor.ts**: 
  - Add `TOTP_ALGORITHM` constant from environment
  - Update `generateTOTPSecret` to use configurable algorithm
  - Update `verifyTOTP` to use configurable algorithm

## Compatibility Notes
⚠️ **Important**: SHA256 may not work with all authenticator apps:
- Google Authenticator: Historically SHA1 only (may vary by version)
- Microsoft Authenticator: Supports SHA256
- Authy: Supports SHA256
- 1Password: Supports SHA256

Recommendation: Only set `TOTP_ALGORITHM=SHA256` if users are instructed to use compatible apps.

## Backward Compatibility
- ✅ Default SHA1 preserves existing behavior
- ✅ Existing 2FA setups continue to work
- ✅ New environment variable is optional

## Test Plan
- [x] TypeScript type check passes
- [x] All 238 tests pass
- [x] Prettier formatting verified

Closes #49

🤖 Generated with [Claude Code](https://claude.ai/code)