### PR TITLE
fix(crypto): prevent password bypass via localStorage

### DIFF
--- a/src/app/groups/create/create-group.tsx
+++ b/src/app/groups/create/create-group.tsx
@@ -59,7 +59,6 @@ export const CreateGroup = () => {
         }
 
         const keyBase64 = keyToBase64(urlKey)
-        const combinedKeyBase64 = keyToBase64(encryptionKey)
 
         // Prepare values for encryption (remove password field, add salt)
         const { password, passwordHint, ...valuesWithoutPassword } =
@@ -91,8 +90,9 @@ export const CreateGroup = () => {
 
         // Save keys to storage BEFORE redirect so EncryptionProvider can find them
         // This is done after group creation succeeds to avoid storing keys for failed creations
-        // Save the combined key to localStorage (persistent)
-        safeSetItem(`${ENCRYPTION_KEY_PREFIX}${groupId}`, combinedKeyBase64)
+        // Save urlKey to localStorage (NOT combinedKey - security fix)
+        // For password-protected groups, combinedKey must only exist in memory/sessionStorage
+        safeSetItem(`${ENCRYPTION_KEY_PREFIX}${groupId}`, keyBase64)
 
         // If password was used, also save password-derived key to sessionStorage
         // This allows EncryptionProvider to verify the key combination

--- a/src/components/encryption-provider.tsx
+++ b/src/components/encryption-provider.tsx
@@ -3,6 +3,7 @@
 import { PasswordPrompt } from '@/components/password-prompt'
 import {
   base64ToKey,
+  combineKeys,
   decrypt,
   decryptNumber,
   decryptObject,
@@ -15,6 +16,7 @@ import {
 import {
   ENCRYPTION_KEY_PREFIX,
   safeGetItem,
+  safeRemoveItem,
   safeSetItem,
   SESSION_PWD_KEY_PREFIX,
 } from '@/lib/storage'
@@ -205,53 +207,87 @@ export function EncryptionProvider({
       const storedKey = restoreUrlKeyFromStorage()
 
       // CASE 1: Password-protected group with session password key
-      // The stored key is already the combined key, use it directly
+      // localStorage now stores urlKey (not combinedKey), so recompute combinedKey
       if (passwordSalt && sessionPwdKey && storedKey) {
-        setEncryptionKey(storedKey)
-        setNeedsPassword(false)
-        setNeedsKey(false)
+        const urlKeyToUse = hashUrlKey || storedKey
+        const combinedKey = combineKeys(urlKeyToUse, sessionPwdKey)
 
-        // Update URL with the URL key from hash if available
-        if (hashUrlKey) {
-          setUrlKey(hashUrlKey)
+        // Validate the computed key by test-decrypting the group name
+        // This detects old combinedKey format in localStorage and falls through to CASE 2
+        let keyValid = true
+        if (encryptedGroupName) {
+          try {
+            await decrypt(encryptedGroupName, combinedKey)
+          } catch {
+            keyValid = false
+          }
         }
 
-        setIsLoading(false)
-        return
-      }
+        if (keyValid) {
+          setEncryptionKey(combinedKey)
+          setUrlKey(urlKeyToUse)
+          setNeedsPassword(false)
+          setNeedsKey(false)
 
-      // CASE 1.5: Password-protected group, just redirected from creation
-      // We have both URL key in hash AND combined key in localStorage
-      // This happens immediately after group creation before session expires
-      if (passwordSalt && hashUrlKey && storedKey) {
-        setEncryptionKey(storedKey)
-        setUrlKey(hashUrlKey)
-        setNeedsPassword(false)
-        setNeedsKey(false)
-        setIsLoading(false)
-        return
+          // Ensure localStorage has urlKey (migration from old combinedKey format)
+          if (groupId) {
+            saveKeyToStorage(groupId, urlKeyToUse)
+          }
+
+          setIsLoading(false)
+          return
+        }
+        // keyValid === false: old combinedKey format detected, fall through to CASE 2
       }
 
       // CASE 2: Password-protected group but no session password key
+      // Password is ALWAYS required when sessionPwdKey is missing (security fix)
       // We need the URL key to derive the combined key after password entry
       if (passwordSalt) {
-        const urlKeyToUse = hashUrlKey || null
+        // Determine urlKey: prefer hashUrlKey, validate storedKey before using
+        let urlKeyToUse: Uint8Array | null = hashUrlKey || null
+
+        if (!urlKeyToUse && storedKey) {
+          // storedKey might be old combinedKey format - validate by hint decryption
+          if (passwordHint) {
+            try {
+              await decrypt(passwordHint, storedKey)
+              // Hint decrypted successfully → storedKey is real urlKey
+              urlKeyToUse = storedKey
+            } catch {
+              // Hint decryption failed → storedKey is likely old combinedKey
+              // Clear invalid stored key (old combinedKey format)
+              if (groupId) {
+                safeRemoveItem(`${ENCRYPTION_KEY_PREFIX}${groupId}`)
+              }
+            }
+          } else {
+            // No hint to validate against, use storedKey (best effort)
+            urlKeyToUse = storedKey
+          }
+        }
+
         if (urlKeyToUse) {
           setUrlKey(urlKeyToUse)
           setNeedsPassword(true)
           setNeedsKey(false)
 
-          // Decrypt password hint if available
-          if (passwordHint) {
+          // Ensure localStorage has urlKey for future access
+          if (groupId) {
+            saveKeyToStorage(groupId, urlKeyToUse)
+          }
+
+          // Decrypt password hint if available and not already decrypted
+          if (passwordHint && !decryptedHint) {
             try {
               const hint = await decrypt(passwordHint, urlKeyToUse)
               setDecryptedHint(hint)
             } catch {
-              // Failed to decrypt hint
+              // Failed to decrypt hint - ignore
             }
           }
         } else {
-          // No URL key available, need key
+          // No valid URL key available, need key from URL
           setNeedsKey(true)
         }
 

--- a/src/components/password-prompt.tsx
+++ b/src/components/password-prompt.tsx
@@ -171,9 +171,12 @@ export function PasswordPrompt({
         }
       }
 
-      // Save to localStorage for this group
-      const keyBase64 = keyToBase64(finalKey)
-      safeSetItem(`${ENCRYPTION_KEY_PREFIX}${groupId}`, keyBase64)
+      // Save urlKey to localStorage (NOT combinedKey - security fix)
+      // combinedKey must only exist in memory/sessionStorage
+      if (urlKey) {
+        const urlKeyBase64 = keyToBase64(urlKey)
+        safeSetItem(`${ENCRYPTION_KEY_PREFIX}${groupId}`, urlKeyBase64)
+      }
 
       // Also save password-derived key separately for session
       sessionStorage.setItem(


### PR DESCRIPTION
## Summary
- **Security fix**: Password-protected groups could be accessed without password from group list
- localStorage now stores `urlKey` instead of `combinedKey` for password-protected groups
- Removed CASE 1.5 bypass that allowed access without sessionPwdKey
- Password re-entry is now required each browser session

## Changed Files
- `src/components/password-prompt.tsx` — Save urlKey to localStorage instead of combinedKey
- `src/app/groups/create/create-group.tsx` — Save urlKey on group creation
- `src/components/encryption-provider.tsx` — Recompute combinedKey from urlKey + sessionPwdKey; remove bypass

## Security Impact
- **Before**: combinedKey in localStorage → group list link included combinedKey → CASE 1.5 bypassed password
- **After**: urlKey in localStorage → password always required when sessionPwdKey is missing

## Test plan
- [ ] Create password-protected group → verify access works
- [ ] Close browser, reopen → verify password is required
- [ ] Access from group list → verify password prompt appears
- [ ] Share link → verify URL contains key fragment
- [ ] Non-password groups → verify no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)