### PR TITLE
fix(security): add authentication to S3 upload in private mode (Issue #57)

### DIFF
--- a/src/app/api/s3-upload/route.ts
+++ b/src/app/api/s3-upload/route.ts
@@ -1,8 +1,11 @@
 import { randomId } from '@/lib/api'
+import { auth } from '@/lib/auth'
 import { env } from '@/lib/env'
-import { POST as route } from 'next-s3-upload/route'
+import { POST as s3Route } from 'next-s3-upload/route'
+import { NextRequest, NextResponse } from 'next/server'
 
-export const POST = route.configure({
+// Configure the S3 upload handler
+const s3Handler = s3Route.configure({
   key(req, filename) {
     const [, extension] = filename.match(/(\.[^\.]*)$/) ?? [null, '']
     const timestamp = new Date().toISOString()
@@ -13,3 +16,26 @@ export const POST = route.configure({
   // forcing path style is only necessary for providers other than AWS
   forcePathStyle: !!env.S3_UPLOAD_ENDPOINT,
 })
+
+/**
+ * S3 Upload handler with authentication for Private Instance Mode (Issue #57)
+ *
+ * In private instance mode, users must be authenticated to upload files.
+ * In public mode, uploads are allowed without authentication (groups are
+ * protected by encryption keys in URLs).
+ */
+export async function POST(request: NextRequest) {
+  // Check if private instance mode is enabled
+  if (env.PRIVATE_INSTANCE) {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: 'Authentication required for file uploads' },
+        { status: 401 },
+      )
+    }
+  }
+
+  // Delegate to the S3 upload handler
+  return s3Handler(request)
+}


### PR DESCRIPTION
## Summary
- Add authentication check to S3 file upload endpoint
- Prevents unauthorized uploads in private instance mode

## Problem
The S3 upload endpoint at `/api/s3-upload` allowed file uploads without authentication, even when `PRIVATE_INSTANCE` mode was enabled.

## Solution
Added authentication check before delegating to the S3 upload handler:
```typescript
if (env.PRIVATE_INSTANCE) {
  const session = await auth()
  if (!session?.user) {
    return NextResponse.json(
      { error: 'Authentication required for file uploads' },
      { status: 401 },
    )
  }
}
```

## Behavior
- **Private Instance Mode**: Requires authenticated session
- **Public Mode**: No change (uploads allowed, groups protected by encryption keys)

## Note
This feature is disabled by default (`NEXT_PUBLIC_ENABLE_EXPENSE_DOCUMENTS=false`).

Closes #57