### PR TITLE
refactor: use storage.ts utilities consistently (Issue #95)

### DIFF
--- a/src/app/groups/recent-group-list-card.tsx
+++ b/src/app/groups/recent-group-list-card.tsx
@@ -17,7 +17,7 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useToast } from '@/components/ui/use-toast'
-import { ENCRYPTION_KEY_PREFIX } from '@/lib/storage'
+import { ENCRYPTION_KEY_PREFIX, safeGetItem } from '@/lib/storage'
 import { AppRouterOutput } from '@/trpc/routers/_app'
 import { StarFilledIcon } from '@radix-ui/react-icons'
 import { Calendar, MoreHorizontal, Star, Users } from 'lucide-react'
@@ -32,13 +32,9 @@ import { useMemo } from 'react'
 function getGroupUrl(groupId: string): string {
   if (typeof window === 'undefined') return `/groups/${groupId}/expenses`
 
-  try {
-    const keyBase64 = localStorage.getItem(`${ENCRYPTION_KEY_PREFIX}${groupId}`)
-    if (keyBase64) {
-      return `/groups/${groupId}/expenses#${keyBase64}`
-    }
-  } catch (error) {
-    console.warn('Failed to get encryption key from localStorage:', error)
+  const keyBase64 = safeGetItem(`${ENCRYPTION_KEY_PREFIX}${groupId}`)
+  if (keyBase64) {
+    return `/groups/${groupId}/expenses#${keyBase64}`
   }
   return `/groups/${groupId}/expenses`
 }

--- a/src/components/encryption-provider.tsx
+++ b/src/components/encryption-provider.tsx
@@ -12,7 +12,12 @@ import {
   generateMasterKey,
   keyToBase64,
 } from '@/lib/crypto'
-import { ENCRYPTION_KEY_PREFIX, SESSION_PWD_KEY_PREFIX } from '@/lib/storage'
+import {
+  ENCRYPTION_KEY_PREFIX,
+  safeGetItem,
+  safeSetItem,
+  SESSION_PWD_KEY_PREFIX,
+} from '@/lib/storage'
 import {
   createContext,
   ReactNode,
@@ -37,12 +42,8 @@ function getGroupIdFromPath(): string | null {
  */
 function saveKeyToStorage(groupId: string, key: Uint8Array): void {
   if (typeof window === 'undefined') return
-  try {
-    const keyBase64 = keyToBase64(key)
-    localStorage.setItem(`${ENCRYPTION_KEY_PREFIX}${groupId}`, keyBase64)
-  } catch (error) {
-    console.warn('Failed to save encryption key to localStorage:', error)
-  }
+  const keyBase64 = keyToBase64(key)
+  safeSetItem(`${ENCRYPTION_KEY_PREFIX}${groupId}`, keyBase64)
 }
 
 /**
@@ -50,17 +51,17 @@ function saveKeyToStorage(groupId: string, key: Uint8Array): void {
  */
 function loadKeyFromStorage(groupId: string): Uint8Array | null {
   if (typeof window === 'undefined') return null
-  try {
-    const keyBase64 = localStorage.getItem(`${ENCRYPTION_KEY_PREFIX}${groupId}`)
-    if (keyBase64) {
+  const keyBase64 = safeGetItem(`${ENCRYPTION_KEY_PREFIX}${groupId}`)
+  if (keyBase64) {
+    try {
       const key = base64ToKey(keyBase64)
       // Support both legacy 128-bit (16 bytes) and new 256-bit (32 bytes) keys (Issue #50)
       if (key.length === 16 || key.length === 32) {
         return key
       }
+    } catch {
+      // Invalid key format - ignore
     }
-  } catch (error) {
-    console.warn('Failed to load encryption key from localStorage:', error)
   }
   return null
 }


### PR DESCRIPTION
## Summary

Replace direct `localStorage` calls with safe utilities from `storage.ts` for consistent error handling across the codebase.

## Changes

### `src/app/groups/recent-group-list-card.tsx`
- Replace `localStorage.getItem` with `safeGetItem`
- Remove redundant try/catch block

### `src/components/password-prompt.tsx`
- Replace local `loadRateLimitState`/`saveRateLimitState` implementations with `safeGetJSON`/`safeSetJSON`
- Replace `localStorage.setItem` with `safeSetItem`

### `src/components/encryption-provider.tsx`
- Replace `localStorage.setItem` with `safeSetItem` in `saveKeyToStorage`
- Replace `localStorage.getItem` with `safeGetItem` in `loadKeyFromStorage`
- Keep try/catch only for `base64ToKey` parsing (actual error case)

### `src/app/groups/create/create-group.tsx`
- Replace `localStorage.setItem` with `safeSetItem`
- Keep sessionStorage wrapped in try/catch (no safe utility for sessionStorage yet)

## Impact

- Consistent error handling for localStorage operations
- DRY compliance - all localStorage access goes through storage.ts utilities
- Cleaner code with less boilerplate try/catch blocks

## Test Plan
- [x] TypeScript type check passes
- [x] All 238 tests pass

Closes #95