### PR TITLE
refactor: extract duplicate toNumber() to utils.ts (Issue #93)

### DIFF
--- a/src/app/groups/[groupId]/expenses/export/csv/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/csv/route.ts
@@ -1,6 +1,10 @@
 import { getCategoryInfo } from '@/app/groups/[groupId]/expenses/category-icon'
 import { getCurrency } from '@/lib/currency'
-import { formatAmountAsDecimal, getCurrencyFromGroup } from '@/lib/utils'
+import {
+  formatAmountAsDecimal,
+  getCurrencyFromGroup,
+  toNumber,
+} from '@/lib/utils'
 import { Parser } from '@json2csv/plainjs'
 import { PrismaClient } from '@prisma/client'
 import contentDisposition from 'content-disposition'
@@ -102,13 +106,6 @@ export async function GET(
   ]
 
   const currency = getCurrencyFromGroup(group)
-
-  // Helper to convert string amounts to numbers (for encrypted groups, this will return 0)
-  const toNumber = (val: string | number): number => {
-    if (typeof val === 'number') return val
-    const num = parseFloat(val)
-    return isNaN(num) ? 0 : num
-  }
 
   const expenses = group.expenses.map((expense) => {
     const expenseAmount = toNumber(expense.amount)

--- a/src/lib/balances.ts
+++ b/src/lib/balances.ts
@@ -1,4 +1,5 @@
 import { getGroupExpenses } from '@/lib/api'
+import { toNumber } from '@/lib/utils'
 import { Participant } from '@prisma/client'
 import { match } from 'ts-pattern'
 
@@ -11,14 +12,6 @@ export type Reimbursement = {
   from: Participant['id']
   to: Participant['id']
   amount: number
-}
-
-/**
- * Helper to convert amount to number (handles string or number)
- */
-function toNumber(val: string | number): number {
-  if (typeof val === 'number') return val
-  return parseFloat(val) || 0
 }
 
 /**

--- a/src/lib/totals.ts
+++ b/src/lib/totals.ts
@@ -1,12 +1,5 @@
 import { getGroupExpenses } from '@/lib/api'
-
-/**
- * Helper to convert amount to number (handles string or number)
- */
-function toNumber(val: string | number): number {
-  if (typeof val === 'number') return val
-  return parseFloat(val) || 0
-}
+import { toNumber } from '@/lib/utils'
 
 /**
  * Generic expense type for totals calculation

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -67,8 +67,7 @@ export function formatCurrency(
   locale: string,
   fractions?: boolean,
 ) {
-  const numAmount =
-    typeof amount === 'string' ? parseFloat(amount) || 0 : amount
+  const numAmount = toNumber(amount)
   const format = new Intl.NumberFormat(locale, {
     minimumFractionDigits: currency.decimal_digits,
     maximumFractionDigits: currency.decimal_digits,
@@ -116,8 +115,7 @@ export function amountAsDecimal(
   currency: Currency,
   round = false,
 ) {
-  const numAmount =
-    typeof amount === 'string' ? parseFloat(amount) || 0 : amount
+  const numAmount = toNumber(amount)
   const decimal = numAmount / 10 ** currency.decimal_digits
   if (round) {
     return Number(decimal.toFixed(currency.decimal_digits))
@@ -137,8 +135,7 @@ export function amountAsMinorUnits(
   amount: number | string,
   currency: Currency,
 ) {
-  const numAmount =
-    typeof amount === 'string' ? parseFloat(amount) || 0 : amount
+  const numAmount = toNumber(amount)
   return Math.round(numAmount * 10 ** currency.decimal_digits)
 }
 
@@ -152,8 +149,7 @@ export function formatAmountAsDecimal(
   amount: number | string,
   currency: Currency,
 ) {
-  const numAmount =
-    typeof amount === 'string' ? parseFloat(amount) || 0 : amount
+  const numAmount = toNumber(amount)
   return amountAsDecimal(numAmount, currency).toFixed(currency.decimal_digits)
 }
 
@@ -178,4 +174,15 @@ export function normalizeString(input: string): string {
     .toLowerCase()
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '')
+}
+
+/**
+ * Converts a value to number, handling both string and number inputs.
+ * Returns 0 for invalid strings.
+ *
+ * @param value - The value to convert (string or number)
+ * @returns The numeric value, or 0 if parsing fails
+ */
+export function toNumber(value: number | string): number {
+  return typeof value === 'string' ? parseFloat(value) || 0 : value
 }


### PR DESCRIPTION
## Summary

Extract the `toNumber()` helper function from 3 duplicate locations into a single shared utility.

## Changes

### Added to `src/lib/utils.ts`
```typescript
export function toNumber(value: number | string): number {
  return typeof value === 'string' ? parseFloat(value) || 0 : value
}
```

### Removed duplicates from
- `src/lib/balances.ts` - now imports from utils.ts
- `src/lib/totals.ts` - now imports from utils.ts
- `src/app/groups/[groupId]/expenses/export/csv/route.ts` - now imports from utils.ts

### Also updated in `src/lib/utils.ts`
Replaced 4 inline occurrences of the same pattern:
- `formatCurrency()`
- `amountAsDecimal()`
- `amountAsMinorUnits()`
- `formatAmountAsDecimal()`

## Impact

- DRY compliance
- Single source of truth for string→number conversion
- Easier maintenance

## Test Plan
- [x] TypeScript type check passes
- [x] All 238 tests pass

Closes #93