### PR TITLE
fix(security): enforce mustChangePassword in 2FA REST routes (closes #142)

### DIFF
--- a/src/app/api/2fa/disable/route.ts
+++ b/src/app/api/2fa/disable/route.ts
@@ -33,6 +33,14 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
+    // Enforce password change before allowing 2FA operations
+    if (session.user.mustChangePassword) {
+      return NextResponse.json(
+        { error: 'You must change your password before managing 2FA' },
+        { status: 403 },
+      )
+    }
+
     const userId = session.user.id
     const isAdmin = session.user.isAdmin
 

--- a/src/app/api/2fa/setup/route.ts
+++ b/src/app/api/2fa/setup/route.ts
@@ -25,6 +25,14 @@ export async function POST() {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
+    // Enforce password change before allowing 2FA operations
+    if (session.user.mustChangePassword) {
+      return NextResponse.json(
+        { error: 'You must change your password before managing 2FA' },
+        { status: 403 },
+      )
+    }
+
     const userId = session.user.id
     const isAdmin = session.user.isAdmin
     const userEmail = session.user.email

--- a/src/app/api/2fa/verify-setup/route.ts
+++ b/src/app/api/2fa/verify-setup/route.ts
@@ -25,6 +25,14 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
+    // Enforce password change before allowing 2FA operations
+    if (session.user.mustChangePassword) {
+      return NextResponse.json(
+        { error: 'You must change your password before managing 2FA' },
+        { status: 403 },
+      )
+    }
+
     // 2. Accept { token } in request body
     const body = (await request.json()) as {
       token?: string


### PR DESCRIPTION
## Summary
Fixes #142: enforces mustChangePassword flag in 2FA REST API routes.

## Problem
The mustChangePassword enforcement only existed in tRPC middleware. REST API routes for 2FA (setup, verify-setup, disable) were accessible even when the user was required to change their password first, bypassing the client-side PasswordChangeGuard.

## Fix
Added mustChangePassword check returning 403 in:
- POST /api/2fa/setup
- POST /api/2fa/verify-setup
- POST /api/2fa/disable

## Testing
- User with mustChangePassword=true → 2FA operations return 403
- User with mustChangePassword=false → 2FA operations work normally

Closes #142