### PR TITLE
fix(crypto): support 256-bit keys in URL hash and localStorage (Issue #89)

### DIFF
--- a/src/components/encryption-provider.tsx
+++ b/src/components/encryption-provider.tsx
@@ -58,7 +58,8 @@ function loadKeyFromStorage(groupId: string): Uint8Array | null {
     const keyBase64 = localStorage.getItem(`${STORAGE_KEY_PREFIX}${groupId}`)
     if (keyBase64) {
       const key = base64ToKey(keyBase64)
-      if (key.length === 16) {
+      // Support both legacy 128-bit (16 bytes) and new 256-bit (32 bytes) keys (Issue #50)
+      if (key.length === 16 || key.length === 32) {
         return key
       }
     }
@@ -139,7 +140,8 @@ export function EncryptionProvider({
 
     try {
       const key = base64ToKey(hash)
-      if (key.length === 16) {
+      // Support both legacy 128-bit (16 bytes) and new 256-bit (32 bytes) keys (Issue #50)
+      if (key.length === 16 || key.length === 32) {
         return key
       }
     } catch {

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -145,7 +145,8 @@ export function useEncryptionKey() {
     if (hash) {
       try {
         const key = base64ToKey(hash)
-        if (key.length === 16) {
+        // Support both legacy 128-bit (16 bytes) and new 256-bit (32 bytes) keys (Issue #50)
+        if (key.length === 16 || key.length === 32) {
           setEncryptionKey(key)
           setError(null)
         } else {
@@ -163,7 +164,8 @@ export function useEncryptionKey() {
       if (newHash) {
         try {
           const key = base64ToKey(newHash)
-          if (key.length === 16) {
+          // Support both legacy 128-bit (16 bytes) and new 256-bit (32 bytes) keys (Issue #50)
+          if (key.length === 16 || key.length === 32) {
             setEncryptionKey(key)
             setError(null)
           }


### PR DESCRIPTION
## Summary

Fix critical bug where 256-bit encryption keys (introduced in Issue #50) were being rejected by key validation, causing groups to be inaccessible after creation.

## Problem

Issue #50 upgraded encryption from AES-128 to AES-256, changing key size from 16 bytes to 32 bytes. However, the key validation was not updated and only accepted 16-byte keys.

**Result**: New groups created with 256-bit keys could not be accessed because:
1. `readUrlKeyFromHash()` returned `null` for 32-byte keys
2. `loadKeyFromStorage()` returned `null` for 32-byte keys
3. `useEncryptionKey()` hook also rejected 32-byte keys
4. System treated valid keys as missing/invalid

## Changes

### `src/components/encryption-provider.tsx`
- Updated `loadKeyFromStorage()` to accept both 16 and 32 byte keys
- Updated `readUrlKeyFromHash()` to accept both 16 and 32 byte keys

### `src/lib/hooks.ts`
- Updated `useEncryptionKey()` hook to accept both 16 and 32 byte keys in initial load
- Updated hash change handler to accept both key sizes

## Backward Compatibility

✅ Fully backward compatible:
- Legacy 128-bit (16 byte) keys continue to work
- New 256-bit (32 byte) keys now work correctly

Closes #89