### PR TITLE
fix: skip postinstall during Docker build to avoid DB requirement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /usr/app
 COPY package.json pnpm-lock.yaml ./
 COPY prisma ./prisma
 
-# Install dependencies
+# Install dependencies (--ignore-scripts skips postinstall which requires DB)
 RUN apk add --no-cache openssl && \
-    pnpm install --frozen-lockfile && \
+    pnpm install --frozen-lockfile --ignore-scripts && \
     pnpm prisma generate
 
 # Copy source files
@@ -45,7 +45,7 @@ WORKDIR /usr/app
 COPY package.json pnpm-lock.yaml ./
 COPY prisma ./prisma
 
-RUN pnpm install --frozen-lockfile --prod && \
+RUN pnpm install --frozen-lockfile --prod --ignore-scripts && \
     pnpm prisma generate
 
 # ===========================================


### PR DESCRIPTION
## Summary
- Use `--ignore-scripts` flag during `pnpm install` to skip postinstall
- postinstall runs `prisma migrate deploy` which requires DB (not available at build time)
- `prisma generate` is run explicitly after install (doesn't need DB)
- Migrations run at container startup via entrypoint (already configured)

## Test
```bash
podman build -t anon-spliit:latest .  # ✅ Build succeeds
podman compose --env-file container.env up -d  # ✅ Containers start
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)