### PR TITLE
fix(security): clear lastTwoFactorVerifiedAt across 2FA lifecycle

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,6 +12,9 @@ const config: Config = {
   testEnvironment: 'jsdom',
   // Add more setup options before each test is run
   setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
 }
  
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/src/__tests__/two-factor-last-verified.test.ts
+++ b/src/__tests__/two-factor-last-verified.test.ts
@@ -1,0 +1,207 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Tests for `lastTwoFactorVerifiedAt` handling across 2FA REST routes
+ * (Issue #139). Prevents the jwt callback's 5-minute window from treating
+ * a stale verification timestamp as a fresh one after disable/re-setup.
+ */
+
+jest.mock('@/lib/auth', () => ({
+  auth: jest.fn(),
+  isPrivateInstance: jest.fn(() => true),
+}))
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    admin: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    whitelistUser: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('@/lib/two-factor', () => ({
+  generateTOTPSecret: jest.fn(() => ({
+    secret: 'SECRET',
+    otpauthUrl: 'otpauth://totp/x',
+  })),
+  generateQRCode: jest.fn(() => Promise.resolve('data:image/png;base64,xxx')),
+  generateBackupCodes: jest.fn(() => ['CODE1', 'CODE2']),
+  encryptSecret: jest.fn(() => 'enc-secret'),
+  encryptBackupCodes: jest.fn(() => 'enc-codes'),
+  decryptSecret: jest.fn(() => 'SECRET'),
+  decryptBackupCodes: jest.fn(() => ['CODE1']),
+  normalizeToken: jest.fn((t: string) => t),
+  timingSafeCompare: jest.fn(() => false),
+  verifyTOTP: jest.fn(() => true),
+}))
+
+jest.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: jest.fn(() => ({ isLimited: false })),
+  recordFailedAttempt: jest.fn(),
+  clearAttempts: jest.fn(),
+}))
+
+jest.mock('bcryptjs', () => ({
+  compare: jest.fn(() => Promise.resolve(true)),
+  hash: jest.fn(() => Promise.resolve('hashed')),
+}))
+
+import { auth } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+
+const mockedAuth = auth as jest.MockedFunction<typeof auth>
+const mockedPrisma = prisma as unknown as {
+  admin: { findUnique: jest.Mock; update: jest.Mock }
+  whitelistUser: { findUnique: jest.Mock; update: jest.Mock }
+}
+
+function makeSession(isAdmin: boolean) {
+  return {
+    user: {
+      id: isAdmin ? 'a1' : 'u1',
+      email: isAdmin ? 'admin@example.com' : 'user@example.com',
+      isAdmin,
+      mustChangePassword: false,
+      twoFactorEnabled: true,
+      requiresTwoFactor: false,
+    },
+    expires: '2099-01-01T00:00:00.000Z',
+  } as never
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('POST /api/2fa/disable — clears lastTwoFactorVerifiedAt (Issue #139)', () => {
+  async function callDisable(isAdmin: boolean) {
+    const { POST } = await import('@/app/api/2fa/disable/route')
+    mockedAuth.mockResolvedValue(makeSession(isAdmin))
+    const table = isAdmin ? mockedPrisma.admin : mockedPrisma.whitelistUser
+    table.findUnique.mockResolvedValue({
+      password: 'hashed',
+      twoFactorSecret: 'enc-secret',
+      twoFactorBackupCodes: 'enc-codes',
+      twoFactorEnabled: true,
+    })
+    table.update.mockResolvedValue({})
+    const req = new Request('http://localhost/api/2fa/disable', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ password: 'p', token: '123456' }),
+    })
+    return POST(req)
+  }
+
+  it('clears lastTwoFactorVerifiedAt for admin', async () => {
+    const res = await callDisable(true)
+    expect(res.status).toBe(200)
+    expect(mockedPrisma.admin.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'a1' },
+        data: expect.objectContaining({
+          twoFactorEnabled: false,
+          twoFactorSecret: null,
+          twoFactorBackupCodes: null,
+          lastTwoFactorVerifiedAt: null,
+        }),
+      }),
+    )
+  })
+
+  it('clears lastTwoFactorVerifiedAt for whitelist user', async () => {
+    const res = await callDisable(false)
+    expect(res.status).toBe(200)
+    expect(mockedPrisma.whitelistUser.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'u1' },
+        data: expect.objectContaining({
+          twoFactorEnabled: false,
+          twoFactorSecret: null,
+          twoFactorBackupCodes: null,
+          lastTwoFactorVerifiedAt: null,
+        }),
+      }),
+    )
+  })
+})
+
+describe('POST /api/2fa/setup — clears stale lastTwoFactorVerifiedAt (Issue #139)', () => {
+  async function callSetup(isAdmin: boolean) {
+    const { POST } = await import('@/app/api/2fa/setup/route')
+    mockedAuth.mockResolvedValue(makeSession(isAdmin))
+    const table = isAdmin ? mockedPrisma.admin : mockedPrisma.whitelistUser
+    table.update.mockResolvedValue({})
+    return POST()
+  }
+
+  it('clears lastTwoFactorVerifiedAt for admin', async () => {
+    const res = await callSetup(true)
+    expect(res.status).toBe(200)
+    expect(mockedPrisma.admin.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'a1' },
+        data: expect.objectContaining({
+          lastTwoFactorVerifiedAt: null,
+        }),
+      }),
+    )
+  })
+
+  it('clears lastTwoFactorVerifiedAt for whitelist user', async () => {
+    const res = await callSetup(false)
+    expect(res.status).toBe(200)
+    expect(mockedPrisma.whitelistUser.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'u1' },
+        data: expect.objectContaining({
+          lastTwoFactorVerifiedAt: null,
+        }),
+      }),
+    )
+  })
+})
+
+describe('POST /api/2fa/verify-setup — records lastTwoFactorVerifiedAt = now (Issue #139)', () => {
+  async function callVerifySetup(isAdmin: boolean) {
+    const { POST } = await import('@/app/api/2fa/verify-setup/route')
+    mockedAuth.mockResolvedValue(makeSession(isAdmin))
+    const table = isAdmin ? mockedPrisma.admin : mockedPrisma.whitelistUser
+    table.findUnique.mockResolvedValue({
+      twoFactorSecret: 'enc-secret',
+      twoFactorEnabled: false,
+    })
+    table.update.mockResolvedValue({})
+    const req = new Request('http://localhost/api/2fa/verify-setup', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ token: '123456' }),
+    })
+    return POST(req)
+  }
+
+  it('records lastTwoFactorVerifiedAt for admin', async () => {
+    const res = await callVerifySetup(true)
+    expect(res.status).toBe(200)
+    const args = mockedPrisma.admin.update.mock.calls[0][0]
+    expect(args.where).toEqual({ id: 'a1' })
+    expect(args.data.twoFactorEnabled).toBe(true)
+    expect(args.data.lastTwoFactorVerifiedAt).toBeInstanceOf(Date)
+  })
+
+  it('records lastTwoFactorVerifiedAt for whitelist user', async () => {
+    const res = await callVerifySetup(false)
+    expect(res.status).toBe(200)
+    const args = mockedPrisma.whitelistUser.update.mock.calls[0][0]
+    expect(args.where).toEqual({ id: 'u1' })
+    expect(args.data.twoFactorEnabled).toBe(true)
+    expect(args.data.lastTwoFactorVerifiedAt).toBeInstanceOf(Date)
+  })
+})

--- a/src/app/api/2fa/disable/route.ts
+++ b/src/app/api/2fa/disable/route.ts
@@ -205,6 +205,7 @@ export async function POST(request: Request) {
           twoFactorEnabled: false,
           twoFactorSecret: null,
           twoFactorBackupCodes: null,
+          lastTwoFactorVerifiedAt: null,
         },
       })
     } else {
@@ -214,6 +215,7 @@ export async function POST(request: Request) {
           twoFactorEnabled: false,
           twoFactorSecret: null,
           twoFactorBackupCodes: null,
+          lastTwoFactorVerifiedAt: null,
         },
       })
     }

--- a/src/app/api/2fa/setup/route.ts
+++ b/src/app/api/2fa/setup/route.ts
@@ -53,6 +53,8 @@ export async function POST() {
         data: {
           twoFactorSecret: encryptedSecret,
           twoFactorBackupCodes: encryptedBackupCodes,
+          // Clear any stale verification timestamp from a previous setup (Issue #139)
+          lastTwoFactorVerifiedAt: null,
           // Keep twoFactorEnabled=false until user verifies with a valid token
         },
       })
@@ -62,6 +64,8 @@ export async function POST() {
         data: {
           twoFactorSecret: encryptedSecret,
           twoFactorBackupCodes: encryptedBackupCodes,
+          // Clear any stale verification timestamp from a previous setup (Issue #139)
+          lastTwoFactorVerifiedAt: null,
           // Keep twoFactorEnabled=false until user verifies with a valid token
         },
       })

--- a/src/app/api/2fa/verify-setup/route.ts
+++ b/src/app/api/2fa/verify-setup/route.ts
@@ -129,16 +129,19 @@ export async function POST(request: Request) {
     // Clear rate limit attempts on successful verification
     clearAttempts(rateLimitKey)
 
-    // 5. If valid, set twoFactorEnabled=true
+    // 5. If valid, set twoFactorEnabled=true and record the verification time
+    // so the jwt callback's 5-minute window treats this setup as the latest
+    // verification (Issue #139).
+    const now = new Date()
     if (isAdmin) {
       await prisma.admin.update({
         where: { id: userId },
-        data: { twoFactorEnabled: true },
+        data: { twoFactorEnabled: true, lastTwoFactorVerifiedAt: now },
       })
     } else {
       await prisma.whitelistUser.update({
         where: { id: userId },
-        data: { twoFactorEnabled: true },
+        data: { twoFactorEnabled: true, lastTwoFactorVerifiedAt: now },
       })
     }
 


### PR DESCRIPTION
## Summary
- jwt callback (`src/lib/auth.ts:161-162, 186-187`) は `lastTwoFactorVerifiedAt` の **過去5分窓** で `requiresTwoFactor=false` を判定する。
- 2FA disable 時に `lastTwoFactorVerifiedAt` をクリアしていなかったため、disable 直後 (5分以内) に再 setup/enable すると、disable 前の verify timestamp を再利用して新規 secret に対する TOTP 認証をスキップできる窓が成立していた (Issue #139)。

## 修正内容

| Route | 変更 |
|---|---|
| `/api/2fa/disable` (`route.ts:204-220`) | secret/backupCodes wipe と同時に `lastTwoFactorVerifiedAt: null` を設定 |
| `/api/2fa/setup` (`route.ts:47-66`) | 新規 secret 設定時に `lastTwoFactorVerifiedAt: null` (再 setup 起点で stale 値を消す defense-in-depth) |
| `/api/2fa/verify-setup` (`route.ts:130-148`) | enable 成功時に `lastTwoFactorVerifiedAt: now` を記録 (signin verify と同等のセマンティクス) |

各 route 内で admin / whitelistUser 両 path に同等に適用。

## テスト

新規: `src/__tests__/two-factor-last-verified.test.ts` (6 ケース)
- Prisma を mock し、各 route POST 後に `prisma.{admin,whitelistUser}.update` の data に期待する `lastTwoFactorVerifiedAt` が含まれることを assert
- admin / whitelistUser の両 path を独立に検証

infra: `jest.config.ts` に `moduleNameMapper: { '^@/(.*)$': '<rootDir>/src/$1' }` を追加。テストの `jest.mock('@/lib/auth', ...)` 等を route 側の import path に揃えるため。既存テストは全て relative path / 外部 module を使っており影響なし。

## Test plan
- [x] `pnpm exec jest src/__tests__/two-factor-last-verified.test.ts` — 6 件パス
- [x] `pnpm exec jest` 全体 — 316 件パス (regression 無し)
- [x] `pnpm lint` — error 0
- [x] `pnpm exec tsc --noEmit` — error 0
- [x] `pnpm exec prettier -c src` — pass

## 互換性

- DB schema 変更なし (既存 nullable column の値書き換えのみ)
- 既存ユーザー: 影響なし (disable/setup/verify-setup は明示的に呼ばれるときのみ)
- 後方互換: enable 中 (verify-setup 未到達) のユーザーは存在しても、次の disable 時に正常に動作

Closes #139