### PR TITLE
fix(security): remove server-side search filter on E2EE titles

### DIFF
--- a/src/app/groups/[groupId]/expenses/expense-list.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-list.tsx
@@ -125,7 +125,7 @@ const ExpenseListForSearch = ({
     isLoading: expensesAreLoading,
     fetchNextPage,
   } = trpc.groups.expenses.list.useInfiniteQuery(
-    { groupId, limit: PAGE_SIZE, filter: searchText },
+    { groupId, limit: PAGE_SIZE },
     { getNextPageParam: ({ nextCursor }) => nextCursor },
   )
 
@@ -216,7 +216,17 @@ const ExpenseListForSearch = ({
     }
   }, [rawExpenses, encryptionKey, isKeyLoading, hasKey])
 
-  const displayExpenses = decryptedExpenses
+  // Client-side title filter (Issue #164): the server no longer accepts
+  // a `filter` param because `title` is E2EE ciphertext on the server.
+  // We filter the already-decrypted, currently-loaded pages here.
+  const displayExpenses = useMemo(() => {
+    if (!decryptedExpenses) return decryptedExpenses
+    if (!searchText) return decryptedExpenses
+    const query = searchText.toLowerCase()
+    return decryptedExpenses.filter((e) =>
+      (e.title ?? '').toLowerCase().includes(query),
+    )
+  }, [decryptedExpenses, searchText])
 
   const isLoading =
     expensesAreLoading || isKeyLoading || !displayExpenses || !group

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -390,18 +390,18 @@ describe('API data access layer', () => {
       )
     })
 
-    it('should support filter option', async () => {
+    it('should not apply any server-side title filter (Issue #164)', async () => {
+      // Server-side filter on `title` was removed because the column stores
+      // E2EE ciphertext; SQL LIKE/ILIKE on it cannot match user input and
+      // leaks the plaintext search term to server logs.
       ;(mockRecurringExpenseLink.findMany as jest.Mock).mockResolvedValue([])
       ;(mockExpense.findMany as jest.Mock).mockResolvedValue([])
 
-      await getGroupExpenses('group-1', { filter: 'dinner' })
+      await getGroupExpenses('group-1')
 
       expect(mockExpense.findMany).toHaveBeenCalledWith(
         expect.objectContaining({
-          where: {
-            groupId: 'group-1',
-            title: { contains: 'dinner', mode: 'insensitive' },
-          },
+          where: { groupId: 'group-1' },
         }),
       )
     })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -424,13 +424,17 @@ export async function getCategories() {
 
 export async function getGroupExpenses(
   groupId: string,
-  options?: { offset?: number; length?: number; filter?: string },
+  options?: { offset?: number; length?: number },
 ) {
   // Process only this group's recurring links to avoid cross-tenant DoS via
   // unauthenticated list calls (Issue #132). Full-fleet processing lives in
   // the dedicated /api/cron/recurring endpoint for self-hosted setups.
   await createRecurringExpenses(groupId)
 
+  // Server-side title filtering removed (Issue #164): `title` is E2EE
+  // ciphertext, so SQL LIKE/ILIKE on it can never match user-typed plaintext
+  // and would leak the search term to server logs. Search is now performed
+  // client-side after decryption.
   return prisma.expense.findMany({
     select: {
       amount: true,
@@ -450,12 +454,7 @@ export async function getGroupExpenses(
       recurrenceRule: true,
       title: true,
     },
-    where: {
-      groupId,
-      title: options?.filter
-        ? { contains: options.filter, mode: 'insensitive' }
-        : undefined,
-    },
+    where: { groupId },
     orderBy: [{ expenseDate: 'desc' }, { createdAt: 'desc' }],
     skip: options && options.offset,
     take: options && options.length,

--- a/src/trpc/routers/groups/expenses/list.procedure.ts
+++ b/src/trpc/routers/groups/expenses/list.procedure.ts
@@ -8,14 +8,12 @@ export const listGroupExpensesProcedure = publicProcedure
       groupId: z.string().min(1).max(30), // nanoid is typically 21 chars
       cursor: z.number().int().min(0).max(100000).optional(), // Pagination offset
       limit: z.number().int().min(1).max(100).optional(), // Max 100 items per request
-      filter: z.string().max(200).optional(), // Limit filter length to prevent abuse
     }),
   )
-  .query(async ({ input: { groupId, cursor = 0, limit = 10, filter } }) => {
+  .query(async ({ input: { groupId, cursor = 0, limit = 10 } }) => {
     const expenses = await getGroupExpenses(groupId, {
       offset: cursor,
       length: limit + 1,
-      filter,
     })
     return {
       expenses: expenses.slice(0, limit).map((expense) => ({


### PR DESCRIPTION
## Summary

Closes #164.

`groups.expenses.list` の `filter` パラメータが server-side で `prisma.expense.findMany({ where: { title: { contains: filter } } })` に渡されており、 暗号化グループで以下 2 つの問題:

1. **プライバシー違反**: ユーザの平文検索クエリが wire 経由で server に送信され、 access/query log に残存
2. **機能不全**: `title` は AES-256-GCM 暗号化 base64 ciphertext のため、 SQL ILIKE が user 入力に対し一致せず、 結果常に空 + sequential scan が発生

## 修正内容

- tRPC `list` zod input から `filter` を削除
- `getGroupExpenses` から `filter` option と `where.title.contains` を削除
- `ExpenseListForSearch` で復号済 expense に対し client-side フィルタを適用

## 既知の制約

検索は **現在 load 済の page** に対してのみ動作。 ユーザがスクロールで次 page を fetch すれば検索対象も拡大。 全 expense 検索は #170 (listAll cursor pagination) の対応後に再検討。

## Test plan

- [x] `pnpm tsc --noEmit` — 型エラーなし
- [x] `pnpm test` — 324/324 passing (新規追加: `should not apply any server-side title filter (Issue #164)`)
- [x] `pnpm lint` — 0 errors (既存 11 warnings は本変更と無関係)
- [x] `pnpm build` — production build 成功
- [ ] **未確認 (要 manual)**: 復号失敗 group / 暗号化なし legacy group での挙動 (dev server 起動 + DB 起動が必要)

## Refs

- レビュー 2026-05-12 (tracking issue: #214)
- 関連 (検索 UX 拡張時): #170