### PR TITLE
feat: add Docker/Podman Compose support (Issue #5)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,44 @@
+# Dependencies
+node_modules
+.pnpm-store
+
+# Build outputs
+.next
+out
+build
+dist
+
+# Development files
+*.log
+*.local
+.env
+.env.local
+.env.*.local
+
+# IDE
+.idea
+.vscode
+*.swp
+*.swo
+
+# Git
+.git
+.gitignore
+
+# Docker
+Dockerfile
+compose.yaml
+container.env
+postgres-data
+
+# Test
+coverage
+*.test.ts
+*.test.tsx
+__tests__
+
+# Misc
+README.md
+LICENSE
+CLAUDE.md
+.jj

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,49 +1,73 @@
+# ===========================================
+# anon-spliit Dockerfile
+# Multi-stage build for Next.js with pnpm
+# ===========================================
+
 FROM node:21-alpine AS base
 
+# Install pnpm
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
 WORKDIR /usr/app
-COPY ./package.json \
-     ./package-lock.json \
-     ./next.config.mjs \
-     ./tsconfig.json \
-     ./reset.d.ts \
-     ./tailwind.config.js \
-     ./postcss.config.js ./
-COPY ./scripts ./scripts
-COPY ./prisma ./prisma
 
+# Copy package files
+COPY package.json pnpm-lock.yaml ./
+COPY prisma ./prisma
+
+# Install dependencies
 RUN apk add --no-cache openssl && \
-    npm ci --ignore-scripts && \
-    npx prisma generate
+    pnpm install --frozen-lockfile && \
+    pnpm prisma generate
 
-COPY ./src ./src
-COPY ./messages ./messages
+# Copy source files
+COPY next.config.mjs tsconfig.json reset.d.ts tailwind.config.js postcss.config.js ./
+COPY src ./src
+COPY messages ./messages
+COPY public ./public
+COPY scripts ./scripts
 
+# Build environment
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# Copy build environment and build
 COPY scripts/build.env .env
-RUN npm run build
+RUN pnpm build && rm -rf .next/cache
 
-RUN rm -r .next/cache
-
+# ===========================================
+# Runtime dependencies stage
+# ===========================================
 FROM node:21-alpine AS runtime-deps
 
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
 WORKDIR /usr/app
-COPY --from=base /usr/app/package.json /usr/app/package-lock.json /usr/app/next.config.mjs ./
-COPY --from=base /usr/app/prisma ./prisma
 
-RUN npm ci --omit=dev --omit=optional --ignore-scripts && \
-    npx prisma generate
+COPY package.json pnpm-lock.yaml ./
+COPY prisma ./prisma
 
+RUN pnpm install --frozen-lockfile --prod && \
+    pnpm prisma generate
+
+# ===========================================
+# Runner stage
+# ===========================================
 FROM node:21-alpine AS runner
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
 
 EXPOSE 3000/tcp
 WORKDIR /usr/app
 
-COPY --from=base /usr/app/package.json /usr/app/package-lock.json /usr/app/next.config.mjs ./
+# Copy necessary files
+COPY package.json ./
 COPY --from=runtime-deps /usr/app/node_modules ./node_modules
-COPY ./public ./public
-COPY ./scripts ./scripts
+COPY --from=base /usr/app/public ./public
 COPY --from=base /usr/app/prisma ./prisma
 COPY --from=base /usr/app/.next ./.next
+COPY scripts ./scripts
+
+# Set production environment
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
 
 ENTRYPOINT ["/bin/sh", "/usr/app/scripts/container-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -103,13 +103,34 @@ pnpm install
 pnpm dev
 ```
 
-### Run with Docker
+### Run with Docker/Podman
 
 ```bash
-pnpm run build-image
+# Copy and configure environment
 cp container.env.example container.env
-pnpm run start-container
+# Edit container.env with your settings (especially POSTGRES_PASSWORD)
+
+# Build and run with Docker
+docker compose up -d
+
+# Or with Podman
+podman-compose up -d
 ```
+
+**Alternative: Build image separately**
+
+```bash
+# Build the image
+./scripts/build-image.sh
+
+# Then start services
+docker compose up -d
+# or: podman-compose up -d
+```
+
+**Services:**
+- App: http://localhost:3000
+- Database: PostgreSQL (internal, port 5432)
 
 ## Private Instance Mode
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,33 +1,49 @@
+# ===========================================
+# anon-spliit Docker/Podman Compose
+# ===========================================
+# Usage:
+#   1. Copy container.env.example to container.env
+#   2. Configure container.env with your settings
+#   3. Run: podman-compose up -d (or docker compose up -d)
+# ===========================================
+
 services:
   app:
     build: .
-    image: spliit:latest
+    image: anon-spliit:latest
+    container_name: anon-spliit-app
     ports:
-      - 3000:3000
+      - "3000:3000"
     env_file:
       - container.env
     depends_on:
       db:
         condition: service_healthy
+    restart: unless-stopped
     networks:
-      - spliit_network
+      - anon-spliit-network
 
   db:
-    image: postgres:latest
+    image: postgres:16-alpine
+    container_name: anon-spliit-db
     expose:
       - 5432
     env_file:
       - container.env
     volumes:
-      - ./postgres-data:/var/lib/postgresql/data
+      - postgres-data:/var/lib/postgresql/data
     healthcheck:
-      test: ['CMD-SHELL', 'pg_isready -U postgres']
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 5s
       timeout: 5s
       retries: 5
+    restart: unless-stopped
     networks:
-      - spliit_network
+      - anon-spliit-network
+
+volumes:
+  postgres-data:
 
 networks:
-  spliit_network:
+  anon-spliit-network:
     driver: bridge

--- a/container.env.example
+++ b/container.env.example
@@ -1,6 +1,50 @@
-# db
-POSTGRES_PASSWORD=1234
+# ===========================================
+# anon-spliit Container Environment
+# Copy this file to container.env and configure
+# ===========================================
 
-# app
-POSTGRES_PRISMA_URL=postgresql://postgres:${POSTGRES_PASSWORD}@db
-POSTGRES_URL_NON_POOLING=postgresql://postgres:${POSTGRES_PASSWORD}@db
+# PostgreSQL Configuration
+POSTGRES_USER=postgres
+POSTGRES_PASSWORD=your-secure-password-here
+POSTGRES_DB=spliit
+
+# Database Connection (uses internal Docker network)
+POSTGRES_PRISMA_URL=postgresql://postgres:your-secure-password-here@db:5432/spliit
+POSTGRES_URL_NON_POOLING=postgresql://postgres:your-secure-password-here@db:5432/spliit
+
+# ===========================================
+# Auto-delete Settings (Optional)
+# ===========================================
+AUTO_DELETE_INACTIVE_DAYS=90
+DELETE_GRACE_PERIOD_DAYS=7
+CRON_SECRET=generate-with-openssl-rand-base64-32
+
+# ===========================================
+# Private Instance Mode (Optional)
+# ===========================================
+PRIVATE_INSTANCE=false
+# ADMIN_EMAIL=admin@example.com
+# ADMIN_PASSWORD=changeme
+# NEXTAUTH_SECRET=generate-with-openssl-rand-base64-32
+# NEXTAUTH_URL=http://localhost:3000
+
+# ===========================================
+# Two-Factor Authentication (Optional)
+# ===========================================
+# TWO_FA_ENCRYPTION_KEY=generate-with-openssl-rand-hex-32
+
+# ===========================================
+# S3 Storage (Optional)
+# ===========================================
+NEXT_PUBLIC_ENABLE_EXPENSE_DOCUMENTS=false
+# S3_UPLOAD_KEY=
+# S3_UPLOAD_SECRET=
+# S3_UPLOAD_BUCKET=
+# S3_UPLOAD_REGION=
+
+# ===========================================
+# AI Features (Optional)
+# ===========================================
+NEXT_PUBLIC_ENABLE_RECEIPT_EXTRACT=false
+NEXT_PUBLIC_ENABLE_CATEGORY_EXTRACT=false
+# OPENAI_API_KEY=

--- a/scripts/build-image.sh
+++ b/scripts/build-image.sh
@@ -1,12 +1,26 @@
-#!/bin/bash
+#!/bin/sh
 
-SPLIIT_APP_NAME=$(node -p -e "require('./package.json').name")
-SPLIIT_VERSION=$(node -p -e "require('./package.json').version")
+set -eu
 
-# we need to set dummy data for POSTGRES env vars in order for build not to fail
-docker buildx build \
-    -t ${SPLIIT_APP_NAME}:${SPLIIT_VERSION} \
-    -t ${SPLIIT_APP_NAME}:latest \
-    .
+APP_NAME=$(node -p -e "require('./package.json').name")
+APP_VERSION=$(node -p -e "require('./package.json').version")
 
-docker image prune -f
+echo "Building ${APP_NAME}:${APP_VERSION}..."
+
+# Build with Docker or Podman
+if command -v podman > /dev/null 2>&1; then
+    echo "Using Podman..."
+    podman build \
+        -t "${APP_NAME}:${APP_VERSION}" \
+        -t "${APP_NAME}:latest" \
+        .
+else
+    echo "Using Docker..."
+    docker buildx build \
+        -t "${APP_NAME}:${APP_VERSION}" \
+        -t "${APP_NAME}:latest" \
+        .
+    docker image prune -f
+fi
+
+echo "Build complete: ${APP_NAME}:${APP_VERSION}"

--- a/scripts/container-entrypoint.sh
+++ b/scripts/container-entrypoint.sh
@@ -1,6 +1,9 @@
-#!/bin/bash
+#!/bin/sh
 
-set -euxo pipefail
+set -eu
 
+echo "Running database migrations..."
 npx prisma migrate deploy
-exec npm run start
+
+echo "Starting application..."
+exec pnpm start


### PR DESCRIPTION
## Summary

Add Docker and Podman Compose support for self-hosted deployments, while keeping existing Supabase + Vercel deployment intact.

## Changes

### New Files
- `.dockerignore` - Exclude unnecessary files from Docker build

### Updated Files
- `Dockerfile` - Updated to use pnpm instead of npm for consistency
- `compose.yaml` - Improved with proper naming, healthchecks, and named volumes
- `container.env.example` - New comprehensive example with all configuration options
- `scripts/build-image.sh` - Support both Docker and Podman
- `scripts/container-entrypoint.sh` - Updated to use pnpm
- `README.md` - Improved Docker/Podman deployment documentation

## Usage

```bash
# Copy and configure environment
cp container.env.example container.env
# Edit container.env with your settings

# Start with Docker
docker compose up -d

# Or with Podman
podman-compose up -d
```

## Services
- **App**: http://localhost:3000
- **Database**: PostgreSQL 16 (internal, port 5432)

## Key Improvements
- Uses pnpm for consistency with development
- Named volumes for data persistence
- Proper healthchecks
- Auto-restart policies
- Works with both Docker and Podman

Closes #5