### PR TITLE
fix(perf): add size limits to localStorage group lists (Issue #55)

### DIFF
--- a/src/app/groups/recent-groups-helpers.ts
+++ b/src/app/groups/recent-groups-helpers.ts
@@ -18,14 +18,26 @@ const STORAGE_KEY = 'recentGroups'
 const STARRED_GROUPS_STORAGE_KEY = 'starredGroups'
 const ARCHIVED_GROUPS_STORAGE_KEY = 'archivedGroups'
 
-export function getRecentGroups() {
+// Default limits to prevent performance issues with large datasets (Issue #55)
+const DEFAULT_RECENT_GROUPS_LIMIT = 100
+const DEFAULT_STARRED_GROUPS_LIMIT = 50
+const DEFAULT_ARCHIVED_GROUPS_LIMIT = 50
+
+/**
+ * Get recent groups from localStorage with optional limit
+ * @param limit Maximum number of groups to return (default: 100)
+ */
+export function getRecentGroups(limit: number = DEFAULT_RECENT_GROUPS_LIMIT) {
   const groupsInStorageRaw = safeGetJSON(STORAGE_KEY, [])
   const parseResult = recentGroupsSchema.safeParse(groupsInStorageRaw)
-  return parseResult.success ? parseResult.data : []
+  const groups = parseResult.success ? parseResult.data : []
+  // Return limited results (groups are already ordered by most recent first)
+  return groups.slice(0, limit)
 }
 
 export function saveRecentGroup(group: RecentGroup) {
-  const recentGroups = getRecentGroups()
+  // Use Infinity to get all groups when modifying storage
+  const recentGroups = getRecentGroups(Infinity)
   safeSetJSON(STORAGE_KEY, [
     group,
     ...recentGroups.filter((rg) => rg.id !== group.id),
@@ -33,45 +45,62 @@ export function saveRecentGroup(group: RecentGroup) {
 }
 
 export function deleteRecentGroup(group: RecentGroup) {
-  const recentGroups = getRecentGroups()
+  // Use Infinity to get all groups when modifying storage
+  const recentGroups = getRecentGroups(Infinity)
   safeSetJSON(
     STORAGE_KEY,
     recentGroups.filter((rg) => rg.id !== group.id),
   )
 }
 
-export function getStarredGroups() {
+/**
+ * Get starred groups from localStorage with optional limit
+ * @param limit Maximum number of groups to return (default: 50)
+ */
+export function getStarredGroups(limit: number = DEFAULT_STARRED_GROUPS_LIMIT) {
   const starredGroupsRaw = safeGetJSON(STARRED_GROUPS_STORAGE_KEY, [])
   const parseResult = starredGroupsSchema.safeParse(starredGroupsRaw)
-  return parseResult.success ? parseResult.data : []
+  const groups = parseResult.success ? parseResult.data : []
+  return groups.slice(0, limit)
 }
 
 export function starGroup(groupId: string) {
-  const starredGroups = getStarredGroups()
+  // Use Infinity to get all groups when modifying storage
+  const starredGroups = getStarredGroups(Infinity)
   safeSetJSON(STARRED_GROUPS_STORAGE_KEY, [...starredGroups, groupId])
 }
 
 export function unstarGroup(groupId: string) {
-  const starredGroups = getStarredGroups()
+  // Use Infinity to get all groups when modifying storage
+  const starredGroups = getStarredGroups(Infinity)
   safeSetJSON(
     STARRED_GROUPS_STORAGE_KEY,
     starredGroups.filter((g) => g !== groupId),
   )
 }
 
-export function getArchivedGroups() {
+/**
+ * Get archived groups from localStorage with optional limit
+ * @param limit Maximum number of groups to return (default: 50)
+ */
+export function getArchivedGroups(
+  limit: number = DEFAULT_ARCHIVED_GROUPS_LIMIT,
+) {
   const archivedGroupsRaw = safeGetJSON(ARCHIVED_GROUPS_STORAGE_KEY, [])
   const parseResult = archivedGroupsSchema.safeParse(archivedGroupsRaw)
-  return parseResult.success ? parseResult.data : []
+  const groups = parseResult.success ? parseResult.data : []
+  return groups.slice(0, limit)
 }
 
 export function archiveGroup(groupId: string) {
-  const archivedGroups = getArchivedGroups()
+  // Use Infinity to get all groups when modifying storage
+  const archivedGroups = getArchivedGroups(Infinity)
   safeSetJSON(ARCHIVED_GROUPS_STORAGE_KEY, [...archivedGroups, groupId])
 }
 
 export function unarchiveGroup(groupId: string) {
-  const archivedGroups = getArchivedGroups()
+  // Use Infinity to get all groups when modifying storage
+  const archivedGroups = getArchivedGroups(Infinity)
   safeSetJSON(
     ARCHIVED_GROUPS_STORAGE_KEY,
     archivedGroups.filter((g) => g !== groupId),


### PR DESCRIPTION
## Summary
- Add `limit` parameter to group list functions
- Prevents performance issues for users with many groups

## Problem
`getRecentGroups()`, `getStarredGroups()`, and `getArchivedGroups()` returned all groups from localStorage without size limits. For users with many groups, this could cause:
- Performance issues
- Memory pressure
- Slow UI rendering

## Solution
Added optional `limit` parameter to each function:
- `getRecentGroups(limit = 100)`
- `getStarredGroups(limit = 50)`
- `getArchivedGroups(limit = 50)`

Internal operations (save, delete, star, unstar, archive, unarchive) use `Infinity` to ensure no data is lost when modifying storage.

## Backward Compatibility
- Default limits are generous enough for typical usage
- Existing code continues to work without changes
- Data is never lost - limits only apply to display

Closes #55