### PR TITLE
fix(perf): skip recurring expense processing for soft-deleted groups

### DIFF
--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -45,6 +45,7 @@ jest.mock('nanoid', () => ({
 import { ActivityType } from '@prisma/client'
 import {
   createGroup,
+  createRecurringExpenses,
   deleteGroup,
   getActivities,
   getCategories,
@@ -521,6 +522,50 @@ describe('API data access layer', () => {
           data: 'Dinner',
         },
       })
+    })
+  })
+
+  describe('createRecurringExpenses', () => {
+    it('skips links whose group is soft-deleted (Issue #141)', async () => {
+      ;(mockRecurringExpenseLink.findMany as jest.Mock).mockResolvedValue([])
+
+      await createRecurringExpenses()
+
+      expect(mockRecurringExpenseLink.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            currentFrameExpense: {
+              group: { deletedAt: null },
+            },
+          }),
+        }),
+      )
+    })
+
+    it('applies the soft-delete filter even when scoped by groupId', async () => {
+      ;(mockRecurringExpenseLink.findMany as jest.Mock).mockResolvedValue([])
+
+      await createRecurringExpenses('g1')
+
+      expect(mockRecurringExpenseLink.findMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            groupId: 'g1',
+            currentFrameExpense: {
+              group: { deletedAt: null },
+            },
+          }),
+        }),
+      )
+    })
+
+    it('does not invoke $transaction when no eligible links exist', async () => {
+      ;(mockRecurringExpenseLink.findMany as jest.Mock).mockResolvedValue([])
+      const mock$transaction = prisma.$transaction as jest.Mock
+
+      await createRecurringExpenses()
+
+      expect(mock$transaction).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -569,6 +569,11 @@ export async function createRecurringExpenses(groupId?: string) {
         },
         // Scope by groupId when provided (Issue #132)
         ...(groupId ? { groupId } : {}),
+        // Skip links whose group is soft-deleted (Issue #141).
+        // Prevents grace-period generation that would surface on restore.
+        currentFrameExpense: {
+          group: { deletedAt: null },
+        },
       },
       include: {
         currentFrameExpense: {


### PR DESCRIPTION
## Summary
- `createRecurringExpenses` の `findMany` where に `currentFrameExpense.group.deletedAt: null` フィルタを追加し、 soft-delete されたグループの recurring 生成を即時停止 (Issue #141)
- grace 期間中の無駄な expense 生成を停止、 restore 時に意図しない expense が湧かないようにする
- DB schema 変更なし、 migration 不要

## Why
従来は `Group.deletedAt` を join していなかったため、 grace 期間中 (デフォルト 7日) も recurring 処理が走り続け、ユーザーが復元したときに 7日分の意図しない expense が追加されていた。

## Implementation
`src/lib/api.ts` の `createRecurringExpenses` の where 句に以下を追加:
```ts
currentFrameExpense: {
  group: { deletedAt: null },
}
```
`RecurringExpenseLink.groupId` は scalar (relation 未定義) のため、 nested filter は既存の `currentFrameExpense` (Expense → Group) relation 経由で適用。

## Test plan
- [x] `pnpm exec tsc --noEmit` (clean)
- [x] `pnpm test` (324 passed / 18 suites — 新規 3 case 含む)
- [x] `pnpm lint` (0 errors, pre-existing warnings のみ)
- [ ] レビュー: where filter が他の用途を阻害しないこと
- [ ] レビュー: restore 後の catch-up 生成が想定通り動くこと

## Backward compatibility
- DB migration なし
- 既に grace 期間中に作られてしまった expense は残る (このPR の範囲外)
- restore したグループは次の cron tick から通常通り catch-up 生成

Closes #141