### PR TITLE
fix(security): prevent user enumeration via timing-safe authorize

### DIFF
--- a/src/__tests__/private-instance.test.ts
+++ b/src/__tests__/private-instance.test.ts
@@ -83,10 +83,8 @@ describe('Private Instance Mode', () => {
 
     it('should search admin and whitelist in parallel pattern', async () => {
       // Simulates Promise.all parallel search pattern
-      const searchAdmin = () =>
-        Promise.resolve(null) // not found
-      const searchWhitelist = () =>
-        Promise.resolve(null) // not found
+      const searchAdmin = () => Promise.resolve(null) // not found
+      const searchWhitelist = () => Promise.resolve(null) // not found
 
       const [admin, whitelistUser] = await Promise.all([
         searchAdmin(),

--- a/src/__tests__/private-instance.test.ts
+++ b/src/__tests__/private-instance.test.ts
@@ -62,6 +62,42 @@ describe('Private Instance Mode', () => {
     })
   })
 
+  describe('Timing-Safe Authorization (Issue #111)', () => {
+    it('should perform bcrypt comparison even when user does not exist', async () => {
+      // Ensures timing is consistent regardless of user existence
+      const DUMMY_HASH = bcrypt.hashSync(
+        'dummy-password-for-timing-equalization',
+        12,
+      )
+      const password = 'any-password'
+
+      // Simulates the behavior when no user is found
+      const start = Date.now()
+      const result = await bcrypt.compare(password, DUMMY_HASH)
+      const elapsed = Date.now() - start
+
+      expect(result).toBe(false)
+      // bcrypt comparison should take measurable time (> 10ms)
+      expect(elapsed).toBeGreaterThan(10)
+    })
+
+    it('should search admin and whitelist in parallel pattern', async () => {
+      // Simulates Promise.all parallel search pattern
+      const searchAdmin = () =>
+        Promise.resolve(null) // not found
+      const searchWhitelist = () =>
+        Promise.resolve(null) // not found
+
+      const [admin, whitelistUser] = await Promise.all([
+        searchAdmin(),
+        searchWhitelist(),
+      ])
+
+      expect(admin).toBeNull()
+      expect(whitelistUser).toBeNull()
+    })
+  })
+
   describe('Password Hashing', () => {
     it('should hash passwords with bcrypt', async () => {
       const password = 'testpassword123'

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -13,6 +13,10 @@ import bcrypt from 'bcryptjs'
 import NextAuth, { type NextAuthConfig } from 'next-auth'
 import Credentials from 'next-auth/providers/credentials'
 
+// Dummy hash for timing-safe comparison when user doesn't exist (Issue #111)
+// This ensures consistent response time regardless of user existence
+const DUMMY_HASH = bcrypt.hashSync('dummy-password-for-timing-equalization', 12)
+
 // Extend the session type to include our custom properties
 declare module 'next-auth' {
   interface Session {
@@ -61,10 +65,12 @@ const authConfig: NextAuthConfig = {
           return null
         }
 
-        // Check if user is an admin
-        const admin = await prisma.admin.findUnique({
-          where: { email },
-        })
+        // Search admin and whitelist tables in parallel to prevent
+        // user enumeration via timing differences (Issue #111)
+        const [admin, whitelistUser] = await Promise.all([
+          prisma.admin.findUnique({ where: { email } }),
+          prisma.whitelistUser.findUnique({ where: { email } }),
+        ])
 
         if (admin) {
           const isValidPassword = await bcrypt.compare(password, admin.password)
@@ -83,14 +89,7 @@ const authConfig: NextAuthConfig = {
               requiresTwoFactor: twoFactorEnabled,
             }
           }
-        }
-
-        // Check if user is in whitelist
-        const whitelistUser = await prisma.whitelistUser.findUnique({
-          where: { email },
-        })
-
-        if (whitelistUser && whitelistUser.password) {
+        } else if (whitelistUser && whitelistUser.password) {
           const isValidPassword = await bcrypt.compare(
             password,
             whitelistUser.password,
@@ -110,6 +109,9 @@ const authConfig: NextAuthConfig = {
               requiresTwoFactor: twoFactorEnabled,
             }
           }
+        } else {
+          // No user found - perform dummy bcrypt comparison to equalize timing
+          await bcrypt.compare(password, DUMMY_HASH)
         }
 
         // Record failed attempt for rate limiting


### PR DESCRIPTION
## Summary
- authorize()でAdmin/WhitelistUserをPromise.allで並行検索
- ユーザー未発見時にダミーbcrypt比較でタイミングを均一化
- 既存の認証フロー（2FA、パスワード変更強制、レート制限）は全て維持

## Test plan
- [x] ダミーbcrypt比較のタイミング均一化テスト追加
- [x] 並行検索パターンのテスト追加
- [x] 既存テスト全パス（265 passed）

Closes #111