### PR TITLE
feat(security): upgrade to AES-256 for new groups with backward compatibility (Issue #50)

### DIFF
--- a/src/components/password-prompt.tsx
+++ b/src/components/password-prompt.tsx
@@ -96,8 +96,15 @@ export function PasswordPrompt({
       // Decode salt from base64
       const salt = base64ToKey(passwordSalt)
 
-      // Derive key from password
-      const passwordKey = await deriveKeyFromPassword(password, salt)
+      // Derive key from password (match URL key length for backward compatibility)
+      // - Existing groups with 16-byte URL keys use AES-128
+      // - New groups with 32-byte URL keys use AES-256 (Issue #50)
+      const keyLengthBytes = urlKey ? urlKey.length : 32
+      const passwordKey = await deriveKeyFromPassword(
+        password,
+        salt,
+        keyLengthBytes,
+      )
 
       // Combine with URL key if present, or use password key alone
       const finalKey = urlKey ? combineKeys(urlKey, passwordKey) : passwordKey

--- a/src/lib/crypto.security.test.ts
+++ b/src/lib/crypto.security.test.ts
@@ -26,9 +26,9 @@ import {
 
 describe('Crypto Security Tests', () => {
   describe('Key Generation Security', () => {
-    it('should generate 128-bit (16 byte) keys', () => {
+    it('should generate 256-bit (32 byte) keys for AES-256 (Issue #50)', () => {
       const key = generateMasterKey()
-      expect(key.length).toBe(16)
+      expect(key.length).toBe(32)
     })
 
     it('should generate unique keys each time', () => {


### PR DESCRIPTION
## Summary
Upgrade encryption from AES-128 to AES-256 for new groups while maintaining backward compatibility with existing groups.

## Problem
AES-128, while currently secure, provides less resistance to potential "harvest now, decrypt later" attacks compared to AES-256. For long-term data protection, AES-256 is preferred.

## Solution
Implement automatic key size detection for seamless backward compatibility:

| Key Size | AES Variant | Use Case |
|----------|-------------|----------|
| 16 bytes | AES-128-GCM | Existing groups (legacy) |
| 32 bytes | AES-256-GCM | New groups |

## Changes

### `src/lib/crypto.ts`
- **generateMasterKey**: Now generates 32-byte (256-bit) keys
- **deriveKey**: Auto-detects key size and derives appropriate AES key
- **deriveKeyFromPassword**: Added optional `keyLengthBytes` parameter (default: 32)

### `src/components/password-prompt.tsx`
- Matches password key length to URL key length for compatibility

### `src/lib/crypto.security.test.ts`
- Updated test to expect 32-byte keys

## Backward Compatibility
- ✅ Existing groups with 16-byte URL keys continue to work (AES-128)
- ✅ New groups automatically use 32-byte keys (AES-256)
- ✅ Password-protected groups: key length derived from URL key
- ✅ No migration required for existing data

## Security Improvement
- AES-256 provides 2^128 times more key space than AES-128
- Better resistance to future cryptanalytic advances
- Recommended for long-term data protection

## Test Plan
- [x] TypeScript type check passes
- [x] All 238 tests pass
- [x] Prettier formatting verified

Closes #50

🤖 Generated with [Claude Code](https://claude.ai/code)