### PR TITLE
fix(security): clear lastTwoFactorVerifiedAt on 2FA disable (closes #139)

### DIFF
--- a/src/app/api/2fa/disable/route.ts
+++ b/src/app/api/2fa/disable/route.ts
@@ -201,6 +201,7 @@ export async function POST(request: Request) {
           twoFactorEnabled: false,
           twoFactorSecret: null,
           twoFactorBackupCodes: null,
+          lastTwoFactorVerifiedAt: null,
         },
       })
     } else {
@@ -210,6 +211,7 @@ export async function POST(request: Request) {
           twoFactorEnabled: false,
           twoFactorSecret: null,
           twoFactorBackupCodes: null,
+          lastTwoFactorVerifiedAt: null,
         },
       })
     }


### PR DESCRIPTION
## Summary
Fixes security issue #139: `lastTwoFactorVerifiedAt` is not cleared when 2FA is disabled.

## Problem
When 2FA is disabled via `/api/2fa/disable`, the `lastTwoFactorVerifiedAt` field is not cleared. If the user immediately re-enables 2FA and goes through setup, the 5-minute verification window from the previous session could be reused.

## Fix
Added `lastTwoFactorVerifiedAt: null` to both the `admin` and `whitelistUser` update blocks in the disable route.

## Testing
- Disable 2FA → verify `lastTwoFactorVerifiedAt` is cleared
- Immediately re-enable 2FA → requires fresh TOTP verification (no reuse)
- No breaking changes to existing functionality

Closes #139