### PR TITLE
docs: refresh README hero, drop removed feature, fix deploy URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="public/banner.png" alt="anon-spliit" width="600" />
+  <img src="public/anon-spliit.png" alt="anon-spliit" width="300" />
 </p>
 
 <h1 align="center">anon spliit</h1>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="public/anon-spliit.png" alt="anon-spliit" width="300" />
+  <img src="public/banner.png" alt="anon-spliit" width="600" />
 </p>
 
 <h1 align="center">anon spliit</h1>
@@ -67,7 +67,6 @@
 - Split expenses evenly or by custom amounts/percentages/shares
 - Track balances and get optimized reimbursement suggestions
 - Support for multiple currencies with exchange rates
-- Attach receipts and documents to expenses
 - Export data to JSON/CSV
 - Progressive Web App (PWA) - install on mobile
 - Dark mode support
@@ -83,7 +82,7 @@
 
 ### Deploy Your Own Instance
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fsora-grayscale%2Fspliit&project-name=my-anon-spliit&repository-name=my-anon-spliit&stores=%5B%7B%22type%22%3A%22postgres%22%7D%5D)
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fsora-grayscale%2Fanon-spliit&project-name=my-anon-spliit&repository-name=my-anon-spliit&stores=%5B%7B%22type%22%3A%22postgres%22%7D%5D)
 
 ### Run Locally
 


### PR DESCRIPTION
## Summary
- README hero image を `public/anon-spliit.png` (1024x559 透過 pad) から `public/banner.png` (1200x670 ブランドバナー) に変更、 width 300 → 600
- 削除済機能「Attach receipts and documents to expenses」を Features list から除去 (PR #157 で file upload 機能削除済のため)
- Vercel Deploy ボタンの repository-url を `sora-grayscale/spliit` → `sora-grayscale/anon-spliit` に修正 (typo、 one-click deploy が機能していなかった)

## Why
- アイコン置き換え後、 `anon-spliit.png` は正方形 icon + 透過 pad の構成になったため README hero として不適切
- README が実装と乖離していた (file upload 機能は E2EE 整合性のため削除済)
- Vercel Deploy URL は upstream 由来の typo、 fork 後一度も修正されていなかった

## Files changed
- `README.md` (3 places, 2 insertions / 3 deletions)