### PR TITLE
fix(security): block 2FA setup re-init when already enabled

### DIFF
--- a/src/__tests__/two-factor-last-verified.test.ts
+++ b/src/__tests__/two-factor-last-verified.test.ts
@@ -138,6 +138,10 @@ describe('POST /api/2fa/setup — clears stale lastTwoFactorVerifiedAt (Issue #1
     const { POST } = await import('@/app/api/2fa/setup/route')
     mockedAuth.mockResolvedValue(makeSession(isAdmin))
     const table = isAdmin ? mockedPrisma.admin : mockedPrisma.whitelistUser
+    // jest.clearAllMocks() preserves mockResolvedValue from earlier describes
+    // (it only clears call history), so explicitly set findUnique here to
+    // bypass the Issue #140 already-enabled guard added in src/app/api/2fa/setup/route.ts.
+    table.findUnique.mockResolvedValue({ twoFactorEnabled: false })
     table.update.mockResolvedValue({})
     return POST()
   }

--- a/src/__tests__/two-factor-setup-already-enabled.test.ts
+++ b/src/__tests__/two-factor-setup-already-enabled.test.ts
@@ -1,0 +1,118 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Tests for blocking 2FA setup re-init when already enabled (Issue #140).
+ * Prevents self-lockout caused by overwriting an active secret.
+ */
+
+jest.mock('@/lib/auth', () => ({
+  auth: jest.fn(),
+  isPrivateInstance: jest.fn(() => true),
+}))
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    admin: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    whitelistUser: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('@/lib/two-factor', () => ({
+  generateTOTPSecret: jest.fn(() => ({
+    secret: 'SECRET',
+    otpauthUrl: 'otpauth://totp/x',
+  })),
+  generateQRCode: jest.fn(() => Promise.resolve('data:image/png;base64,xxx')),
+  generateBackupCodes: jest.fn(() => ['CODE1', 'CODE2']),
+  encryptSecret: jest.fn(() => 'enc-secret'),
+  encryptBackupCodes: jest.fn(() => 'enc-codes'),
+}))
+
+import { auth } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+
+const mockedAuth = auth as jest.MockedFunction<typeof auth>
+const mockedPrisma = prisma as unknown as {
+  admin: { findUnique: jest.Mock; update: jest.Mock }
+  whitelistUser: { findUnique: jest.Mock; update: jest.Mock }
+}
+
+function makeSession(isAdmin: boolean) {
+  return {
+    user: {
+      id: isAdmin ? 'a1' : 'u1',
+      email: isAdmin ? 'admin@example.com' : 'user@example.com',
+      isAdmin,
+      mustChangePassword: false,
+      twoFactorEnabled: false,
+      requiresTwoFactor: false,
+    },
+    expires: '2099-01-01T00:00:00.000Z',
+  } as never
+}
+
+async function callSetup(isAdmin: boolean) {
+  const { POST } = await import('@/app/api/2fa/setup/route')
+  mockedAuth.mockResolvedValue(makeSession(isAdmin))
+  return POST()
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('POST /api/2fa/setup — blocks re-init when already enabled (Issue #140)', () => {
+  it('returns 400 and does not write when admin has 2FA enabled', async () => {
+    mockedPrisma.admin.findUnique.mockResolvedValue({ twoFactorEnabled: true })
+    const res = await callSetup(true)
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error?: string }
+    expect(body.error).toMatch(/already enabled/i)
+    expect(mockedPrisma.admin.update).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 and does not write when whitelist user has 2FA enabled', async () => {
+    mockedPrisma.whitelistUser.findUnique.mockResolvedValue({
+      twoFactorEnabled: true,
+    })
+    const res = await callSetup(false)
+    expect(res.status).toBe(400)
+    const body = (await res.json()) as { error?: string }
+    expect(body.error).toMatch(/already enabled/i)
+    expect(mockedPrisma.whitelistUser.update).not.toHaveBeenCalled()
+  })
+
+  it('proceeds normally when admin has 2FA disabled', async () => {
+    mockedPrisma.admin.findUnique.mockResolvedValue({ twoFactorEnabled: false })
+    mockedPrisma.admin.update.mockResolvedValue({})
+    const res = await callSetup(true)
+    expect(res.status).toBe(200)
+    expect(mockedPrisma.admin.update).toHaveBeenCalled()
+  })
+
+  it('proceeds normally when whitelist user has 2FA disabled', async () => {
+    mockedPrisma.whitelistUser.findUnique.mockResolvedValue({
+      twoFactorEnabled: false,
+    })
+    mockedPrisma.whitelistUser.update.mockResolvedValue({})
+    const res = await callSetup(false)
+    expect(res.status).toBe(200)
+    expect(mockedPrisma.whitelistUser.update).toHaveBeenCalled()
+  })
+
+  it('proceeds when admin record is missing (defaults to disabled)', async () => {
+    mockedPrisma.admin.findUnique.mockResolvedValue(null)
+    mockedPrisma.admin.update.mockResolvedValue({})
+    const res = await callSetup(true)
+    expect(res.status).toBe(200)
+    expect(mockedPrisma.admin.update).toHaveBeenCalled()
+  })
+})

--- a/src/app/api/2fa/setup/route.ts
+++ b/src/app/api/2fa/setup/route.ts
@@ -33,6 +33,31 @@ export async function POST() {
     const isAdmin = session.user.isAdmin
     const userEmail = session.user.email
 
+    // Block re-init when 2FA is already enabled (Issue #140).
+    // Use DB rather than session.user.twoFactorEnabled because the JWT may
+    // be stale (e.g. the user disabled 2FA on another device).
+    let alreadyEnabled = false
+    if (isAdmin) {
+      const admin = await prisma.admin.findUnique({
+        where: { id: userId },
+        select: { twoFactorEnabled: true },
+      })
+      alreadyEnabled = admin?.twoFactorEnabled ?? false
+    } else {
+      const whitelistUser = await prisma.whitelistUser.findUnique({
+        where: { id: userId },
+        select: { twoFactorEnabled: true },
+      })
+      alreadyEnabled = whitelistUser?.twoFactorEnabled ?? false
+    }
+
+    if (alreadyEnabled) {
+      return NextResponse.json(
+        { error: '2FA is already enabled. Please disable first.' },
+        { status: 400 },
+      )
+    }
+
     // 2. Generate TOTP secret
     const { secret, otpauthUrl } = generateTOTPSecret(userEmail)
 


### PR DESCRIPTION
## Summary
- `/api/2fa/setup` を既に enabled なユーザーが叩くと既存 `twoFactorSecret` / `twoFactorBackupCodes` が新しい値で上書きされる → ユーザーが新 QR を Authenticator に登録する前にアプリを閉じると、旧 secret 失効・新 secret 未登録で **永続ロックアウト** (Issue #140)。
- DB から `twoFactorEnabled` を確認し、true なら `400 Bad Request` を返す。

## なぜ DB lookup なのか

`session.user.twoFactorEnabled` は JWT 経由でキャッシュされており、他デバイスで disable した直後等は stale な可能性。極小サイズの indexed lookup で誤判定を防ぐ。

## 適用箇所

`src/app/api/2fa/setup/route.ts` の冒頭 (auth + passwordChangeRequiredResponse の後、`generateTOTPSecret` の前) に admin / whitelistUser 両 path 分の guard を追加。

| 入力 | 既存挙動 | 修正後 |
|---|---|---|
| `twoFactorEnabled=true` | secret 上書き 200 | **400 `2FA is already enabled. Please disable first.`** |
| `twoFactorEnabled=false` | 200 setup 完了 | 同じ |
| record 不在 (`findUnique=null`) | update で Prisma error → 500 | 同じ (`?? false` で disabled 扱い、update で同じ error) |

## テスト

新規 `src/__tests__/two-factor-setup-already-enabled.test.ts` (5 ケース):
- admin enabled=true → 400 + update 未呼出
- whitelist user enabled=true → 400 + update 未呼出
- admin enabled=false → 200 + 既存 setup 動作 (regression)
- whitelist user enabled=false → 200 + 既存 setup 動作 (regression)
- admin record missing → 200 (`?? false` defaults to disabled)

副次修正: `src/__tests__/two-factor-last-verified.test.ts` の `setup describe` で `findUnique.mockResolvedValue` を明示。`jest.clearAllMocks()` が `mockResolvedValue` を保持するため、前 describe (disable) で設定した `twoFactorEnabled: true` が leak して新 guard を誤って trip していた。

## Test plan
- [x] `pnpm exec jest src/__tests__/two-factor-setup-already-enabled.test.ts` — 5 件パス
- [x] `pnpm exec jest` 全体 — 321 件パス (regression 無し)
- [x] `pnpm lint` — error 0
- [x] `pnpm exec tsc --noEmit` — error 0
- [x] `pnpm exec prettier -c src` — pass

## 互換性
- DB schema 変更なし
- 正常な disable → setup フロー: 変更なし
- enabled 状態での setup のみ拒否 (UI 側 `two-factor-setup.tsx` は既に enabled 時呼ばないが、API 層でも二重防衛)

Closes #140