### PR TITLE
fix(security): require 2FA for REST endpoints

### DIFF
--- a/src/__tests__/rest-2fa-gate.test.ts
+++ b/src/__tests__/rest-2fa-gate.test.ts
@@ -1,0 +1,167 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Route-level regression tests for the requiresTwoFactor gate (Issue #166).
+ *
+ * Verifies that REST endpoints return 401 `Two-factor authentication required`
+ * when the session has not yet completed 2FA for the current login. Covers
+ * representative endpoints from each affected area: 2FA management
+ * (setup/disable) and admin whitelist (POST/GET). The remaining gated
+ * endpoints (verify-setup, change-password, whitelist PATCH/DELETE) share
+ * the same helper call and are exercised by the helper's own unit tests in
+ * `src/lib/auth-helpers.test.ts`.
+ */
+
+jest.mock('@/lib/auth', () => ({
+  auth: jest.fn(),
+  isPrivateInstance: jest.fn(() => true),
+}))
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    admin: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      findMany: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+    },
+    whitelistUser: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      findMany: jest.fn(),
+      create: jest.fn(),
+      delete: jest.fn(),
+    },
+  },
+}))
+
+// Mirror `two-factor-last-verified.test.ts`: stub server-only modules so
+// importing the route handlers doesn't pull in crypto/qrcode/timer
+// side-effects during test setup.
+jest.mock('@/lib/two-factor', () => ({
+  generateTOTPSecret: jest.fn(() => ({
+    secret: 'SECRET',
+    otpauthUrl: 'otpauth://totp/x',
+  })),
+  generateQRCode: jest.fn(() => Promise.resolve('data:image/png;base64,xxx')),
+  generateBackupCodes: jest.fn(() => ['CODE1', 'CODE2']),
+  encryptSecret: jest.fn(() => 'enc-secret'),
+  encryptBackupCodes: jest.fn(() => 'enc-codes'),
+  decryptSecret: jest.fn(() => 'SECRET'),
+  decryptBackupCodes: jest.fn(() => ['CODE1', 'CODE2']),
+  normalizeToken: jest.fn((t: string) => t),
+  timingSafeCompare: jest.fn(() => false),
+  verifyTOTP: jest.fn(() => false),
+}))
+
+jest.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: jest.fn(() => ({ isLimited: false })),
+  recordFailedAttempt: jest.fn(),
+  clearAttempts: jest.fn(),
+}))
+
+jest.mock('bcryptjs', () => ({
+  compare: jest.fn(() => Promise.resolve(true)),
+  hash: jest.fn(() => Promise.resolve('hashed')),
+}))
+
+import { auth } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+
+const mockedAuth = auth as jest.MockedFunction<typeof auth>
+const mockedPrisma = prisma as unknown as {
+  admin: { findUnique: jest.Mock; findMany: jest.Mock; create: jest.Mock }
+  whitelistUser: {
+    findUnique: jest.Mock
+    findMany: jest.Mock
+    create: jest.Mock
+  }
+}
+
+function makeSession({
+  isAdmin = false,
+  requiresTwoFactor = false,
+}: {
+  isAdmin?: boolean
+  requiresTwoFactor?: boolean
+} = {}) {
+  return {
+    user: {
+      id: isAdmin ? 'a1' : 'u1',
+      email: isAdmin ? 'admin@example.com' : 'user@example.com',
+      isAdmin,
+      mustChangePassword: false,
+      twoFactorEnabled: true,
+      requiresTwoFactor,
+    },
+    expires: '2099-01-01T00:00:00.000Z',
+  } as never
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('REST endpoints — requiresTwoFactor gate (Issue #166)', () => {
+  it('POST /api/2fa/setup returns 401 when requiresTwoFactor is true', async () => {
+    mockedAuth.mockResolvedValue(makeSession({ requiresTwoFactor: true }))
+    const { POST } = await import('@/app/api/2fa/setup/route')
+    const res = await POST()
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({
+      error: 'Two-factor authentication required',
+    })
+    // Should short-circuit before touching the database.
+    expect(mockedPrisma.admin.findUnique).not.toHaveBeenCalled()
+    expect(mockedPrisma.whitelistUser.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('POST /api/2fa/disable returns 401 when requiresTwoFactor is true', async () => {
+    mockedAuth.mockResolvedValue(makeSession({ requiresTwoFactor: true }))
+    const { POST } = await import('@/app/api/2fa/disable/route')
+    const request = new Request('http://localhost/api/2fa/disable', {
+      method: 'POST',
+      body: JSON.stringify({ password: 'irrelevant', token: '123456' }),
+    })
+    const res = await POST(request)
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({
+      error: 'Two-factor authentication required',
+    })
+    expect(mockedPrisma.admin.findUnique).not.toHaveBeenCalled()
+    expect(mockedPrisma.whitelistUser.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('POST /api/admin/whitelist returns 401 when admin requiresTwoFactor is true', async () => {
+    mockedAuth.mockResolvedValue(
+      makeSession({ isAdmin: true, requiresTwoFactor: true }),
+    )
+    const { POST } = await import('@/app/api/admin/whitelist/route')
+    const request = new Request('http://localhost/api/admin/whitelist', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'new@example.com' }),
+    })
+    const res = await POST(request)
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({
+      error: 'Two-factor authentication required',
+    })
+    expect(mockedPrisma.whitelistUser.create).not.toHaveBeenCalled()
+  })
+
+  it('GET /api/admin/whitelist returns 401 when admin requiresTwoFactor is true', async () => {
+    mockedAuth.mockResolvedValue(
+      makeSession({ isAdmin: true, requiresTwoFactor: true }),
+    )
+    const { GET } = await import('@/app/api/admin/whitelist/route')
+    const res = await GET()
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({
+      error: 'Two-factor authentication required',
+    })
+    expect(mockedPrisma.whitelistUser.findMany).not.toHaveBeenCalled()
+  })
+})

--- a/src/__tests__/rest-2fa-gate.test.ts
+++ b/src/__tests__/rest-2fa-gate.test.ts
@@ -8,10 +8,14 @@
  * Verifies that REST endpoints return 401 `Two-factor authentication required`
  * when the session has not yet completed 2FA for the current login. Covers
  * representative endpoints from each affected area: 2FA management
- * (setup/disable) and admin whitelist (POST/GET). The remaining gated
- * endpoints (verify-setup, change-password, whitelist PATCH/DELETE) share
- * the same helper call and are exercised by the helper's own unit tests in
- * `src/lib/auth-helpers.test.ts`.
+ * (setup/disable) and admin whitelist (POST/GET).
+ *
+ * The remaining gated handlers (verify-setup, change-password, whitelist
+ * PATCH/DELETE) make the same `requiresTwoFactorResponse(session)` call;
+ * that wiring is verified by code review rather than by tests here. The
+ * helper's own behavior is covered by `src/lib/auth-helpers.test.ts`.
+ * Route-level tests for those endpoints can be added later if regression
+ * coverage becomes a concern.
  */
 
 jest.mock('@/lib/auth', () => ({

--- a/src/app/api/2fa/disable/route.ts
+++ b/src/app/api/2fa/disable/route.ts
@@ -6,7 +6,10 @@
  */
 
 import { auth } from '@/lib/auth'
-import { passwordChangeRequiredResponse } from '@/lib/auth-helpers'
+import {
+  passwordChangeRequiredResponse,
+  requiresTwoFactorResponse,
+} from '@/lib/auth-helpers'
 import { prisma } from '@/lib/prisma'
 import {
   checkRateLimit,
@@ -33,6 +36,9 @@ export async function POST(request: Request) {
     if (!session?.user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const twoFaResp = requiresTwoFactorResponse(session)
+    if (twoFaResp) return twoFaResp
 
     const pwChangeResp = passwordChangeRequiredResponse(session)
     if (pwChangeResp) return pwChangeResp

--- a/src/app/api/2fa/setup/route.ts
+++ b/src/app/api/2fa/setup/route.ts
@@ -6,7 +6,10 @@
  */
 
 import { auth } from '@/lib/auth'
-import { passwordChangeRequiredResponse } from '@/lib/auth-helpers'
+import {
+  passwordChangeRequiredResponse,
+  requiresTwoFactorResponse,
+} from '@/lib/auth-helpers'
 import { prisma } from '@/lib/prisma'
 import {
   encryptBackupCodes,
@@ -25,6 +28,9 @@ export async function POST() {
     if (!session?.user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const twoFaResp = requiresTwoFactorResponse(session)
+    if (twoFaResp) return twoFaResp
 
     const pwChangeResp = passwordChangeRequiredResponse(session)
     if (pwChangeResp) return pwChangeResp

--- a/src/app/api/2fa/verify-setup/route.ts
+++ b/src/app/api/2fa/verify-setup/route.ts
@@ -5,7 +5,10 @@
  */
 
 import { auth } from '@/lib/auth'
-import { passwordChangeRequiredResponse } from '@/lib/auth-helpers'
+import {
+  passwordChangeRequiredResponse,
+  requiresTwoFactorResponse,
+} from '@/lib/auth-helpers'
 import { prisma } from '@/lib/prisma'
 import {
   checkRateLimit,
@@ -25,6 +28,9 @@ export async function POST(request: Request) {
     if (!session?.user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const twoFaResp = requiresTwoFactorResponse(session)
+    if (twoFaResp) return twoFaResp
 
     const pwChangeResp = passwordChangeRequiredResponse(session)
     if (pwChangeResp) return pwChangeResp

--- a/src/app/api/admin/whitelist/[userId]/route.ts
+++ b/src/app/api/admin/whitelist/[userId]/route.ts
@@ -3,7 +3,10 @@
  */
 
 import { auth, isPrivateInstance } from '@/lib/auth'
-import { passwordChangeRequiredResponse } from '@/lib/auth-helpers'
+import {
+  passwordChangeRequiredResponse,
+  requiresTwoFactorResponse,
+} from '@/lib/auth-helpers'
 import { prisma } from '@/lib/prisma'
 import bcrypt from 'bcryptjs'
 import { randomBytes } from 'crypto'
@@ -36,6 +39,9 @@ export async function PATCH(
     if (!session?.user?.isAdmin) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const twoFaResp = requiresTwoFactorResponse(session)
+    if (twoFaResp) return twoFaResp
 
     const pwChangeResp = passwordChangeRequiredResponse(session)
     if (pwChangeResp) return pwChangeResp
@@ -92,6 +98,9 @@ export async function DELETE(
     if (!session?.user?.isAdmin) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const twoFaResp = requiresTwoFactorResponse(session)
+    if (twoFaResp) return twoFaResp
 
     const pwChangeResp = passwordChangeRequiredResponse(session)
     if (pwChangeResp) return pwChangeResp

--- a/src/app/api/admin/whitelist/route.ts
+++ b/src/app/api/admin/whitelist/route.ts
@@ -3,7 +3,10 @@
  */
 
 import { auth, isPrivateInstance } from '@/lib/auth'
-import { passwordChangeRequiredResponse } from '@/lib/auth-helpers'
+import {
+  passwordChangeRequiredResponse,
+  requiresTwoFactorResponse,
+} from '@/lib/auth-helpers'
 import { prisma } from '@/lib/prisma'
 import bcrypt from 'bcryptjs'
 import { randomBytes } from 'crypto'
@@ -32,6 +35,9 @@ export async function POST(request: Request) {
     if (!session?.user?.isAdmin) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const twoFaResp = requiresTwoFactorResponse(session)
+    if (twoFaResp) return twoFaResp
 
     const pwChangeResp = passwordChangeRequiredResponse(session)
     if (pwChangeResp) return pwChangeResp
@@ -125,6 +131,9 @@ export async function GET() {
     if (!session?.user?.isAdmin) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    const twoFaResp = requiresTwoFactorResponse(session)
+    if (twoFaResp) return twoFaResp
 
     const pwChangeResp = passwordChangeRequiredResponse(session)
     if (pwChangeResp) return pwChangeResp

--- a/src/app/api/auth/change-password/route.ts
+++ b/src/app/api/auth/change-password/route.ts
@@ -5,6 +5,7 @@
  */
 
 import { auth } from '@/lib/auth'
+import { requiresTwoFactorResponse } from '@/lib/auth-helpers'
 import { prisma } from '@/lib/prisma'
 import {
   checkRateLimit,
@@ -24,6 +25,12 @@ export async function POST(request: Request) {
     if (!session?.user?.email) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
+
+    // Block users who have not yet completed 2FA for this login (Issue #166).
+    // mustChangePassword is intentionally NOT gated here — this is the endpoint
+    // that lets such users clear that flag.
+    const twoFaResp = requiresTwoFactorResponse(session)
+    if (twoFaResp) return twoFaResp
 
     // Check rate limit before processing (Issue #43)
     const rateLimitKey = `${RATE_LIMIT_PREFIX}${session.user.email}`

--- a/src/lib/auth-helpers.test.ts
+++ b/src/lib/auth-helpers.test.ts
@@ -3,11 +3,14 @@
  */
 
 /**
- * Tests for REST API authentication helpers (Issue #142)
+ * Tests for REST API authentication helpers (Issues #142, #166)
  */
 
 import type { Session } from 'next-auth'
-import { passwordChangeRequiredResponse } from './auth-helpers'
+import {
+  passwordChangeRequiredResponse,
+  requiresTwoFactorResponse,
+} from './auth-helpers'
 
 function makeSession(overrides: Partial<Session['user']> = {}): Session {
   return {
@@ -52,5 +55,37 @@ describe('passwordChangeRequiredResponse', () => {
       makeSession({ isAdmin: true, mustChangePassword: true }),
     )
     expect(result?.status).toBe(403)
+  })
+})
+
+describe('requiresTwoFactorResponse', () => {
+  it('returns null when session is null', () => {
+    expect(requiresTwoFactorResponse(null)).toBeNull()
+  })
+
+  it('returns null when requiresTwoFactor is false', () => {
+    expect(
+      requiresTwoFactorResponse(makeSession({ requiresTwoFactor: false })),
+    ).toBeNull()
+  })
+
+  it('returns 401 NextResponse when requiresTwoFactor is true', async () => {
+    const result = requiresTwoFactorResponse(
+      makeSession({ requiresTwoFactor: true }),
+    )
+    expect(result).not.toBeNull()
+    expect(result?.status).toBe(401)
+    const body = await result!.json()
+    expect(body).toEqual({ error: 'Two-factor authentication required' })
+  })
+
+  it('is independent of mustChangePassword', async () => {
+    // requiresTwoFactor must gate independently of mustChangePassword so the
+    // 2FA check fires even when no password change is pending (mirrors the
+    // tRPC ordering in src/trpc/init.ts:63-75).
+    const result = requiresTwoFactorResponse(
+      makeSession({ requiresTwoFactor: true, mustChangePassword: false }),
+    )
+    expect(result?.status).toBe(401)
   })
 })

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -28,3 +28,28 @@ export function passwordChangeRequiredResponse(
   }
   return null
 }
+
+/**
+ * Returns a 401 NextResponse if the session indicates the user has not yet
+ * completed two-factor authentication for the current login, or null
+ * otherwise.
+ *
+ * Mirrors the `requiresTwoFactor` check in publicProcedure / adminProcedure
+ * (`src/trpc/init.ts`, Issue #166). REST API handlers must call this BEFORE
+ * `passwordChangeRequiredResponse` so the 2FA gate matches the tRPC ordering.
+ *
+ * The pre-auth 2FA verify endpoint (`/api/2fa/verify`, which runs without a
+ * full session) is intentionally exempt — calling this helper there would
+ * block the very flow that clears the flag.
+ */
+export function requiresTwoFactorResponse(
+  session: Session | null,
+): NextResponse | null {
+  if (session?.user?.requiresTwoFactor) {
+    return NextResponse.json(
+      { error: 'Two-factor authentication required' },
+      { status: 401 },
+    )
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

REST API ハンドラが `session.user.requiresTwoFactor` を check しておらず、 2FA verify 未完了 user が 2FA 管理 / password 変更 / admin whitelist endpoint を REST 経由で直接呼べる bypass があった。 tRPC では `publicProcedure`/`adminProcedure` で既に gate 済 (`src/trpc/init.ts:63-75`) で、 REST 側だけ抜けていた状態。

- `src/lib/auth-helpers.ts` に `requiresTwoFactorResponse(session)` helper を追加 (401 `two_factor_required`)
- 8 handler (5 files) に gate を適用、 tRPC と同じ **requiresTwoFactor → mustChangePassword** の順で呼出
- `change-password` だけは 2FA gate のみ (mustChangePassword は意図的 exempt — このフラグを解除する endpoint 自身のため)

Closes #166

## 変更内容

| File | Handler | 適用 gate |
|---|---|---|
| `src/app/api/2fa/setup/route.ts` | POST | requiresTwoFactor + mustChangePassword (既存) |
| `src/app/api/2fa/verify-setup/route.ts` | POST | requiresTwoFactor + mustChangePassword (既存) |
| `src/app/api/2fa/disable/route.ts` | POST | requiresTwoFactor + mustChangePassword (既存) |
| `src/app/api/auth/change-password/route.ts` | POST | requiresTwoFactor のみ |
| `src/app/api/admin/whitelist/route.ts` | POST + GET | requiresTwoFactor + mustChangePassword (既存) |
| `src/app/api/admin/whitelist/[userId]/route.ts` | PATCH + DELETE | requiresTwoFactor + mustChangePassword (既存) |

**除外**: `/api/2fa/verify` (pre-auth, full session を持たない — このフロー自体が `requiresTwoFactor` フラグを解除する)、 NextAuth handler。

## Test plan

- [x] `pnpm check-types` (tsc --noEmit, 0 errors)
- [x] `pnpm test src/lib/auth-helpers.test.ts` (8/8 pass、 新規 4 test 含む)
- [x] `pnpm check-formatting` (prettier pass)
- [x] `pnpm lint` (0 errors、 既存 warnings のみ)
- [x] `pnpm build` (production build pass)
- [ ] 手動確認: `requiresTwoFactor=true` session で各 endpoint を呼出し → 401 `two_factor_required` を確認
- [ ] 手動確認: 正常 user (2FA verify 済) で各 endpoint を呼出し → 通常レスポンス確認