### PR TITLE
fix(security): enforce mustChangePassword in REST API routes

### DIFF
--- a/src/app/api/2fa/disable/route.ts
+++ b/src/app/api/2fa/disable/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { auth } from '@/lib/auth'
+import { passwordChangeRequiredResponse } from '@/lib/auth-helpers'
 import { prisma } from '@/lib/prisma'
 import {
   checkRateLimit,
@@ -32,6 +33,9 @@ export async function POST(request: Request) {
     if (!session?.user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const pwChangeResp = passwordChangeRequiredResponse(session)
+    if (pwChangeResp) return pwChangeResp
 
     const userId = session.user.id
     const isAdmin = session.user.isAdmin

--- a/src/app/api/2fa/setup/route.ts
+++ b/src/app/api/2fa/setup/route.ts
@@ -6,6 +6,7 @@
  */
 
 import { auth } from '@/lib/auth'
+import { passwordChangeRequiredResponse } from '@/lib/auth-helpers'
 import { prisma } from '@/lib/prisma'
 import {
   encryptBackupCodes,
@@ -24,6 +25,9 @@ export async function POST() {
     if (!session?.user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const pwChangeResp = passwordChangeRequiredResponse(session)
+    if (pwChangeResp) return pwChangeResp
 
     const userId = session.user.id
     const isAdmin = session.user.isAdmin

--- a/src/app/api/2fa/verify-setup/route.ts
+++ b/src/app/api/2fa/verify-setup/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { auth } from '@/lib/auth'
+import { passwordChangeRequiredResponse } from '@/lib/auth-helpers'
 import { prisma } from '@/lib/prisma'
 import {
   checkRateLimit,
@@ -24,6 +25,9 @@ export async function POST(request: Request) {
     if (!session?.user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const pwChangeResp = passwordChangeRequiredResponse(session)
+    if (pwChangeResp) return pwChangeResp
 
     // 2. Accept { token } in request body
     const body = (await request.json()) as {

--- a/src/app/api/admin/whitelist/[userId]/route.ts
+++ b/src/app/api/admin/whitelist/[userId]/route.ts
@@ -3,6 +3,7 @@
  */
 
 import { auth, isPrivateInstance } from '@/lib/auth'
+import { passwordChangeRequiredResponse } from '@/lib/auth-helpers'
 import { prisma } from '@/lib/prisma'
 import bcrypt from 'bcryptjs'
 import { randomBytes } from 'crypto'
@@ -35,6 +36,9 @@ export async function PATCH(
     if (!session?.user?.isAdmin) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const pwChangeResp = passwordChangeRequiredResponse(session)
+    if (pwChangeResp) return pwChangeResp
 
     // Check if user exists
     const user = await prisma.whitelistUser.findUnique({
@@ -88,6 +92,9 @@ export async function DELETE(
     if (!session?.user?.isAdmin) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const pwChangeResp = passwordChangeRequiredResponse(session)
+    if (pwChangeResp) return pwChangeResp
 
     // Check if user exists
     const user = await prisma.whitelistUser.findUnique({

--- a/src/app/api/admin/whitelist/route.ts
+++ b/src/app/api/admin/whitelist/route.ts
@@ -3,6 +3,7 @@
  */
 
 import { auth, isPrivateInstance } from '@/lib/auth'
+import { passwordChangeRequiredResponse } from '@/lib/auth-helpers'
 import { prisma } from '@/lib/prisma'
 import bcrypt from 'bcryptjs'
 import { randomBytes } from 'crypto'
@@ -31,6 +32,9 @@ export async function POST(request: Request) {
     if (!session?.user?.isAdmin) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const pwChangeResp = passwordChangeRequiredResponse(session)
+    if (pwChangeResp) return pwChangeResp
 
     const body = (await request.json()) as { email?: string; name?: string }
     const { email, name } = body
@@ -121,6 +125,9 @@ export async function GET() {
     if (!session?.user?.isAdmin) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const pwChangeResp = passwordChangeRequiredResponse(session)
+    if (pwChangeResp) return pwChangeResp
 
     const users = await prisma.whitelistUser.findMany({
       select: {

--- a/src/lib/auth-helpers.test.ts
+++ b/src/lib/auth-helpers.test.ts
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Tests for REST API authentication helpers (Issue #142)
+ */
+
+import type { Session } from 'next-auth'
+import { passwordChangeRequiredResponse } from './auth-helpers'
+
+function makeSession(overrides: Partial<Session['user']> = {}): Session {
+  return {
+    expires: '2099-01-01T00:00:00.000Z',
+    user: {
+      id: 'u1',
+      email: 'user@example.com',
+      isAdmin: false,
+      mustChangePassword: false,
+      twoFactorEnabled: false,
+      requiresTwoFactor: false,
+      ...overrides,
+    },
+  }
+}
+
+describe('passwordChangeRequiredResponse', () => {
+  it('returns null when session is null', () => {
+    expect(passwordChangeRequiredResponse(null)).toBeNull()
+  })
+
+  it('returns null when mustChangePassword is false', () => {
+    expect(
+      passwordChangeRequiredResponse(makeSession({ mustChangePassword: false })),
+    ).toBeNull()
+  })
+
+  it('returns 403 NextResponse when mustChangePassword is true', async () => {
+    const result = passwordChangeRequiredResponse(
+      makeSession({ mustChangePassword: true }),
+    )
+    expect(result).not.toBeNull()
+    expect(result?.status).toBe(403)
+    const body = await result!.json()
+    expect(body).toEqual({ error: 'Password change required' })
+  })
+
+  it('returns 403 for admin users too', async () => {
+    const result = passwordChangeRequiredResponse(
+      makeSession({ isAdmin: true, mustChangePassword: true }),
+    )
+    expect(result?.status).toBe(403)
+  })
+})

--- a/src/lib/auth-helpers.test.ts
+++ b/src/lib/auth-helpers.test.ts
@@ -31,7 +31,9 @@ describe('passwordChangeRequiredResponse', () => {
 
   it('returns null when mustChangePassword is false', () => {
     expect(
-      passwordChangeRequiredResponse(makeSession({ mustChangePassword: false })),
+      passwordChangeRequiredResponse(
+        makeSession({ mustChangePassword: false }),
+      ),
     ).toBeNull()
   })
 

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -1,0 +1,30 @@
+/**
+ * Authentication helpers for REST API route handlers.
+ *
+ * These helpers mirror the equivalent checks in tRPC procedures
+ * (`src/trpc/init.ts`) so REST API routes cannot be used to bypass them.
+ */
+
+import type { Session } from 'next-auth'
+import { NextResponse } from 'next/server'
+
+/**
+ * Returns a 403 NextResponse if the session indicates the user must change
+ * their password before performing other actions, or null otherwise.
+ *
+ * Mirrors the `mustChangePassword` check in publicProcedure / adminProcedure
+ * (Issue #142). The change-password endpoint and the pre-auth 2FA verify
+ * endpoint (which has no session) are intentionally exempt and should not
+ * call this helper.
+ */
+export function passwordChangeRequiredResponse(
+  session: Session | null,
+): NextResponse | null {
+  if (session?.user?.mustChangePassword) {
+    return NextResponse.json(
+      { error: 'Password change required' },
+      { status: 403 },
+    )
+  }
+  return null
+}


### PR DESCRIPTION
## Summary
- `mustChangePassword` の強制チェックが tRPC procedure (`src/trpc/init.ts`) にしか無く、REST API では未チェックだったため、クライアントの `PasswordChangeGuard` をバイパスすれば強制パスワード変更前に 2FA 設定や whitelist 操作等が可能だった (Issue #142)。
- 共通ヘルパー `src/lib/auth-helpers.ts#passwordChangeRequiredResponse` を追加。`session.user.mustChangePassword === true` なら 403 NextResponse を返し、それ以外は null を返す。
- 該当する保護 REST route 全てで、`auth()` の直後・処理本体の前に同ヘルパーを呼ぶ。

## 適用範囲

| Route | 方法 | 適用 |
|---|---|---|
| `/api/2fa/setup` | POST | ✅ |
| `/api/2fa/verify-setup` | POST | ✅ |
| `/api/2fa/disable` | POST | ✅ |
| `/api/admin/whitelist` | POST, GET | ✅ |
| `/api/admin/whitelist/[userId]` | PATCH, DELETE | ✅ |
| `/api/2fa/verify` | POST | ❌ 除外 (signin 前で session 無し) |
| `/api/auth/change-password` | POST | ❌ 除外 (フラグ解除自体の経路) |

## 整合性

tRPC 側 (`src/trpc/init.ts:70-75`, `:106-111`) と同じ:
- HTTP status: `403`
- Error message: `Password change required`

既存の export route 2 件 (`groups/[groupId]/expenses/export/{csv,json}/route.ts`) は #136 で個別チェック済。今回の helper をそちらにも展開するリファクタは scope 外。

## Test plan
- [x] `pnpm exec jest src/lib/auth-helpers.test.ts` — 4 件パス
- [x] `pnpm exec jest` 全体 — 310 件パス (regression 無し)
- [x] `pnpm lint` — error 0
- [x] `pnpm exec tsc --noEmit` — error 0
- [ ] 手動 (オプション): mustChangePassword=true のユーザーで上記 route を直接叩き 403 を確認

## 互換性

`mustChangePassword=false` のユーザーには無影響 (helper は null を返し既存処理が継続)。強制変更フラグが立ったユーザーは change-password 経由でフラグ解除可能なので dead-lock しない。

Closes #142