### PR TITLE
feat(crypto): add encryption format versioning with backward compatibility

### DIFF
--- a/src/lib/crypto.security.test.ts
+++ b/src/lib/crypto.security.test.ts
@@ -557,4 +557,87 @@ describe('Crypto Security Tests', () => {
       }
     })
   })
+
+  describe('Encryption Format Versioning (Issue #112)', () => {
+    it('should encrypt with v1 format (version byte prepended)', async () => {
+      const key = generateMasterKey()
+      const plaintext = 'test data for v1 format'
+      const encrypted = await encrypt(plaintext, key)
+
+      // Decode and verify v1 format: first byte should be 0x01
+      const bytes = base64ToKey(encrypted)
+      expect(bytes[0]).toBe(0x01)
+      // Total should be: 1 (version) + 12 (IV) + ciphertext (>= 16 for GCM tag)
+      expect(bytes.length).toBeGreaterThanOrEqual(29)
+    })
+
+    it('should decrypt v1 format correctly', async () => {
+      const key = generateMasterKey()
+      const plaintext = 'roundtrip test for v1'
+      const encrypted = await encrypt(plaintext, key)
+      const decrypted = await decrypt(encrypted, key)
+
+      expect(decrypted).toBe(plaintext)
+    })
+
+    it('should decrypt legacy format (no version byte) correctly', async () => {
+      const key = generateMasterKey()
+
+      // Manually create legacy format: [IV(12)] + [ciphertext]
+      const derivedKey = await deriveKey(key, 'data', false)
+      const iv = crypto.getRandomValues(new Uint8Array(12))
+      const plaintext = 'legacy format test'
+      const encoded = new TextEncoder().encode(plaintext)
+      const ciphertext = await crypto.subtle.encrypt(
+        { name: 'AES-GCM', iv },
+        derivedKey,
+        encoded,
+      )
+
+      // Combine as legacy: IV + ciphertext (no version byte)
+      const combined = new Uint8Array(12 + ciphertext.byteLength)
+      combined.set(iv)
+      combined.set(new Uint8Array(ciphertext), 12)
+      const legacyEncrypted = keyToBase64(combined)
+
+      // decrypt() should handle legacy format via fallback
+      const decrypted = await decrypt(legacyEncrypted, key)
+      expect(decrypted).toBe(plaintext)
+    })
+
+    it('should handle v1 encrypt -> decrypt for numbers', async () => {
+      const key = generateMasterKey()
+      const num = 12345
+      const encrypted = await encryptNumber(num, key)
+      const decrypted = await decryptNumber(encrypted, key)
+
+      expect(decrypted).toBe(num)
+    })
+
+    it('should handle v1 encrypt -> decrypt for objects', async () => {
+      const key = generateMasterKey()
+      const obj = { amount: 100, currency: 'USD' }
+      const encrypted = await encryptObject(obj, key)
+      const decrypted = await decryptObject(encrypted, key)
+
+      expect(decrypted).toEqual(obj)
+    })
+
+    it('should handle unicode text in v1 format', async () => {
+      const key = generateMasterKey()
+      const plaintext = '日本語テスト 🔐 Ñoño'
+      const encrypted = await encrypt(plaintext, key)
+      const decrypted = await decrypt(encrypted, key)
+
+      expect(decrypted).toBe(plaintext)
+    })
+
+    it('should fail decryption with wrong key for v1 format', async () => {
+      const key1 = generateMasterKey()
+      const key2 = generateMasterKey()
+      const encrypted = await encrypt('secret', key1)
+
+      await expect(decrypt(encrypted, key2)).rejects.toThrow()
+    })
+  })
 })

--- a/src/lib/crypto.security.test.ts
+++ b/src/lib/crypto.security.test.ts
@@ -639,5 +639,32 @@ describe('Crypto Security Tests', () => {
 
       await expect(decrypt(encrypted, key2)).rejects.toThrow()
     })
+
+    it('should handle legacy data where IV[0] happens to be 0x01', async () => {
+      const key = generateMasterKey()
+
+      // Create legacy format with IV starting with 0x01 (mimics false v1 detection)
+      const derivedKey = await deriveKey(key, 'data', false)
+      const iv = new Uint8Array(12)
+      iv[0] = 0x01 // Force first byte to match ENCRYPTION_FORMAT_VERSION
+      crypto.getRandomValues(iv.subarray(1)) // Randomize the rest
+      const plaintext = 'legacy data with 0x01 IV'
+      const encoded = new TextEncoder().encode(plaintext)
+      const ciphertext = await crypto.subtle.encrypt(
+        { name: 'AES-GCM', iv },
+        derivedKey,
+        encoded,
+      )
+
+      // Combine as legacy: IV + ciphertext (no version byte)
+      const combined = new Uint8Array(12 + ciphertext.byteLength)
+      combined.set(iv)
+      combined.set(new Uint8Array(ciphertext), 12)
+      const legacyEncrypted = keyToBase64(combined)
+
+      // decrypt() should try v1 first (fails), then fallback to legacy successfully
+      const decrypted = await decrypt(legacyEncrypted, key)
+      expect(decrypted).toBe(plaintext)
+    })
   })
 })

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -234,18 +234,25 @@ export async function decrypt(
   const combined = base64ToKey(encryptedData)
 
   // Detect format version (Issue #112)
+  // Note: Legacy data where IV[0] happens to be 0x01 (1/256 chance) will
+  // be tried as v1 first, fail, then fall through to legacy format below
   if (combined.length > 13 && combined[0] === ENCRYPTION_FORMAT_VERSION) {
-    // v1 format: skip version byte, extract IV and ciphertext
-    const iv = combined.slice(1, 13)
-    const ciphertext = combined.slice(13)
+    try {
+      // v1 format: skip version byte, extract IV and ciphertext
+      const iv = combined.slice(1, 13)
+      const ciphertext = combined.slice(13)
 
-    const key = await deriveKey(masterKey, 'data', false)
-    const decrypted = await crypto.subtle.decrypt(
-      { name: 'AES-GCM', iv },
-      key,
-      ciphertext,
-    )
-    return new TextDecoder().decode(decrypted)
+      const key = await deriveKey(masterKey, 'data', false)
+      const decrypted = await crypto.subtle.decrypt(
+        { name: 'AES-GCM', iv },
+        key,
+        ciphertext,
+      )
+      return new TextDecoder().decode(decrypted)
+    } catch {
+      // v1 decryption failed - may be legacy data where IV[0] == 0x01
+      // Fall through to legacy format handling below
+    }
   }
 
   // Legacy format: [IV(12 bytes)] + [ciphertext]

--- a/src/lib/crypto.ts
+++ b/src/lib/crypto.ts
@@ -172,9 +172,21 @@ export async function deriveKey(
   return derivationPromise
 }
 
+// ============================================================
+// Encryption Format Versioning (Issue #112)
+// ============================================================
+
+/**
+ * Current encryption format version
+ * v1: [version(1 byte)] + [IV(12 bytes)] + [ciphertext]
+ * Legacy (no version byte): [IV(12 bytes)] + [ciphertext]
+ */
+const ENCRYPTION_FORMAT_VERSION = 0x01
+
 /**
  * Encrypt data using AES-GCM (128 or 256 bit based on key size)
- * Returns base64-encoded ciphertext with IV prepended
+ * Returns base64-encoded ciphertext with version byte and IV prepended (Issue #112)
+ * Format: [version(1 byte)] + [IV(12 bytes)] + [ciphertext]
  * - 16-byte master key -> AES-128-GCM (legacy)
  * - 32-byte master key -> AES-256-GCM (new, Issue #50)
  */
@@ -196,19 +208,20 @@ export async function encrypt(
     encoded,
   )
 
-  // Combine IV + ciphertext
-  const combined = new Uint8Array(iv.length + ciphertext.byteLength)
-  combined.set(iv)
-  combined.set(new Uint8Array(ciphertext), iv.length)
+  // v1 format: version byte + IV + ciphertext (Issue #112)
+  const combined = new Uint8Array(1 + iv.length + ciphertext.byteLength)
+  combined[0] = ENCRYPTION_FORMAT_VERSION
+  combined.set(iv, 1)
+  combined.set(new Uint8Array(ciphertext), 1 + iv.length)
 
   return keyToBase64(combined)
 }
 
 /**
  * Decrypt data using AES-GCM (128 or 256 bit based on key size)
- * Tries new salt first, falls back to zero salt for backward compatibility
- * - 16-byte master key -> AES-128-GCM (legacy)
- * - 32-byte master key -> AES-256-GCM (new, Issue #50)
+ * Supports both v1 format (with version byte) and legacy format (Issue #112)
+ * - v1: [version(1 byte)] + [IV(12 bytes)] + [ciphertext] — uses new HKDF salt only
+ * - Legacy: [IV(12 bytes)] + [ciphertext] — tries new salt, falls back to zero salt
  */
 export async function decrypt(
   encryptedData: string,
@@ -220,11 +233,26 @@ export async function decrypt(
 
   const combined = base64ToKey(encryptedData)
 
-  // Extract IV and ciphertext
+  // Detect format version (Issue #112)
+  if (combined.length > 13 && combined[0] === ENCRYPTION_FORMAT_VERSION) {
+    // v1 format: skip version byte, extract IV and ciphertext
+    const iv = combined.slice(1, 13)
+    const ciphertext = combined.slice(13)
+
+    const key = await deriveKey(masterKey, 'data', false)
+    const decrypted = await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv },
+      key,
+      ciphertext,
+    )
+    return new TextDecoder().decode(decrypted)
+  }
+
+  // Legacy format: [IV(12 bytes)] + [ciphertext]
   const iv = combined.slice(0, 12)
   const ciphertext = combined.slice(12)
 
-  // Try with new salt first (for data encrypted with v1)
+  // Try with new salt first (for data encrypted with HKDF salt)
   try {
     const key = await deriveKey(masterKey, 'data', false)
     const decrypted = await crypto.subtle.decrypt(
@@ -234,7 +262,7 @@ export async function decrypt(
     )
     return new TextDecoder().decode(decrypted)
   } catch {
-    // Fallback to zero salt for backward compatibility (pre-v1 data)
+    // Fallback to zero salt for backward compatibility (pre-HKDF data)
     const legacyKey = await deriveKey(masterKey, 'data', true)
     const decrypted = await crypto.subtle.decrypt(
       { name: 'AES-GCM', iv },

--- a/src/lib/encrypt-helpers.ts
+++ b/src/lib/encrypt-helpers.ts
@@ -133,12 +133,15 @@ export async function decryptGroup<
 }
 
 /**
- * Check if a string looks like it might be encrypted
+ * Check if a string looks like it might be encrypted (Issue #112)
+ * Supports both v1 format (version byte + IV + ciphertext) and legacy format
+ * Minimum encrypted payload: IV(12 bytes) + GCM tag(16 bytes) + 1 byte = 29 bytes
+ * In base64: ceil(29 * 4/3) = 39 characters (legacy), 40+ characters (v1 with version byte)
  */
 export function looksEncrypted(value: string): boolean {
-  // Encrypted data will be at least 20 characters (12 bytes IV + some ciphertext in base64)
+  // Minimum length check: base64 of at least 29 bytes (legacy) ≈ 20 chars
   if (value.length < 20) return false
-  // Check if it's valid URL-safe base64
+  // Must be valid URL-safe base64
   return /^[A-Za-z0-9_-]+$/.test(value)
 }
 


### PR DESCRIPTION
## Summary
- encrypt()が新v1フォーマットで出力: [version(1byte)] + [IV(12bytes)] + [ciphertext]
- decrypt()がバージョンバイトで自動判別: v1→直接復号、レガシー→既存フォールバックロジック
- looksEncrypted()のコメント改善（ロジック自体は維持）
- 後方互換性を完全に維持（レガシーデータの復号は一切影響なし）

## 後方互換性
- レガシーフォーマット（バージョンバイトなし）は引き続き正常に復号される
- v1フォーマットのデータは旧バージョンのコードでは復号できない（一方向移行）
- 既存の全暗号化テスト（encrypt-helpers含む）がパス

## Test plan
- [x] v1フォーマットのバージョンバイト確認テスト
- [x] v1 encrypt→decrypt往復テスト
- [x] レガシーフォーマットの手動構築→decrypt成功テスト
- [x] v1で数値/オブジェクト/Unicode往復テスト
- [x] 不正キーでの復号失敗テスト
- [x] 既存テスト全パス（270 passed、+7新規テスト）

Closes #112