### PR TITLE
fix(security): add rate limiting to destructive group operations (Issue #78)

### DIFF
--- a/src/trpc/routers/groups/delete.procedure.ts
+++ b/src/trpc/routers/groups/delete.procedure.ts
@@ -1,11 +1,18 @@
 import { deleteGroup } from '@/lib/api'
-import { publicProcedure } from '@/trpc/init'
+import { createRateLimitedProcedure } from '@/trpc/init'
 import { z } from 'zod'
 
-export const deleteGroupProcedure = publicProcedure
+// Rate limit: 10 delete attempts per hour per groupId (Issue #78)
+const HOUR_MS = 60 * 60 * 1000
+
+export const deleteGroupProcedure = createRateLimitedProcedure(
+  'delete',
+  10,
+  HOUR_MS,
+)
   .input(
     z.object({
-      groupId: z.string().min(1),
+      groupId: z.string().min(1).max(30),
     }),
   )
   .mutation(async ({ input: { groupId } }) => {

--- a/src/trpc/routers/groups/expenses/create.procedure.ts
+++ b/src/trpc/routers/groups/expenses/create.procedure.ts
@@ -1,12 +1,19 @@
 import { createExpense } from '@/lib/api'
 import { expenseFormSchema } from '@/lib/schemas'
-import { publicProcedure } from '@/trpc/init'
+import { createRateLimitedProcedure } from '@/trpc/init'
 import { z } from 'zod'
 
-export const createGroupExpenseProcedure = publicProcedure
+// Rate limit: 100 expense creations per hour per groupId (Issue #78)
+const HOUR_MS = 60 * 60 * 1000
+
+export const createGroupExpenseProcedure = createRateLimitedProcedure(
+  'create-expense',
+  100,
+  HOUR_MS,
+)
   .input(
     z.object({
-      groupId: z.string().min(1),
+      groupId: z.string().min(1).max(30),
       expenseFormValues: expenseFormSchema,
       participantId: z.string().optional(),
     }),

--- a/src/trpc/routers/groups/permanentDelete.procedure.ts
+++ b/src/trpc/routers/groups/permanentDelete.procedure.ts
@@ -1,11 +1,18 @@
 import { permanentlyDeleteGroup } from '@/lib/api'
-import { publicProcedure } from '@/trpc/init'
+import { createRateLimitedProcedure } from '@/trpc/init'
 import { z } from 'zod'
 
-export const permanentDeleteGroupProcedure = publicProcedure
+// Rate limit: 5 permanent delete attempts per hour per groupId (Issue #78)
+const HOUR_MS = 60 * 60 * 1000
+
+export const permanentDeleteGroupProcedure = createRateLimitedProcedure(
+  'permanent-delete',
+  5,
+  HOUR_MS,
+)
   .input(
     z.object({
-      groupId: z.string().min(1),
+      groupId: z.string().min(1).max(30),
     }),
   )
   .mutation(async ({ input: { groupId } }) => {

--- a/src/trpc/routers/groups/restore.procedure.ts
+++ b/src/trpc/routers/groups/restore.procedure.ts
@@ -1,11 +1,18 @@
 import { restoreGroup } from '@/lib/api'
-import { publicProcedure } from '@/trpc/init'
+import { createRateLimitedProcedure } from '@/trpc/init'
 import { z } from 'zod'
 
-export const restoreGroupProcedure = publicProcedure
+// Rate limit: 10 restore attempts per hour per groupId (Issue #78)
+const HOUR_MS = 60 * 60 * 1000
+
+export const restoreGroupProcedure = createRateLimitedProcedure(
+  'restore',
+  10,
+  HOUR_MS,
+)
   .input(
     z.object({
-      groupId: z.string().min(1),
+      groupId: z.string().min(1).max(30),
     }),
   )
   .mutation(async ({ input: { groupId } }) => {


### PR DESCRIPTION
## Summary

Adds rate limiting to destructive group operations to prevent brute-force attacks and abuse.

## Changes

### New Rate Limiting Infrastructure

**`src/lib/rate-limit.ts`**:
- `checkOperationRateLimit(key, maxAttempts, windowMs)` - Check if operation is rate limited
- `recordOperationAttempt(key, maxAttempts, windowMs)` - Record an attempt

**`src/trpc/init.ts`**:
- `createRateLimitMiddleware()` - Factory for rate limiting middleware
- `createRateLimitedProcedure()` - Factory for rate-limited procedures

### Rate Limits Applied

| Operation | Limit | Window |
|-----------|-------|--------|
| `groups.delete` | 10 attempts | 1 hour |
| `groups.permanentDelete` | 5 attempts | 1 hour |
| `groups.restore` | 10 attempts | 1 hour |
| `groups.expenses.create` | 100 attempts | 1 hour |

Rate limits are per-groupId, preventing attackers from:
- Brute-forcing delete operations on unknown groupIds
- Spamming expense creation
- Abusing restore/delete cycles

### Additional Security

- Added `.max(30)` to groupId validation in all procedures (Issue #77 follow-up)

## Security Impact

**Before**: Unlimited delete/create attempts allowed
**After**: Rate-limited with clear error messages

Error response example:
```json
{
  "code": "TOO_MANY_REQUESTS",
  "message": "Too many delete attempts. Please try again in 3420 seconds."
}
```

## Test Results

- ✅ 238 tests passing
- ✅ Type check passing

Closes #78

🤖 Generated with [Claude Code](https://claude.ai/code)