### PR TITLE
fix(security): use async rate-limit API in all callers

### DIFF
--- a/src/__tests__/rate-limit-callers.test.ts
+++ b/src/__tests__/rate-limit-callers.test.ts
@@ -1,0 +1,142 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Caller-side regression tests for Issue #167.
+ *
+ * The sync `checkRateLimit` entry point silently returns `{ isLimited:
+ * false }` when `RATE_LIMIT_STORAGE` is not `memory`, which bypassed all
+ * rate limiting in distributed deployments. The fix migrates every
+ * in-repo caller to the async API. These tests pin that wiring: if a
+ * future refactor re-introduces a sync `checkRateLimit(...)` call, the
+ * mocked async function won't see `isLimited: true` and the assertion
+ * here will fail.
+ *
+ * Two representative caller paths are exercised:
+ *   - POST /api/auth/change-password
+ *   - POST /api/2fa/verify
+ * Other handlers (verify-setup, 2fa/disable) share the same call shape
+ * and are covered by code review.
+ */
+
+jest.mock('@/lib/auth', () => ({
+  auth: jest.fn(),
+  isPrivateInstance: jest.fn(() => true),
+}))
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    admin: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    whitelistUser: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('@/lib/rate-limit', () => ({
+  checkRateLimit: jest.fn(() => ({ isLimited: false })),
+  recordFailedAttempt: jest.fn(),
+  clearAttempts: jest.fn(),
+  checkRateLimitAsync: jest.fn(),
+  recordFailedAttemptAsync: jest.fn(() => Promise.resolve()),
+  clearAttemptsAsync: jest.fn(() => Promise.resolve()),
+}))
+
+jest.mock('@/lib/two-factor', () => ({
+  decryptSecret: jest.fn(() => 'SECRET'),
+  verifyTOTP: jest.fn(() => false),
+  decryptBackupCodes: jest.fn(() => ['CODE1']),
+  encryptBackupCodes: jest.fn(() => 'enc-codes'),
+  normalizeToken: jest.fn((t: string) => t),
+  timingSafeCompare: jest.fn(() => false),
+  generateTOTPSecret: jest.fn(() => ({ secret: 'S', otpauthUrl: 'o' })),
+  generateQRCode: jest.fn(() => Promise.resolve('data:image/png;base64,xxx')),
+  generateBackupCodes: jest.fn(() => ['CODE1']),
+  encryptSecret: jest.fn(() => 'enc-secret'),
+}))
+
+jest.mock('bcryptjs', () => ({
+  compare: jest.fn(() => Promise.resolve(true)),
+  hash: jest.fn(() => Promise.resolve('hashed')),
+}))
+
+import { auth } from '@/lib/auth'
+import { checkRateLimitAsync } from '@/lib/rate-limit'
+
+const mockedAuth = auth as jest.MockedFunction<typeof auth>
+const mockedCheckRateLimitAsync = checkRateLimitAsync as jest.MockedFunction<
+  typeof checkRateLimitAsync
+>
+
+function makeSession() {
+  return {
+    user: {
+      id: 'u1',
+      email: 'user@example.com',
+      isAdmin: false,
+      mustChangePassword: false,
+      twoFactorEnabled: true,
+      requiresTwoFactor: false,
+    },
+    expires: '2099-01-01T00:00:00.000Z',
+  } as never
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  // Default to not limited so the gate doesn't trigger unless a test opts in.
+  mockedCheckRateLimitAsync.mockResolvedValue({ isLimited: false })
+})
+
+describe('rate-limit async callers (Issue #167)', () => {
+  it('POST /api/auth/change-password returns 429 from the async rate limit', async () => {
+    mockedAuth.mockResolvedValue(makeSession())
+    mockedCheckRateLimitAsync.mockResolvedValueOnce({
+      isLimited: true,
+      retryAfter: 60,
+    })
+
+    const { POST } = await import('@/app/api/auth/change-password/route')
+    const request = new Request('http://localhost/api/auth/change-password', {
+      method: 'POST',
+      body: JSON.stringify({
+        currentPassword: 'old',
+        newPassword: 'newpass12',
+      }),
+    })
+    const res = await POST(request)
+
+    expect(res.status).toBe(429)
+    const body = (await res.json()) as { retryAfter?: number; error: string }
+    expect(body.retryAfter).toBe(60)
+    expect(body.error).toMatch(/too many/i)
+    // The caller must use the async API; if a future refactor re-introduces
+    // the sync `checkRateLimit`, this expectation will fail.
+    expect(mockedCheckRateLimitAsync).toHaveBeenCalledTimes(1)
+  })
+
+  it('POST /api/2fa/verify returns 429 from the async rate limit', async () => {
+    mockedCheckRateLimitAsync.mockResolvedValueOnce({
+      isLimited: true,
+      retryAfter: 30,
+    })
+
+    const { POST } = await import('@/app/api/2fa/verify/route')
+    const request = new Request('http://localhost/api/2fa/verify', {
+      method: 'POST',
+      body: JSON.stringify({ email: 'user@example.com', token: '123456' }),
+    })
+    const res = await POST(request)
+
+    expect(res.status).toBe(429)
+    const body = (await res.json()) as { retryAfter?: number; error: string }
+    expect(body.retryAfter).toBe(30)
+    expect(body.error).toMatch(/too many/i)
+    expect(mockedCheckRateLimitAsync).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/__tests__/rest-2fa-gate.test.ts
+++ b/src/__tests__/rest-2fa-gate.test.ts
@@ -62,9 +62,14 @@ jest.mock('@/lib/two-factor', () => ({
 }))
 
 jest.mock('@/lib/rate-limit', () => ({
+  // Sync API still exported (kept for back-compat, deprecated in #167).
   checkRateLimit: jest.fn(() => ({ isLimited: false })),
   recordFailedAttempt: jest.fn(),
   clearAttempts: jest.fn(),
+  // Async API — used by all callers in this repo after #167.
+  checkRateLimitAsync: jest.fn(() => Promise.resolve({ isLimited: false })),
+  recordFailedAttemptAsync: jest.fn(() => Promise.resolve()),
+  clearAttemptsAsync: jest.fn(() => Promise.resolve()),
 }))
 
 jest.mock('bcryptjs', () => ({

--- a/src/__tests__/two-factor-last-verified.test.ts
+++ b/src/__tests__/two-factor-last-verified.test.ts
@@ -43,9 +43,14 @@ jest.mock('@/lib/two-factor', () => ({
 }))
 
 jest.mock('@/lib/rate-limit', () => ({
+  // Sync API still exported (kept for back-compat, deprecated in #167).
   checkRateLimit: jest.fn(() => ({ isLimited: false })),
   recordFailedAttempt: jest.fn(),
   clearAttempts: jest.fn(),
+  // Async API — used by all callers in this repo after #167.
+  checkRateLimitAsync: jest.fn(() => Promise.resolve({ isLimited: false })),
+  recordFailedAttemptAsync: jest.fn(() => Promise.resolve()),
+  clearAttemptsAsync: jest.fn(() => Promise.resolve()),
 }))
 
 jest.mock('bcryptjs', () => ({

--- a/src/app/api/2fa/disable/route.ts
+++ b/src/app/api/2fa/disable/route.ts
@@ -12,9 +12,9 @@ import {
 } from '@/lib/auth-helpers'
 import { prisma } from '@/lib/prisma'
 import {
-  checkRateLimit,
-  clearAttempts,
-  recordFailedAttempt,
+  checkRateLimitAsync,
+  clearAttemptsAsync,
+  recordFailedAttemptAsync,
 } from '@/lib/rate-limit'
 import {
   decryptBackupCodes,
@@ -48,7 +48,7 @@ export async function POST(request: Request) {
 
     // Check rate limit (5 attempts per 15 minutes per user)
     const rateLimitKey = `${RATE_LIMIT_PREFIX}${userId}`
-    const rateLimitResult = checkRateLimit(rateLimitKey)
+    const rateLimitResult = await checkRateLimitAsync(rateLimitKey)
 
     if (rateLimitResult.isLimited) {
       return NextResponse.json(
@@ -134,7 +134,7 @@ export async function POST(request: Request) {
     // 3. Verify the password matches user's password
     const isValidPassword = await bcrypt.compare(password, userPassword)
     if (!isValidPassword) {
-      recordFailedAttempt(rateLimitKey)
+      await recordFailedAttemptAsync(rateLimitKey)
       return NextResponse.json(
         { error: 'Password is incorrect' },
         { status: 400 },
@@ -193,7 +193,7 @@ export async function POST(request: Request) {
     }
 
     if (!isValidToken) {
-      recordFailedAttempt(rateLimitKey)
+      await recordFailedAttemptAsync(rateLimitKey)
       return NextResponse.json(
         { error: 'Invalid token or backup code' },
         { status: 400 },
@@ -201,7 +201,7 @@ export async function POST(request: Request) {
     }
 
     // Clear rate limit attempts on successful verification
-    clearAttempts(rateLimitKey)
+    await clearAttemptsAsync(rateLimitKey)
 
     // 5. If verified, set twoFactorEnabled=false, twoFactorSecret=null, twoFactorBackupCodes=null
     if (isAdmin) {

--- a/src/app/api/2fa/verify-setup/route.ts
+++ b/src/app/api/2fa/verify-setup/route.ts
@@ -11,9 +11,9 @@ import {
 } from '@/lib/auth-helpers'
 import { prisma } from '@/lib/prisma'
 import {
-  checkRateLimit,
-  clearAttempts,
-  recordFailedAttempt,
+  checkRateLimitAsync,
+  clearAttemptsAsync,
+  recordFailedAttemptAsync,
 } from '@/lib/rate-limit'
 import { decryptSecret, verifyTOTP } from '@/lib/two-factor'
 import { NextResponse } from 'next/server'
@@ -58,7 +58,7 @@ export async function POST(request: Request) {
 
     // Check rate limit (5 attempts per 15 minutes per user)
     const rateLimitKey = `${RATE_LIMIT_PREFIX}${userId}`
-    const rateLimitResult = checkRateLimit(rateLimitKey)
+    const rateLimitResult = await checkRateLimitAsync(rateLimitKey)
 
     if (rateLimitResult.isLimited) {
       return NextResponse.json(
@@ -125,7 +125,7 @@ export async function POST(request: Request) {
     const isValidToken = verifyTOTP(decryptedSecret, token)
 
     if (!isValidToken) {
-      recordFailedAttempt(rateLimitKey)
+      await recordFailedAttemptAsync(rateLimitKey)
       return NextResponse.json(
         { error: 'Invalid token. Please try again.' },
         { status: 400 },
@@ -133,7 +133,7 @@ export async function POST(request: Request) {
     }
 
     // Clear rate limit attempts on successful verification
-    clearAttempts(rateLimitKey)
+    await clearAttemptsAsync(rateLimitKey)
 
     // 5. If valid, set twoFactorEnabled=true and record the verification time
     // so the jwt callback's 5-minute window treats this setup as the latest

--- a/src/app/api/2fa/verify/route.ts
+++ b/src/app/api/2fa/verify/route.ts
@@ -8,9 +8,9 @@
 
 import { prisma } from '@/lib/prisma'
 import {
-  checkRateLimit,
-  clearAttempts,
-  recordFailedAttempt,
+  checkRateLimitAsync,
+  clearAttemptsAsync,
+  recordFailedAttemptAsync,
 } from '@/lib/rate-limit'
 import {
   decryptBackupCodes,
@@ -47,7 +47,7 @@ export async function POST(request: Request) {
 
     // Check rate limit before processing (5 attempts per minute per email)
     const rateLimitKey = `${RATE_LIMIT_PREFIX}${email}`
-    const rateLimitResult = checkRateLimit(rateLimitKey)
+    const rateLimitResult = await checkRateLimitAsync(rateLimitKey)
 
     if (rateLimitResult.isLimited) {
       return NextResponse.json(
@@ -184,12 +184,12 @@ export async function POST(request: Request) {
 
     if (!verified) {
       // Record failed attempt for rate limiting
-      recordFailedAttempt(rateLimitKey)
+      await recordFailedAttemptAsync(rateLimitKey)
       return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
     }
 
     // Clear rate limit attempts on successful verification
-    clearAttempts(rateLimitKey)
+    await clearAttemptsAsync(rateLimitKey)
 
     // Record server-side 2FA verification timestamp (Issue #123)
     // This prevents client-side bypass of twoFactorVerified flag

--- a/src/app/api/auth/change-password/route.ts
+++ b/src/app/api/auth/change-password/route.ts
@@ -8,9 +8,9 @@ import { auth } from '@/lib/auth'
 import { requiresTwoFactorResponse } from '@/lib/auth-helpers'
 import { prisma } from '@/lib/prisma'
 import {
-  checkRateLimit,
-  clearAttempts,
-  recordFailedAttempt,
+  checkRateLimitAsync,
+  clearAttemptsAsync,
+  recordFailedAttemptAsync,
 } from '@/lib/rate-limit'
 import bcrypt from 'bcryptjs'
 import { NextResponse } from 'next/server'
@@ -34,7 +34,7 @@ export async function POST(request: Request) {
 
     // Check rate limit before processing (Issue #43)
     const rateLimitKey = `${RATE_LIMIT_PREFIX}${session.user.email}`
-    const rateLimitResult = checkRateLimit(rateLimitKey)
+    const rateLimitResult = await checkRateLimitAsync(rateLimitKey)
 
     if (rateLimitResult.isLimited) {
       return NextResponse.json(
@@ -105,7 +105,7 @@ export async function POST(request: Request) {
     const isValidPassword = await bcrypt.compare(currentPassword, userPassword)
     if (!isValidPassword) {
       // Record failed attempt for rate limiting (Issue #43)
-      recordFailedAttempt(rateLimitKey)
+      await recordFailedAttemptAsync(rateLimitKey)
       return NextResponse.json(
         { error: 'Current password is incorrect' },
         { status: 400 },
@@ -139,7 +139,7 @@ export async function POST(request: Request) {
     }
 
     // Clear rate limit attempts on successful password change (Issue #43)
-    clearAttempts(rateLimitKey)
+    await clearAttemptsAsync(rateLimitKey)
 
     return NextResponse.json({ success: true })
   } catch (error) {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -4,9 +4,9 @@
 
 import { prisma } from '@/lib/prisma'
 import {
-  checkRateLimit,
-  clearAttempts,
-  recordFailedAttempt,
+  checkRateLimitAsync,
+  clearAttemptsAsync,
+  recordFailedAttemptAsync,
 } from '@/lib/rate-limit'
 import { isJwtValidForUser } from '@/lib/session-validation'
 import { PrismaAdapter } from '@auth/prisma-adapter'
@@ -56,8 +56,10 @@ const authConfig: NextAuthConfig = {
         const email = credentials.email as string
         const password = credentials.password as string
 
-        // Check rate limit before attempting authentication
-        const rateLimit = checkRateLimit(email)
+        // Check rate limit before attempting authentication.
+        // Use the async API so database storage (Issue #167) is respected;
+        // the sync entry point silently bypasses non-memory backends.
+        const rateLimit = await checkRateLimitAsync(email)
         if (rateLimit.isLimited) {
           console.warn(
             `Rate limited login attempt for ${email}. Retry after ${rateLimit.retryAfter}s`,
@@ -77,7 +79,7 @@ const authConfig: NextAuthConfig = {
           const isValidPassword = await bcrypt.compare(password, admin.password)
           if (isValidPassword) {
             // Clear rate limit on successful login
-            clearAttempts(email)
+            await clearAttemptsAsync(email)
             // Check if 2FA is enabled for this user
             const twoFactorEnabled = admin.twoFactorEnabled ?? false
             return {
@@ -97,7 +99,7 @@ const authConfig: NextAuthConfig = {
           )
           if (isValidPassword) {
             // Clear rate limit on successful login
-            clearAttempts(email)
+            await clearAttemptsAsync(email)
             // Check if 2FA is enabled for this user
             const twoFactorEnabled = whitelistUser.twoFactorEnabled ?? false
             return {
@@ -116,7 +118,7 @@ const authConfig: NextAuthConfig = {
         }
 
         // Record failed attempt for rate limiting
-        recordFailedAttempt(email)
+        await recordFailedAttemptAsync(email)
         return null
       },
     }),

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -273,7 +273,16 @@ function getStorageSync(): RateLimitStorage {
 // ============================================================
 
 /**
- * Check if an email is rate limited
+ * Check if an email is rate limited (synchronous, memory-only).
+ *
+ * @deprecated Use `checkRateLimitAsync` instead. When
+ * `RATE_LIMIT_STORAGE=database` (or `auto` resolving to database) this
+ * function unconditionally returns `{ isLimited: false }` and therefore
+ * bypasses rate limiting entirely (Issue #167). It remains exported for
+ * backward compatibility with callers that only run in single-instance,
+ * memory-storage deployments. All callers inside this repo were migrated
+ * to the async API in #167.
+ *
  * @returns Object with isLimited flag and optional retryAfter (seconds)
  */
 export function checkRateLimit(email: string): {
@@ -401,8 +410,13 @@ export async function checkRateLimitAsync(email: string): Promise<{
 }
 
 /**
- * Record a failed login attempt
- * Uses sync memory storage for immediate effect when available
+ * Record a failed login attempt (synchronous, memory-only).
+ *
+ * @deprecated Use `recordFailedAttemptAsync` instead. For non-memory
+ * storage backends this function fires `recordFailedAttemptAsync` as a
+ * fire-and-forget promise, so the increment is racy and may not be
+ * observed by the next `checkRateLimit` call (Issue #167). All callers
+ * inside this repo were migrated to the async API in #167.
  */
 export function recordFailedAttempt(email: string): void {
   const key = email.toLowerCase()
@@ -460,8 +474,12 @@ export async function recordFailedAttemptAsync(email: string): Promise<void> {
 }
 
 /**
- * Clear attempts on successful login
- * Uses sync memory storage for immediate effect when available
+ * Clear attempts on successful login (synchronous, memory-only).
+ *
+ * @deprecated Use `clearAttemptsAsync` instead. For non-memory storage
+ * backends this function fires `clearAttemptsAsync` as a fire-and-forget
+ * promise, so the reset is racy (Issue #167). All callers inside this
+ * repo were migrated to the async API in #167.
  */
 export function clearAttempts(email: string): void {
   const key = email.toLowerCase()


### PR DESCRIPTION
## Summary

`src/lib/rate-limit.ts:307-311` の sync `checkRateLimit()` は storage backend が `MemoryStorage` 以外の場合 unconditionally `{ isLimited: false }` を返す:

\`\`\`ts
if (!(store instanceof MemoryStorage)) {
  return { isLimited: false, remainingAttempts: MAX_ATTEMPTS }
}
\`\`\`

これにより \`RATE_LIMIT_STORAGE=database\` (multi-instance deployment 推奨構成) で **NextAuth ログイン + 4 REST endpoint の rate limiting が完全 bypass** され、 password / TOTP / backup code brute force が unthrottled で実行可能になる。

## 修正方針

Issue #167 提案 #1 (全 caller を async 化) を採用。 sync API は `@deprecated` で残し後方互換維持。

| File | 関数 |
|---|---|
| `src/lib/auth.ts` | NextAuth Credentials.authorize |
| `src/app/api/auth/change-password/route.ts` | POST |
| `src/app/api/2fa/verify/route.ts` | POST (pre-auth) |
| `src/app/api/2fa/verify-setup/route.ts` | POST |
| `src/app/api/2fa/disable/route.ts` | POST |

各 file で:
- `checkRateLimit(...)` → `await checkRateLimitAsync(...)`
- `recordFailedAttempt(...)` → `await recordFailedAttemptAsync(...)`
- `clearAttempts(...)` → `await clearAttemptsAsync(...)`

全 caller が既に async 関数 (authorize / POST handler) なので `await` 追加は機械的。

## 後方互換

sync API (`checkRateLimit`, `recordFailedAttempt`, `clearAttempts`) は引き続き export、 `@deprecated` JSDoc + Issue #167 へのリンク追加のみ。 削除はしない (外部から import している人がいた場合のため + memory storage の既存挙動を維持するため)。

## Tests

- **既存 `src/lib/rate-limit.test.ts`** (sync + async 両 path test) は **削除せず維持** — memory storage の後方互換挙動を pin
- **`rest-2fa-gate.test.ts` / `two-factor-last-verified.test.ts`** の `jest.mock('@/lib/rate-limit', ...)` に async API も追加
- **新規 `src/__tests__/rate-limit-callers.test.ts`** caller regression test 2 件:
  - POST /api/auth/change-password が async API isLimited:true で 429 返す
  - POST /api/2fa/verify が async API isLimited:true で 429 返す
  - `expect(mockedCheckRateLimitAsync).toHaveBeenCalledTimes(1)` で「sync を再導入したら fail」する保証

## Test plan

- [x] \`pnpm check-types\` (tsc --noEmit, 0 errors)
- [x] \`pnpm test\` (20 suites / 334 tests pass、 PR #217 から +1 suite / +2 tests)
- [x] \`pnpm check-formatting\` (prettier pass)
- [x] \`pnpm lint\` (0 errors、 既存 warnings のみ)
- [x] \`pnpm build\` (production build pass)
- [ ] 手動確認: \`RATE_LIMIT_STORAGE=database\` で 5 回失敗ログイン → 6 回目 lockout (429) を確認
- [ ] 手動確認: \`RATE_LIMIT_STORAGE=memory\` (default) で挙動変化なし