### PR TITLE
fix(security): block 2FA setup re-init when already enabled (closes #140)

### DIFF
--- a/src/app/api/2fa/setup/route.ts
+++ b/src/app/api/2fa/setup/route.ts
@@ -29,6 +29,17 @@ export async function POST() {
     const isAdmin = session.user.isAdmin
     const userEmail = session.user.email
 
+    // Check if 2FA is already enabled — prevent re-init overwrite
+    const existingUser = isAdmin
+      ? await prisma.admin.findUnique({ where: { id: userId } })
+      : await prisma.whitelistUser.findUnique({ where: { id: userId } })
+    if (existingUser?.twoFactorEnabled) {
+      return NextResponse.json(
+        { error: '2FA is already enabled. Disable it first before re-initializing.' },
+        { status: 400 }
+      )
+    }
+
     // 2. Generate TOTP secret
     const { secret, otpauthUrl } = generateTOTPSecret(userEmail)
 


### PR DESCRIPTION
## Summary
Fixes security issue #140: 2FA setup endpoint does not check if 2FA is already enabled, allowing overwrite of existing secrets.

## Problem
When 2FA is already enabled, calling `/api/2fa/setup` would overwrite the existing `twoFactorSecret` and `twoFactorBackupCodes` with new values, potentially causing self-lockout.

## Fix
Added a check before setup: if `twoFactorEnabled` is already true, return a 400 error instructing the user to disable 2FA first.

## Testing
- 2FA disabled → setup works normally
- 2FA enabled → setup returns 400 "2FA is already enabled"
- After disabling 2FA → setup works again

Closes #140