### PR TITLE
docs: clarify admin role verification layers in proxy comments

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -92,7 +92,10 @@ export async function proxy(request: NextRequest) {
       signInUrl.searchParams.set('callbackUrl', pathname)
       return NextResponse.redirect(signInUrl)
     }
-    // Detailed admin role check is done in the page component
+    // Admin role (isAdmin) is verified in:
+    // - Page component: src/app/admin/page.tsx (auth() + isAdmin check)
+    // - API layer: src/app/api/admin/*/route.ts (session.user.isAdmin check)
+    // JWT decoding in proxy is avoided to prevent NextAuth internal dependency
     return NextResponse.next()
   }
 


### PR DESCRIPTION
## Summary
proxy.tsのadminルート保護コメントを改善し、adminロール検証が行われる全レイヤーを明記:
- Page component: `src/app/admin/page.tsx` (auth() + isAdmin)
- API layer: `src/app/api/admin/*/route.ts` (session.user.isAdmin)
- JWT decoding in proxyは見送り（NextAuth内部実装への依存回避）

proxy層でのJWTデコードは壊れやすく、sessionToken存在チェック（PR #116）+ ページ/API層のisAdminチェックで二重防御が確立されている。

## Test plan
- [x] 全テスト合格 (275 passed)

Closes #126