### PR TITLE
fix(perf): add upper bound limit to listAll expense procedure

### DIFF
--- a/src/trpc/routers/groups/expenses/listAll.procedure.ts
+++ b/src/trpc/routers/groups/expenses/listAll.procedure.ts
@@ -2,14 +2,29 @@ import { getGroupExpenses } from '@/lib/api'
 import { publicProcedure } from '@/trpc/init'
 import { z } from 'zod'
 
+// Maximum number of expenses to fetch at once (Issue #113)
+// Prevents excessive memory usage and DoS via large groups
+const MAX_EXPENSES_LIMIT = 10000
+
 /**
- * List all expenses for a group (no pagination)
+ * List all expenses for a group with upper bound limit
  * Used for client-side balance calculation with encrypted amounts
  */
 export const listAllGroupExpensesProcedure = publicProcedure
-  .input(z.object({ groupId: z.string().min(1) }))
-  .query(async ({ input: { groupId } }) => {
-    const expenses = await getGroupExpenses(groupId)
+  .input(
+    z.object({
+      groupId: z.string().min(1),
+      limit: z
+        .number()
+        .int()
+        .min(1)
+        .max(MAX_EXPENSES_LIMIT)
+        .optional()
+        .default(MAX_EXPENSES_LIMIT),
+    }),
+  )
+  .query(async ({ input: { groupId, limit } }) => {
+    const expenses = await getGroupExpenses(groupId, { length: limit })
     return {
       expenses: expenses.map((expense) => ({
         ...expense,


### PR DESCRIPTION
## Summary
- listAll procedureにlimitパラメータを追加（デフォルト10,000、最大10,000）
- 大量経費グループでのメモリ圧迫・DoSリスクを軽減
- 既存のgetGroupExpenses()のlengthパラメータを活用（API層変更なし）
- useBalancesフックは変更なし（デフォルト値で後方互換）

## Test plan
- [x] 既存テスト全パス（263 passed）
- [x] tRPCルーター変更のみ、クライアント側への影響なし

Closes #113