### PR TITLE
fix(security): add max password length validation (Issue #92)

### DIFF
--- a/src/app/api/auth/change-password/route.ts
+++ b/src/app/api/auth/change-password/route.ts
@@ -57,9 +57,9 @@ export async function POST(request: Request) {
       )
     }
 
-    if (newPassword.length < 8) {
+    if (newPassword.length < 8 || newPassword.length > 128) {
       return NextResponse.json(
-        { error: 'New password must be at least 8 characters' },
+        { error: 'Password must be between 8 and 128 characters' },
         { status: 400 },
       )
     }


### PR DESCRIPTION
## Summary

Add maximum password length validation (128 characters) to prevent DoS via resource exhaustion when hashing extremely long passwords.

## Problem

Server-side validation only checked minimum length (8 chars) but not maximum. Client-side already enforces 128 char limit.

## Changes

- `src/app/api/auth/change-password/route.ts`: Add `|| newPassword.length > 128` check

## Before
```typescript
if (newPassword.length < 8) {
```

## After
```typescript
if (newPassword.length < 8 || newPassword.length > 128) {
```

Closes #92