### PR TITLE
fix(security): replace sessionStorage with in-memory cache for password keys

### DIFF
--- a/src/app/groups/create/create-group.tsx
+++ b/src/app/groups/create/create-group.tsx
@@ -15,6 +15,7 @@ import {
   ENCRYPTION_KEY_PREFIX,
   safeSetItem,
   SESSION_PWD_KEY_PREFIX,
+  setSessionKey,
 } from '@/lib/storage'
 import { trpc } from '@/trpc/client'
 import { useRouter } from 'next/navigation'
@@ -94,17 +95,13 @@ export const CreateGroup = () => {
         // For password-protected groups, combinedKey must only exist in memory/sessionStorage
         safeSetItem(`${ENCRYPTION_KEY_PREFIX}${groupId}`, keyBase64)
 
-        // If password was used, also save password-derived key to sessionStorage
-        // This allows EncryptionProvider to verify the key combination
+        // If password was used, save password-derived key to in-memory cache (Issue #114)
+        // Using in-memory cache instead of sessionStorage to prevent XSS-based theft
         if (passwordKeyBase64) {
-          try {
-            sessionStorage.setItem(
-              `${SESSION_PWD_KEY_PREFIX}${groupId}`,
-              passwordKeyBase64,
-            )
-          } catch {
-            // sessionStorage not available - continue without saving
-          }
+          setSessionKey(
+            `${SESSION_PWD_KEY_PREFIX}${groupId}`,
+            passwordKeyBase64,
+          )
         }
 
         // Redirect with URL key in fragment

--- a/src/components/encryption-provider.tsx
+++ b/src/components/encryption-provider.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/lib/crypto'
 import {
   ENCRYPTION_KEY_PREFIX,
+  getSessionKey,
   safeGetItem,
   safeRemoveItem,
   safeSetItem,
@@ -162,7 +163,7 @@ export function EncryptionProvider({
     return savedKey
   }, [])
 
-  // Function to get password-derived key from session storage
+  // Function to get password-derived key from in-memory cache (Issue #114)
   const getSessionPasswordKey = useCallback(() => {
     if (typeof window === 'undefined') return null
 
@@ -170,14 +171,14 @@ export function EncryptionProvider({
     if (!groupId) return null
 
     try {
-      const keyBase64 = sessionStorage.getItem(
+      const keyBase64 = getSessionKey(
         `${SESSION_PWD_KEY_PREFIX}${groupId}`,
       )
       if (keyBase64) {
         return base64ToKey(keyBase64)
       }
     } catch {
-      // Session storage not available or invalid key
+      // Invalid key format
     }
     return null
   }, [])

--- a/src/components/encryption-provider.tsx
+++ b/src/components/encryption-provider.tsx
@@ -171,9 +171,7 @@ export function EncryptionProvider({
     if (!groupId) return null
 
     try {
-      const keyBase64 = getSessionKey(
-        `${SESSION_PWD_KEY_PREFIX}${groupId}`,
-      )
+      const keyBase64 = getSessionKey(`${SESSION_PWD_KEY_PREFIX}${groupId}`)
       if (keyBase64) {
         return base64ToKey(keyBase64)
       }

--- a/src/components/password-prompt.tsx
+++ b/src/components/password-prompt.tsx
@@ -24,6 +24,7 @@ import {
   safeSetItem,
   safeSetJSON,
   SESSION_PWD_KEY_PREFIX,
+  setSessionKey,
 } from '@/lib/storage'
 import { AlertCircle, Eye, EyeOff, KeyRound, Loader2 } from 'lucide-react'
 import { useTranslations } from 'next-intl'
@@ -178,8 +179,9 @@ export function PasswordPrompt({
         safeSetItem(`${ENCRYPTION_KEY_PREFIX}${groupId}`, urlKeyBase64)
       }
 
-      // Also save password-derived key separately for session
-      sessionStorage.setItem(
+      // Save password-derived key in memory-only cache (Issue #114)
+      // Using in-memory cache instead of sessionStorage to prevent XSS-based theft
+      setSessionKey(
         `${SESSION_PWD_KEY_PREFIX}${groupId}`,
         keyToBase64(passwordKey),
       )

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -14,6 +14,32 @@
 export const ENCRYPTION_KEY_PREFIX = 'spliit-e2ee-key-'
 export const SESSION_PWD_KEY_PREFIX = 'spliit-pwd-key-'
 
+// In-memory cache for sensitive session keys (Issue #114)
+// Replaces sessionStorage to prevent XSS-based key theft
+const sessionKeyCache = new Map<string, string>()
+
+/**
+ * Set a sensitive key in memory-only cache
+ * Unlike sessionStorage, this is not accessible via DOM APIs
+ */
+export function setSessionKey(key: string, value: string): void {
+  sessionKeyCache.set(key, value)
+}
+
+/**
+ * Get a sensitive key from memory-only cache
+ */
+export function getSessionKey(key: string): string | null {
+  return sessionKeyCache.get(key) ?? null
+}
+
+/**
+ * Remove a sensitive key from memory-only cache
+ */
+export function removeSessionKey(key: string): void {
+  sessionKeyCache.delete(key)
+}
+
 /**
  * Safely get an item from localStorage
  * @returns The stored value, or null if not found or on error


### PR DESCRIPTION
## Summary
- sessionStorageの代わりにモジュールスコープのMapでパスワード導出キーを保持
- XSS時のキー窃取リスクを軽減（sessionStorageはDOM APIでアクセス可能だが、メモリ内Mapは不可）
- storage.tsに汎用的なsetSessionKey/getSessionKey/removeSessionKeyユーティリティを追加
- encryption-provider.tsx、password-prompt.tsx、create-group.tsxの3ファイルを更新

## トレードオフ
- ページリロード時にパスワード再入力が必要になる（セキュリティ上はむしろ望ましい）

## Test plan
- [x] 既存テスト全パス（263 passed）
- [x] 暗号化関連テストに回帰なし

Closes #114