### PR TITLE
fix(security): invalidate sessions on password change via passwordChangedAt

### DIFF
--- a/prisma/migrations/20260511020000_add_password_changed_at/migration.sql
+++ b/prisma/migrations/20260511020000_add_password_changed_at/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "Admin" ADD COLUMN "passwordChangedAt" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "WhitelistUser" ADD COLUMN "passwordChangedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -169,6 +169,7 @@ model Admin {
   twoFactorSecret           String?   // Encrypted TOTP secret
   twoFactorBackupCodes      String?   // JSON array of encrypted backup codes
   lastTwoFactorVerifiedAt   DateTime? // Server-side 2FA verification timestamp (Issue #123)
+  passwordChangedAt         DateTime? // Set on password change to invalidate prior JWTs (Issue #135)
   createdAt                 DateTime  @default(now())
   updatedAt                 DateTime  @updatedAt
 }
@@ -183,6 +184,7 @@ model WhitelistUser {
   twoFactorSecret           String?   // Encrypted TOTP secret
   twoFactorBackupCodes      String?   // JSON array of encrypted backup codes
   lastTwoFactorVerifiedAt   DateTime? // Server-side 2FA verification timestamp (Issue #123)
+  passwordChangedAt         DateTime? // Set on password change to invalidate prior JWTs (Issue #135)
   addedById                 String    // Admin who added this user
   createdAt                 DateTime  @default(now())
 }

--- a/src/app/api/auth/change-password/route.ts
+++ b/src/app/api/auth/change-password/route.ts
@@ -108,13 +108,16 @@ export async function POST(request: Request) {
     // Hash new password
     const hashedPassword = await bcrypt.hash(newPassword, 12)
 
-    // Update password and clear mustChangePassword flag
+    // Update password and clear mustChangePassword flag.
+    // Set passwordChangedAt to invalidate all JWTs issued before now (Issue #135).
+    const now = new Date()
     if (isAdmin) {
       await prisma.admin.update({
         where: { id: userId },
         data: {
           password: hashedPassword,
           mustChangePassword: false,
+          passwordChangedAt: now,
         },
       })
     } else {
@@ -123,6 +126,7 @@ export async function POST(request: Request) {
         data: {
           password: hashedPassword,
           mustChangePassword: false,
+          passwordChangedAt: now,
         },
       })
     }

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -8,6 +8,7 @@ import {
   clearAttempts,
   recordFailedAttempt,
 } from '@/lib/rate-limit'
+import { isJwtValidForUser } from '@/lib/session-validation'
 import { PrismaAdapter } from '@auth/prisma-adapter'
 import bcrypt from 'bcryptjs'
 import NextAuth, { type NextAuthConfig } from 'next-auth'
@@ -191,11 +192,31 @@ const authConfig: NextAuthConfig = {
           }
         }
       }
+
+      // Invalidate the token if the user's password has been changed since the
+      // token was issued (Issue #135). The check runs on every JWT callback,
+      // backed by a single indexed DB lookup. Users that never changed their
+      // password since the migration have `passwordChangedAt = null` and are
+      // unaffected.
+      if (token.sub && typeof token.iat === 'number') {
+        const isAdmin = (token as Record<string, unknown>).isAdmin === true
+        const ok = await isJwtValidForUser(token.sub, isAdmin, token.iat)
+        if (!ok) {
+          // Return a token without `sub` so the session callback rejects it.
+          return { ...token, sub: undefined }
+        }
+      }
+
       return token
     },
     async session({ session, token }) {
+      // Token sub is cleared by the jwt callback when the token has been
+      // invalidated (e.g. password changed after issuance, Issue #135).
+      // Returning the session with no user.id causes downstream auth checks
+      // (publicProcedure, adminProcedure, route guards) to treat the request
+      // as unauthenticated.
       if (session.user) {
-        session.user.id = token.sub as string
+        session.user.id = (token.sub as string) ?? ''
         session.user.isAdmin =
           ((token as Record<string, unknown>).isAdmin as boolean) ?? false
         session.user.mustChangePassword =

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -197,26 +197,41 @@ const authConfig: NextAuthConfig = {
       // token was issued (Issue #135). The check runs on every JWT callback,
       // backed by a single indexed DB lookup. Users that never changed their
       // password since the migration have `passwordChangedAt = null` and are
-      // unaffected.
+      // unaffected. When invalid, we clear the auth-relevant fields so the
+      // session callback yields a session without a user id, which causes
+      // downstream guards (publicProcedure, adminProcedure, route handlers)
+      // that test `session?.user?.id` to treat the request as unauthenticated.
       if (token.sub && typeof token.iat === 'number') {
         const isAdmin = (token as Record<string, unknown>).isAdmin === true
         const ok = await isJwtValidForUser(token.sub, isAdmin, token.iat)
         if (!ok) {
-          // Return a token without `sub` so the session callback rejects it.
-          return { ...token, sub: undefined }
+          return {
+            // Preserve only the bare token shell; strip identity and roles.
+            ...token,
+            sub: undefined,
+            isAdmin: false,
+            mustChangePassword: false,
+            twoFactorEnabled: false,
+            requiresTwoFactor: false,
+          } as typeof token
         }
       }
 
       return token
     },
     async session({ session, token }) {
-      // Token sub is cleared by the jwt callback when the token has been
-      // invalidated (e.g. password changed after issuance, Issue #135).
-      // Returning the session with no user.id causes downstream auth checks
-      // (publicProcedure, adminProcedure, route guards) to treat the request
-      // as unauthenticated.
+      // When the jwt callback invalidates a token (e.g. password changed after
+      // issuance, Issue #135), `token.sub` is cleared. We drop `session.user`
+      // entirely so callers that inspect either `session?.user` or
+      // `session?.user?.id` see no authenticated user.
+      if (!token.sub) {
+        return {
+          ...session,
+          user: undefined,
+        } as unknown as typeof session
+      }
       if (session.user) {
-        session.user.id = (token.sub as string) ?? ''
+        session.user.id = token.sub as string
         session.user.isAdmin =
           ((token as Record<string, unknown>).isAdmin as boolean) ?? false
         session.user.mustChangePassword =

--- a/src/lib/session-validation.test.ts
+++ b/src/lib/session-validation.test.ts
@@ -1,0 +1,66 @@
+import { isTokenIatAcceptable } from './session-validation'
+
+describe('isTokenIatAcceptable (Issue #135)', () => {
+  const tokenIat = 1_700_000_000 // arbitrary seconds-since-epoch
+  const tokenIatMs = tokenIat * 1000
+
+  describe('passwordChangedAt is null/undefined', () => {
+    it('accepts any token when passwordChangedAt is null', () => {
+      expect(isTokenIatAcceptable(tokenIat, null)).toBe(true)
+    })
+
+    it('accepts any token when passwordChangedAt is undefined', () => {
+      expect(isTokenIatAcceptable(tokenIat, undefined)).toBe(true)
+    })
+
+    it('accepts token without iat when passwordChangedAt is null', () => {
+      expect(isTokenIatAcceptable(undefined, null)).toBe(true)
+    })
+  })
+
+  describe('passwordChangedAt is set', () => {
+    it('accepts token issued after password change', () => {
+      const passwordChangedAt = new Date(tokenIatMs - 1000) // 1s before token
+      expect(isTokenIatAcceptable(tokenIat, passwordChangedAt)).toBe(true)
+    })
+
+    it('accepts token issued exactly at password change time', () => {
+      const passwordChangedAt = new Date(tokenIatMs)
+      expect(isTokenIatAcceptable(tokenIat, passwordChangedAt)).toBe(true)
+    })
+
+    it('rejects token issued before password change', () => {
+      const passwordChangedAt = new Date(tokenIatMs + 1000) // 1s after token
+      expect(isTokenIatAcceptable(tokenIat, passwordChangedAt)).toBe(false)
+    })
+
+    it('rejects token issued well before password change', () => {
+      const passwordChangedAt = new Date(tokenIatMs + 86400_000) // 1 day after
+      expect(isTokenIatAcceptable(tokenIat, passwordChangedAt)).toBe(false)
+    })
+
+    it('rejects token without iat when passwordChangedAt is set', () => {
+      const passwordChangedAt = new Date(tokenIatMs)
+      expect(isTokenIatAcceptable(undefined, passwordChangedAt)).toBe(false)
+    })
+  })
+
+  describe('attack scenarios', () => {
+    it('rejects a stolen JWT issued before the legitimate password change', () => {
+      // Attacker stole token at time T
+      // User changed password at time T+1h
+      // Attacker's request comes after the password change
+      const stolenIat = 1_700_000_000 // T (seconds)
+      const passwordChangedAt = new Date((stolenIat + 3600) * 1000) // T+1h
+      expect(isTokenIatAcceptable(stolenIat, passwordChangedAt)).toBe(false)
+    })
+
+    it('continues to honour fresh tokens after password change', () => {
+      // User changes password at T, then logs back in at T+5min, getting a
+      // fresh token. The fresh token should remain valid.
+      const passwordChangedAt = new Date(1_700_000_000 * 1000) // T
+      const freshIat = 1_700_000_000 + 300 // T+5min (seconds)
+      expect(isTokenIatAcceptable(freshIat, passwordChangedAt)).toBe(true)
+    })
+  })
+})

--- a/src/lib/session-validation.ts
+++ b/src/lib/session-validation.ts
@@ -1,0 +1,68 @@
+/**
+ * Session validation helpers for invalidating JWTs after password change (Issue #135)
+ *
+ * When a user changes their password, all previously-issued JWTs should be
+ * rejected so a stolen token cannot continue to be used. This is achieved by:
+ *  1. Storing `passwordChangedAt` on the user record at password change time.
+ *  2. On every JWT validation, comparing the token's `iat` (issued-at) with
+ *     the user's current `passwordChangedAt`. If the token predates the
+ *     password change, it is considered invalid.
+ *
+ * Backward compatibility: users that have never changed their password since
+ * this column was added have `passwordChangedAt = null`, in which case the
+ * check always passes (no constraint).
+ */
+
+import { prisma } from './prisma'
+
+/**
+ * Decide whether a JWT remains valid given the user's `passwordChangedAt`.
+ *
+ * Pure function for testability — does not perform DB access.
+ *
+ * @param tokenIatSeconds - JWT `iat` claim (seconds since epoch)
+ * @param passwordChangedAt - User's `passwordChangedAt`, may be null
+ * @returns true if the token is still acceptable, false if it should be rejected
+ */
+export function isTokenIatAcceptable(
+  tokenIatSeconds: number | undefined,
+  passwordChangedAt: Date | null | undefined,
+): boolean {
+  // No constraint set => token always acceptable
+  if (!passwordChangedAt) return true
+  // Token without iat cannot be validated — reject conservatively
+  if (typeof tokenIatSeconds !== 'number') return false
+  return tokenIatSeconds * 1000 >= passwordChangedAt.getTime()
+}
+
+/**
+ * Look up the user's `passwordChangedAt` and decide whether the JWT is still
+ * acceptable. Queries only the table indicated by `isAdmin` to keep this a
+ * single indexed lookup per request.
+ */
+export async function isJwtValidForUser(
+  userId: string,
+  isAdmin: boolean,
+  tokenIatSeconds: number | undefined,
+): Promise<boolean> {
+  if (!userId) return false
+
+  let passwordChangedAt: Date | null = null
+  if (isAdmin) {
+    const admin = await prisma.admin.findUnique({
+      where: { id: userId },
+      select: { passwordChangedAt: true },
+    })
+    if (!admin) return false
+    passwordChangedAt = admin.passwordChangedAt
+  } else {
+    const user = await prisma.whitelistUser.findUnique({
+      where: { id: userId },
+      select: { passwordChangedAt: true },
+    })
+    if (!user) return false
+    passwordChangedAt = user.passwordChangedAt
+  }
+
+  return isTokenIatAcceptable(tokenIatSeconds, passwordChangedAt)
+}


### PR DESCRIPTION
Closes #135

## Summary
- A password change did not invalidate previously-issued JWTs. A stolen token retained validity for the full NextAuth maxAge window (~30 days) even after the legitimate user rotated the password.
- New nullable `passwordChangedAt` column on `Admin` and `WhitelistUser`. The change-password endpoint sets it on every successful rotation.
- `jwt` callback fetches the user's `passwordChangedAt` per request (single indexed lookup) and clears `token.sub` whenever the token's `iat` predates the timestamp; the `session` callback then yields an unauthenticated session, forcing re-authentication.
- Validation logic is isolated in `src/lib/session-validation.ts` and covered by 10 unit tests including the canonical stolen-token scenario.

## Backward compatibility
- Migration adds nullable columns; no existing rows are touched.
- Users who have never rotated their password since this deploy retain valid sessions (`passwordChangedAt = null` ⇒ no constraint).
- On the next password change, both the legitimate device and any compromised devices are forced to re-authenticate. This trades a small UX cost (re-sign-in on the current session) for security correctness.
- DB cost: one extra indexed `findUnique({where:{id}})` lookup per `auth()` call. Acceptable for the private-instance use case.

## Test plan
- [x] New `src/lib/session-validation.test.ts` (10 cases): null/undefined `passwordChangedAt`, exact boundary, before/after rotation, missing `iat`, two attack scenarios (stolen token rejected; fresh post-rotation token accepted).
- [x] `npx jest` — 320/320 passing (10 new + 310 existing).
- [x] `npx tsc --noEmit` — clean.
- [x] `npx prettier -c src` — clean.
- [x] Migration applies cleanly (Prisma schema validated, follow-up Vercel deploy will run it).
- [ ] Post-merge: confirm `prisma migrate deploy` succeeds, change password from the admin UI, observe that prior tokens return 401 on next request.