### PR TITLE
fix(security): authenticate export endpoints and escape CSV cells

### DIFF
--- a/src/app/groups/[groupId]/expenses/export/csv/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/csv/route.ts
@@ -1,5 +1,8 @@
 import { getCategoryInfo } from '@/app/groups/[groupId]/expenses/category-icon'
+import { auth } from '@/lib/auth'
+import { escapeCsvCell, escapeCsvRow } from '@/lib/csv-injection'
 import { getCurrency } from '@/lib/currency'
+import { env } from '@/lib/env'
 import {
   formatAmountAsDecimal,
   getCurrencyFromGroup,
@@ -31,6 +34,31 @@ export async function GET(
   req: Request,
   { params }: { params: Promise<{ groupId: string }> },
 ) {
+  // Require authentication in private instance mode (Issue #136).
+  // Public instances retain the share-by-URL model (group access is gated
+  // by the encryption key in the URL fragment).
+  if (env.PRIVATE_INSTANCE) {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 },
+      )
+    }
+    if (session.user.requiresTwoFactor) {
+      return NextResponse.json(
+        { error: 'Two-factor authentication required' },
+        { status: 401 },
+      )
+    }
+    if (session.user.mustChangePassword) {
+      return NextResponse.json(
+        { error: 'Password change required' },
+        { status: 403 },
+      )
+    }
+  }
+
   const { groupId } = await params
   const group = await prisma.group.findUnique({
     where: { id: groupId },
@@ -88,6 +116,10 @@ export async function GET(
 
   */
 
+  // Escape user-provided participant names in the column headers as well to
+  // prevent formula injection via header rows (Issue #136). The value key
+  // still uses the raw name so json2csv can look up the corresponding cell
+  // in each row.
   const fields = [
     { label: 'Date', value: 'date' },
     { label: 'Description', value: 'title' },
@@ -100,7 +132,7 @@ export async function GET(
     { label: 'Is Reimbursement', value: 'isReimbursement' },
     { label: 'Split mode', value: 'splitMode' },
     ...group.participants.map((participant) => ({
-      label: participant.name,
+      label: escapeCsvCell(participant.name) as string,
       value: participant.name,
     })),
   ]
@@ -110,7 +142,7 @@ export async function GET(
   const expenses = group.expenses.map((expense) => {
     const expenseAmount = toNumber(expense.amount)
 
-    return {
+    return escapeCsvRow({
       date: formatDate(expense.expenseDate),
       title: expense.title,
       categoryName: getCategoryInfo(expense.categoryId)?.name || '',
@@ -153,7 +185,7 @@ export async function GET(
           ]
         }),
       ),
-    }
+    })
   })
 
   const json2csvParser = new Parser({ fields })

--- a/src/app/groups/[groupId]/expenses/export/json/route.ts
+++ b/src/app/groups/[groupId]/expenses/export/json/route.ts
@@ -1,3 +1,5 @@
+import { auth } from '@/lib/auth'
+import { env } from '@/lib/env'
 import { prisma } from '@/lib/prisma'
 import contentDisposition from 'content-disposition'
 import { NextResponse } from 'next/server'
@@ -6,6 +8,30 @@ export async function GET(
   req: Request,
   { params }: { params: Promise<{ groupId: string }> },
 ) {
+  // Require authentication in private instance mode (Issue #136). Public
+  // instances still use the share-by-URL model (encryption key in fragment).
+  if (env.PRIVATE_INSTANCE) {
+    const session = await auth()
+    if (!session?.user) {
+      return NextResponse.json(
+        { error: 'Authentication required' },
+        { status: 401 },
+      )
+    }
+    if (session.user.requiresTwoFactor) {
+      return NextResponse.json(
+        { error: 'Two-factor authentication required' },
+        { status: 401 },
+      )
+    }
+    if (session.user.mustChangePassword) {
+      return NextResponse.json(
+        { error: 'Password change required' },
+        { status: 403 },
+      )
+    }
+  }
+
   const { groupId } = await params
   const group = await prisma.group.findUnique({
     where: { id: groupId },

--- a/src/lib/csv-injection.test.ts
+++ b/src/lib/csv-injection.test.ts
@@ -1,0 +1,92 @@
+import { escapeCsvCell, escapeCsvRow } from './csv-injection'
+
+describe('escapeCsvCell', () => {
+  describe('dangerous prefixes (Issue #136)', () => {
+    it('prepends single quote to cells starting with =', () => {
+      expect(escapeCsvCell('=cmd|"/c calc"!A1')).toBe('\'=cmd|"/c calc"!A1')
+      expect(escapeCsvCell('=SUM(A1:A2)')).toBe("'=SUM(A1:A2)")
+    })
+
+    it('prepends single quote to cells starting with +', () => {
+      expect(escapeCsvCell('+1+1')).toBe("'+1+1")
+    })
+
+    it('prepends single quote to cells starting with -', () => {
+      expect(escapeCsvCell('-2+3')).toBe("'-2+3")
+    })
+
+    it('prepends single quote to cells starting with @', () => {
+      expect(escapeCsvCell('@SUM(A1)')).toBe("'@SUM(A1)")
+    })
+
+    it('prepends single quote to cells starting with tab', () => {
+      expect(escapeCsvCell('\tmalicious')).toBe("'\tmalicious")
+    })
+
+    it('prepends single quote to cells starting with carriage return', () => {
+      expect(escapeCsvCell('\rfoo')).toBe("'\rfoo")
+    })
+  })
+
+  describe('benign values', () => {
+    it('returns plain strings unchanged', () => {
+      expect(escapeCsvCell('hello world')).toBe('hello world')
+      expect(escapeCsvCell('1000')).toBe('1000')
+      expect(escapeCsvCell('Coffee')).toBe('Coffee')
+    })
+
+    it('returns empty string unchanged', () => {
+      expect(escapeCsvCell('')).toBe('')
+    })
+
+    it('preserves strings with dangerous chars not at the start', () => {
+      expect(escapeCsvCell('a=b')).toBe('a=b')
+      expect(escapeCsvCell('foo+bar')).toBe('foo+bar')
+    })
+
+    it('returns non-string values unchanged', () => {
+      expect(escapeCsvCell(42)).toBe(42)
+      expect(escapeCsvCell(null)).toBe(null)
+      expect(escapeCsvCell(undefined)).toBe(undefined)
+      expect(escapeCsvCell(true)).toBe(true)
+      const d = new Date('2026-01-01')
+      expect(escapeCsvCell(d)).toBe(d)
+    })
+  })
+
+  describe('encrypted base64 strings (typical app payload)', () => {
+    // Encrypted values start with the first base64 character of the version
+    // byte (0x01 -> 'A' in URL-safe base64). They should not trigger escape.
+    it('does not escape typical encrypted base64 starting with A', () => {
+      expect(escapeCsvCell('AY8xK9z2vQR0aB7c')).toBe('AY8xK9z2vQR0aB7c')
+    })
+  })
+})
+
+describe('escapeCsvRow', () => {
+  it('escapes string fields and preserves numeric ones', () => {
+    const row = {
+      title: '=cmd|calc',
+      amount: 1000,
+      currency: 'USD',
+      malicious: '@SUM(A1)',
+      empty: '',
+      nullField: null,
+    }
+    expect(escapeCsvRow(row)).toEqual({
+      title: "'=cmd|calc",
+      amount: 1000,
+      currency: 'USD',
+      malicious: "'@SUM(A1)",
+      empty: '',
+      nullField: null,
+    })
+  })
+
+  it('does not mutate the original row', () => {
+    const row = { title: '=evil', amount: 5 }
+    const escaped = escapeCsvRow(row)
+    expect(row.title).toBe('=evil')
+    expect(escaped.title).toBe("'=evil")
+  })
+})

--- a/src/lib/csv-injection.ts
+++ b/src/lib/csv-injection.ts
@@ -1,0 +1,40 @@
+/**
+ * CSV Injection (formula injection) prevention helpers (Issue #136)
+ *
+ * Spreadsheet applications (Excel, LibreOffice Calc, Google Sheets) may
+ * interpret cells whose first character is one of `=`, `+`, `-`, `@`,
+ * `\t`, or `\r` as formulas or commands. If user-controlled strings are
+ * exported verbatim to CSV, opening the file can trigger code execution
+ * or data exfiltration via spreadsheet features (e.g. `=cmd|'...'`).
+ *
+ * Mitigation: prepend a single quote (`'`) to any value that starts with
+ * one of these characters. The quote is the standard "text override"
+ * marker recognized by major spreadsheet applications.
+ *
+ * Reference: OWASP "CSV Injection" page.
+ */
+
+const DANGEROUS_PREFIX_CHARS = new Set(['=', '+', '-', '@', '\t', '\r'])
+
+/**
+ * Escape a single CSV cell value to prevent formula injection.
+ * Returns non-string values unchanged.
+ */
+export function escapeCsvCell<T>(value: T): T | string {
+  if (typeof value !== 'string' || value.length === 0) return value
+  if (DANGEROUS_PREFIX_CHARS.has(value[0])) {
+    return `'${value}`
+  }
+  return value
+}
+
+/**
+ * Return a shallow copy of `row` with every string field escaped.
+ */
+export function escapeCsvRow<T extends Record<string, unknown>>(row: T): T {
+  const result: Record<string, unknown> = {}
+  for (const [key, value] of Object.entries(row)) {
+    result[key] = escapeCsvCell(value)
+  }
+  return result as T
+}


### PR DESCRIPTION
Closes #136

## Summary
- The CSV and JSON export routes for a group's expenses were reachable with only the groupId — no authentication in private-instance mode and no formula-injection protection in the CSV output.
- Private-instance mode now requires an authenticated session for both `/expenses/export/csv` and `/expenses/export/json`. Sessions that still require 2FA or a password change are rejected with the appropriate status code, mirroring `publicProcedure` semantics from tRPC.
- New `escapeCsvCell` / `escapeCsvRow` helpers prefix any string cell starting with `=`, `+`, `-`, `@`, tab, or carriage return with a single quote, per OWASP CSV Injection guidance. Both data rows and participant-name column headers are escaped.

## Backward compatibility
- Public-instance mode is unchanged: groups remain accessible via the share-by-URL model (encryption key in the URL fragment).
- Benign export contents (numeric amounts, dates, plain titles, encrypted base64 payloads) are unaffected — the escape only triggers when a cell **starts** with one of the dangerous prefix characters.
- Issue #131 (decrypt exports client-side) remains a separate concern; this PR only fixes auth and CSV injection.

## Test plan
- [x] New `src/lib/csv-injection.test.ts` (13 cases): all 6 dangerous prefixes, benign values (plain strings, numbers, null, dates, empty), mid-string dangerous chars, encrypted base64 payloads.
- [x] `npx jest` — 310/310 passing (13 new + 297 existing).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx prettier -c src` — clean.
- [ ] Post-merge: verify export returns 401 in private mode without session, 200 with session.