### PR TITLE
fix(security): add max constraints to arrays to prevent DoS (Issue #77)

### DIFF
--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -17,7 +17,8 @@ export const groupFormSchema = z
           name: z.string().min(2, 'min2').max(50, 'max50'),
         }),
       )
-      .min(1),
+      .min(1)
+      .max(500),
     // Password protection (Issue #2)
     password: z.string().optional(), // Used only during creation, not stored
     passwordHint: z.string().max(100, 'max100').optional(),
@@ -140,6 +141,7 @@ export const expenseFormSchema = z
         }),
       )
       .min(1, 'paidForMin1')
+      .max(500)
       .superRefine((paidFor, ctx) => {
         for (const { shares } of paidFor) {
           // Skip validation for encrypted strings (long and not parseable as numbers)
@@ -174,10 +176,11 @@ export const expenseFormSchema = z
         z.object({
           id: z.string(),
           url: z.string().url(),
-          width: z.number().int().min(1),
-          height: z.number().int().min(1),
+          width: z.number().int().min(1).max(10000),
+          height: z.number().int().min(1).max(10000),
         }),
       )
+      .max(100)
       .default([]),
     notes: z.string().optional(),
     recurrenceRule: z

--- a/src/trpc/routers/groups/list.procedure.ts
+++ b/src/trpc/routers/groups/list.procedure.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 export const listGroupsProcedure = publicProcedure
   .input(
     z.object({
-      groupIds: z.array(z.string().min(1)),
+      groupIds: z.array(z.string().min(1).max(30)).max(100),
     }),
   )
   .query(async ({ input: { groupIds } }) => {


### PR DESCRIPTION
## Summary

Adds `.max()` constraints to all unbounded arrays in Zod schemas to prevent Denial of Service (DoS) attacks.

## Changes

| File | Array | Constraint Added |
|------|-------|------------------|
| `list.procedure.ts` | groupIds | `.max(100)` + `.max(30)` per ID |
| `schemas.ts` | participants | `.max(500)` |
| `schemas.ts` | paidFor | `.max(500)` |
| `schemas.ts` | documents | `.max(100)` |
| `schemas.ts` | width/height | `.max(10000)` |

## Security Impact

Before: Attacker could send `{ groupIds: [...10000 items] }` causing massive database queries
After: Arrays are bounded, preventing resource exhaustion attacks

## Test Results

- ✅ 238 tests passing
- ✅ Type check passing

Closes #77

🤖 Generated with [Claude Code](https://claude.ai/code)