### PR TITLE
fix(security): bound expenseDate and cap recurring generation per run

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -553,6 +553,10 @@ export async function logActivity(
 }
 
 const MAX_RETRY_COUNT = 3
+// Maximum recurring expenses to generate per link per single invocation (Issue #133)
+// Prevents DoS via past-dated recurring expenses with frequent rules (e.g. DAILY).
+// Subsequent invocations will continue processing where this run left off.
+export const MAX_GENERATIONS_PER_RUN = 100
 
 async function createRecurringExpenses() {
   const localDate = new Date() // Current local date
@@ -596,8 +600,19 @@ async function createRecurringExpenses() {
 
     let currentExpenseRecord = recurringExpenseLink.currentFrameExpense
     let currentReccuringExpenseLinkId = recurringExpenseLink.id
+    let generationsForThisLink = 0
 
     while (newExpenseDate < utcDateFromLocal) {
+      // Cap per-link generation to prevent runaway expense creation (Issue #133)
+      if (generationsForThisLink >= MAX_GENERATIONS_PER_RUN) {
+        console.warn(
+          'Reached MAX_GENERATIONS_PER_RUN (%d) for recurringExpenseLink %s; deferring remaining generations',
+          MAX_GENERATIONS_PER_RUN,
+          currentReccuringExpenseLinkId,
+        )
+        break
+      }
+
       const newExpenseId = randomId()
       const newRecurringExpenseLinkId = randomId()
 
@@ -709,6 +724,7 @@ async function createRecurringExpenses() {
       currentExpenseRecord = newExpense
       currentReccuringExpenseLinkId = newRecurringExpenseLinkId
       newExpenseDate = newRecurringExpenseNextExpenseDate
+      generationsForThisLink++
     }
   }
 }

--- a/src/lib/schemas.test.ts
+++ b/src/lib/schemas.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for schema-level bounds enforcement (Issue #133)
+ */
+
+import {
+  EXPENSE_DATE_MAX_YEARS_FUTURE,
+  EXPENSE_DATE_MIN_YEARS_PAST,
+  expenseFormSchema,
+} from './schemas'
+
+const MS_PER_YEAR = 365 * 24 * 60 * 60 * 1000
+
+// Helper to build a minimal valid input
+function makeBaseExpense(overrides: Record<string, unknown> = {}) {
+  return {
+    title: 'lunch',
+    amount: 1000,
+    paidBy: 'p1',
+    paidFor: [{ participant: 'p1', shares: 1 }],
+    splitMode: 'EVENLY',
+    saveDefaultSplittingOptions: false,
+    isReimbursement: false,
+    documents: [],
+    notes: undefined,
+    recurrenceRule: 'NONE',
+    category: 0,
+    ...overrides,
+  }
+}
+
+describe('expenseFormSchema expenseDate bounds (Issue #133)', () => {
+  it('accepts current date', () => {
+    const result = expenseFormSchema.safeParse(
+      makeBaseExpense({ expenseDate: new Date() }),
+    )
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts date 1 year in the past', () => {
+    const oneYearAgo = new Date(Date.now() - MS_PER_YEAR)
+    const result = expenseFormSchema.safeParse(
+      makeBaseExpense({ expenseDate: oneYearAgo }),
+    )
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts date near the past boundary', () => {
+    const nearBoundary = new Date(
+      Date.now() - (EXPENSE_DATE_MIN_YEARS_PAST - 0.01) * MS_PER_YEAR,
+    )
+    const result = expenseFormSchema.safeParse(
+      makeBaseExpense({ expenseDate: nearBoundary }),
+    )
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects date too far in the past', () => {
+    const tooOld = new Date(
+      Date.now() - (EXPENSE_DATE_MIN_YEARS_PAST + 1) * MS_PER_YEAR,
+    )
+    const result = expenseFormSchema.safeParse(
+      makeBaseExpense({ expenseDate: tooOld }),
+    )
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const dateIssue = result.error.issues.find((i) =>
+        i.path.includes('expenseDate'),
+      )
+      expect(dateIssue?.message).toBe('expenseDateTooOld')
+    }
+  })
+
+  it('rejects date 10 years in the past (DoS prevention)', () => {
+    const tenYearsAgo = new Date(Date.now() - 10 * MS_PER_YEAR)
+    const result = expenseFormSchema.safeParse(
+      makeBaseExpense({ expenseDate: tenYearsAgo }),
+    )
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts date within future bound', () => {
+    const sixMonthsFromNow = new Date(Date.now() + MS_PER_YEAR / 2)
+    const result = expenseFormSchema.safeParse(
+      makeBaseExpense({ expenseDate: sixMonthsFromNow }),
+    )
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects date too far in the future', () => {
+    const tooFuture = new Date(
+      Date.now() + (EXPENSE_DATE_MAX_YEARS_FUTURE + 1) * MS_PER_YEAR,
+    )
+    const result = expenseFormSchema.safeParse(
+      makeBaseExpense({ expenseDate: tooFuture }),
+    )
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      const dateIssue = result.error.issues.find((i) =>
+        i.path.includes('expenseDate'),
+      )
+      expect(dateIssue?.message).toBe('expenseDateTooFuture')
+    }
+  })
+
+  it('coerces ISO date strings within bounds', () => {
+    const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000)
+    const result = expenseFormSchema.safeParse(
+      makeBaseExpense({ expenseDate: yesterday.toISOString() }),
+    )
+    expect(result.success).toBe(true)
+  })
+})

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -60,9 +60,28 @@ const encryptableNumber = z.union([
   z.string(), // Encrypted string or numeric string
 ])
 
+// expenseDate bounds to prevent abuse via recurring expense generation (Issue #133)
+// - Past: 5 years from now (generous enough for tax-year retro entries)
+// - Future: 1 year from now (allows annual recurring scheduling)
+export const EXPENSE_DATE_MIN_YEARS_PAST = 5
+export const EXPENSE_DATE_MAX_YEARS_FUTURE = 1
+const MS_PER_YEAR = 365 * 24 * 60 * 60 * 1000
+
 export const expenseFormSchema = z
   .object({
-    expenseDate: z.coerce.date(),
+    expenseDate: z.coerce
+      .date()
+      .refine(
+        (d) =>
+          d.getTime() >= Date.now() - EXPENSE_DATE_MIN_YEARS_PAST * MS_PER_YEAR,
+        'expenseDateTooOld',
+      )
+      .refine(
+        (d) =>
+          d.getTime() <=
+          Date.now() + EXPENSE_DATE_MAX_YEARS_FUTURE * MS_PER_YEAR,
+        'expenseDateTooFuture',
+      ),
     title: z.string({ required_error: 'titleRequired' }).min(2, 'min2'),
     // Category can be number (form input) or encrypted string (Issue #19 - E2EE)
     category: z.union([z.number(), z.string()]).default(0),


### PR DESCRIPTION
Closes #133

## Summary
- The Zod schema for `expenseDate` had no bounds. Combined with `createRecurringExpenses` unconditionally filling the gap from `nextExpenseDate` to "now", a user could submit a multi-year-old expense with a DAILY recurrence and generate thousands of rows in one request.
- Two layers of protection are added:
  1. Schema bounds on `expenseDate`: dynamic refine checks reject dates more than 5 years in the past or 1 year in the future. Bounds are computed at validation time so they remain relative to "now" across long-lived processes.
  2. Per-link cap (`MAX_GENERATIONS_PER_RUN = 100`) in `createRecurringExpenses`. Remaining generations carry over to subsequent invocations, preserving correctness while preventing DoS on legacy or abusive data.

## Backward compatibility
- Existing DB rows are untouched; bounds apply only to new submissions via `expenseFormSchema`.
- Realistic use cases (tax year backfill, annual subscription scheduling) fit comfortably inside the chosen window.
- For legacy recurring links whose `nextExpenseDate` is far in the past, generation continues on every invocation, just capped at 100 per run. Eventually consistent.

## Test plan
- [x] New `src/lib/schemas.test.ts` (8 cases): current date, 1y past, near-past-boundary, beyond-past-boundary, 10y past (DoS scenario), within future bound, beyond future bound, ISO string coercion.
- [x] `npx jest` — 297/297 passing (8 new + 289 existing).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx prettier -c src` — clean.