### PR TITLE
refactor: centralize storage key constants (Issue #94)

### DIFF
--- a/src/app/groups/create/create-group.tsx
+++ b/src/app/groups/create/create-group.tsx
@@ -11,12 +11,9 @@ import {
 } from '@/lib/crypto'
 import { encryptGroupFormValues } from '@/lib/encrypt-helpers'
 import { GroupFormValues } from '@/lib/schemas'
+import { ENCRYPTION_KEY_PREFIX, SESSION_PWD_KEY_PREFIX } from '@/lib/storage'
 import { trpc } from '@/trpc/client'
 import { useRouter } from 'next/navigation'
-
-// Storage key prefixes (must match encryption-provider.tsx)
-const STORAGE_KEY_PREFIX = 'spliit-e2ee-key-'
-const SESSION_PWD_KEY_PREFIX = 'spliit-pwd-key-'
 
 export const CreateGroup = () => {
   const { mutateAsync } = trpc.groups.create.useMutation()
@@ -93,7 +90,7 @@ export const CreateGroup = () => {
         try {
           // Save the combined key to localStorage (persistent)
           localStorage.setItem(
-            `${STORAGE_KEY_PREFIX}${groupId}`,
+            `${ENCRYPTION_KEY_PREFIX}${groupId}`,
             combinedKeyBase64,
           )
 

--- a/src/app/groups/recent-group-list-card.tsx
+++ b/src/app/groups/recent-group-list-card.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useToast } from '@/components/ui/use-toast'
+import { ENCRYPTION_KEY_PREFIX } from '@/lib/storage'
 import { AppRouterOutput } from '@/trpc/routers/_app'
 import { StarFilledIcon } from '@radix-ui/react-icons'
 import { Calendar, MoreHorizontal, Star, Users } from 'lucide-react'
@@ -25,9 +26,6 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { useMemo } from 'react'
 
-// localStorage key prefix for encryption keys
-const STORAGE_KEY_PREFIX = 'spliit-e2ee-key-'
-
 /**
  * Get the group URL with encryption key if available
  */
@@ -35,7 +33,7 @@ function getGroupUrl(groupId: string): string {
   if (typeof window === 'undefined') return `/groups/${groupId}/expenses`
 
   try {
-    const keyBase64 = localStorage.getItem(`${STORAGE_KEY_PREFIX}${groupId}`)
+    const keyBase64 = localStorage.getItem(`${ENCRYPTION_KEY_PREFIX}${groupId}`)
     if (keyBase64) {
       return `/groups/${groupId}/expenses#${keyBase64}`
     }

--- a/src/components/encryption-provider.tsx
+++ b/src/components/encryption-provider.tsx
@@ -12,6 +12,7 @@ import {
   generateMasterKey,
   keyToBase64,
 } from '@/lib/crypto'
+import { ENCRYPTION_KEY_PREFIX, SESSION_PWD_KEY_PREFIX } from '@/lib/storage'
 import {
   createContext,
   ReactNode,
@@ -21,11 +22,6 @@ import {
   useMemo,
   useState,
 } from 'react'
-
-// localStorage key prefix for encryption keys
-const STORAGE_KEY_PREFIX = 'spliit-e2ee-key-'
-// sessionStorage key prefix for password-derived keys
-const SESSION_PWD_KEY_PREFIX = 'spliit-pwd-key-'
 
 /**
  * Extract groupId from current URL path
@@ -43,7 +39,7 @@ function saveKeyToStorage(groupId: string, key: Uint8Array): void {
   if (typeof window === 'undefined') return
   try {
     const keyBase64 = keyToBase64(key)
-    localStorage.setItem(`${STORAGE_KEY_PREFIX}${groupId}`, keyBase64)
+    localStorage.setItem(`${ENCRYPTION_KEY_PREFIX}${groupId}`, keyBase64)
   } catch (error) {
     console.warn('Failed to save encryption key to localStorage:', error)
   }
@@ -55,7 +51,7 @@ function saveKeyToStorage(groupId: string, key: Uint8Array): void {
 function loadKeyFromStorage(groupId: string): Uint8Array | null {
   if (typeof window === 'undefined') return null
   try {
-    const keyBase64 = localStorage.getItem(`${STORAGE_KEY_PREFIX}${groupId}`)
+    const keyBase64 = localStorage.getItem(`${ENCRYPTION_KEY_PREFIX}${groupId}`)
     if (keyBase64) {
       const key = base64ToKey(keyBase64)
       // Support both legacy 128-bit (16 bytes) and new 256-bit (32 bytes) keys (Issue #50)

--- a/src/components/password-prompt.tsx
+++ b/src/components/password-prompt.tsx
@@ -18,6 +18,7 @@ import {
   deriveKeyFromPassword,
   keyToBase64,
 } from '@/lib/crypto'
+import { ENCRYPTION_KEY_PREFIX, SESSION_PWD_KEY_PREFIX } from '@/lib/storage'
 import { AlertCircle, Eye, EyeOff, KeyRound, Loader2 } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { useEffect, useState } from 'react'
@@ -179,14 +180,14 @@ export function PasswordPrompt({
       // Save to localStorage for this group
       const keyBase64 = keyToBase64(finalKey)
       try {
-        localStorage.setItem(`spliit-e2ee-key-${groupId}`, keyBase64)
+        localStorage.setItem(`${ENCRYPTION_KEY_PREFIX}${groupId}`, keyBase64)
       } catch {
         // localStorage not available - continue without saving
       }
 
       // Also save password-derived key separately for session
       sessionStorage.setItem(
-        `spliit-pwd-key-${groupId}`,
+        `${SESSION_PWD_KEY_PREFIX}${groupId}`,
         keyToBase64(passwordKey),
       )
 

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -10,6 +10,10 @@
  * to handle these edge cases gracefully.
  */
 
+// Storage key prefixes for encryption keys (Issue #94)
+export const ENCRYPTION_KEY_PREFIX = 'spliit-e2ee-key-'
+export const SESSION_PWD_KEY_PREFIX = 'spliit-pwd-key-'
+
 /**
  * Safely get an item from localStorage
  * @returns The stored value, or null if not found or on error


### PR DESCRIPTION
## Summary
- Centralizes `ENCRYPTION_KEY_PREFIX` and `SESSION_PWD_KEY_PREFIX` constants in `src/lib/storage.ts`
- Removes duplicate constant definitions from 4 files
- Uses consistent imports across the codebase

## Files Changed
- `src/lib/storage.ts`: Added `ENCRYPTION_KEY_PREFIX` and `SESSION_PWD_KEY_PREFIX` exports
- `src/components/encryption-provider.tsx`: Updated to import from storage.ts
- `src/app/groups/create/create-group.tsx`: Updated to import from storage.ts
- `src/app/groups/recent-group-list-card.tsx`: Updated to import from storage.ts
- `src/components/password-prompt.tsx`: Updated to import from storage.ts

## Test Plan
- [x] TypeScript type check passes
- [x] All 238 tests pass
- [x] No functional changes - only refactoring

Closes #94