### PR TITLE
fix(security): refresh isAdmin/mustChangePassword/twoFactorEnabled on every JWT validation (closes #173)

### DIFF
--- a/src/__tests__/jwt-refresh-stale-role.test.ts
+++ b/src/__tests__/jwt-refresh-stale-role.test.ts
@@ -21,14 +21,13 @@
  *    window) keep working through the new code path.
  */
 
-import type { JWT } from 'next-auth/jwt'
-
 jest.mock('@/lib/session-validation', () => ({
   refreshJwtFromUser: jest.fn(),
 }))
 
 import { jwtCallback } from '@/lib/auth-jwt'
 import { refreshJwtFromUser } from '@/lib/session-validation'
+import type { JWT } from 'next-auth/jwt'
 
 const mockedRefresh = refreshJwtFromUser as jest.MockedFunction<
   typeof refreshJwtFromUser
@@ -55,14 +54,7 @@ describe('jwtCallback (Issue #173)', () => {
   })
 
   describe('initial sign-in (user parameter present)', () => {
-    it('seeds the token from authorize() and still refreshes from DB', async () => {
-      mockedRefresh.mockResolvedValueOnce({
-        isAdmin: true,
-        mustChangePassword: false,
-        twoFactorEnabled: true,
-        lastTwoFactorVerifiedAt: null,
-      })
-
+    it('seeds the token from authorize() without calling refresh', async () => {
       const token = makeToken({ isAdmin: false })
       const result = await jwtCallback({
         token,
@@ -77,12 +69,40 @@ describe('jwtCallback (Issue #173)', () => {
         trigger: 'signIn',
       })
 
-      // user.isAdmin=true seeded, then DB refresh keeps it true.
+      // Values come straight from authorize()'s return value.
       expect((result as Record<string, unknown>).isAdmin).toBe(true)
       expect((result as Record<string, unknown>).twoFactorEnabled).toBe(true)
-      // requiresTwoFactor stays true because the DB confirms 2FA is on and
-      // it was just seeded as true (no transition to clear it).
       expect((result as Record<string, unknown>).requiresTwoFactor).toBe(true)
+      // Refresh is intentionally skipped on initial sign-in because
+      // NextAuth has not yet populated `token.iat`, and the
+      // passwordChangedAt check in refreshJwtFromUser would otherwise
+      // reject the token.
+      expect(mockedRefresh).not.toHaveBeenCalled()
+    })
+
+    it('does not strip identity on initial sign-in when iat is absent and the user has passwordChangedAt set (PR #220 regression)', async () => {
+      // Pre-fix behaviour: refreshJwtFromUser ran with iat=undefined.
+      // isTokenIatAcceptable returns false whenever passwordChangedAt is
+      // set and iat is missing, so the callback would strip identity and
+      // the user could not re-authenticate even with the correct
+      // password. The fix is to skip refresh on initial sign-in.
+      const token = makeToken({ iat: undefined })
+
+      const result = (await jwtCallback({
+        token,
+        user: {
+          id: 'user-1',
+          email: 'user@example.com',
+          isAdmin: false,
+          mustChangePassword: false,
+          twoFactorEnabled: false,
+          requiresTwoFactor: false,
+        },
+        trigger: 'signIn',
+      })) as Record<string, unknown>
+
+      expect(result.sub).toBe('user-1')
+      expect(mockedRefresh).not.toHaveBeenCalled()
     })
   })
 

--- a/src/__tests__/jwt-refresh-stale-role.test.ts
+++ b/src/__tests__/jwt-refresh-stale-role.test.ts
@@ -1,0 +1,326 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Regression tests for the JWT callback's per-request refresh of
+ * security-critical user fields (Issue #173).
+ *
+ * The callback is exported from `@/lib/auth-jwt` so it can be exercised
+ * directly without booting the NextAuth runtime in `@/lib/auth`. Here we
+ * mock `@/lib/session-validation` so each test pins the
+ * `refreshJwtFromUser` return value and asserts the callback's reaction:
+ *
+ *  - Admin role revoke -> token identity stripped on next request.
+ *  - Admin disables a user's 2FA -> `requiresTwoFactor` clears so the user
+ *    is not stuck on the 2FA gate.
+ *  - Admin sets `mustChangePassword=true` -> reflected on next request.
+ *  - 2FA newly enabled while session is alive -> `requiresTwoFactor`
+ *    becomes true so the user must re-verify.
+ *  - Issue #135 (password rotation) and #123 (5-minute verification
+ *    window) keep working through the new code path.
+ */
+
+import type { JWT } from 'next-auth/jwt'
+
+jest.mock('@/lib/session-validation', () => ({
+  refreshJwtFromUser: jest.fn(),
+}))
+
+import { jwtCallback } from '@/lib/auth-jwt'
+import { refreshJwtFromUser } from '@/lib/session-validation'
+
+const mockedRefresh = refreshJwtFromUser as jest.MockedFunction<
+  typeof refreshJwtFromUser
+>
+
+// Helper: build a token with the security-critical claims our codebase
+// stores. `as unknown as JWT` lets us bypass the strict JWT type while
+// keeping the shape explicit at each test site.
+function makeToken(overrides: Record<string, unknown>): JWT {
+  return {
+    sub: 'user-1',
+    iat: 1_700_000_000,
+    isAdmin: false,
+    mustChangePassword: false,
+    twoFactorEnabled: false,
+    requiresTwoFactor: false,
+    ...overrides,
+  } as unknown as JWT
+}
+
+describe('jwtCallback (Issue #173)', () => {
+  beforeEach(() => {
+    mockedRefresh.mockReset()
+  })
+
+  describe('initial sign-in (user parameter present)', () => {
+    it('seeds the token from authorize() and still refreshes from DB', async () => {
+      mockedRefresh.mockResolvedValueOnce({
+        isAdmin: true,
+        mustChangePassword: false,
+        twoFactorEnabled: true,
+        lastTwoFactorVerifiedAt: null,
+      })
+
+      const token = makeToken({ isAdmin: false })
+      const result = await jwtCallback({
+        token,
+        user: {
+          id: 'user-1',
+          email: 'admin@example.com',
+          isAdmin: true,
+          mustChangePassword: false,
+          twoFactorEnabled: true,
+          requiresTwoFactor: true,
+        },
+        trigger: 'signIn',
+      })
+
+      // user.isAdmin=true seeded, then DB refresh keeps it true.
+      expect((result as Record<string, unknown>).isAdmin).toBe(true)
+      expect((result as Record<string, unknown>).twoFactorEnabled).toBe(true)
+      // requiresTwoFactor stays true because the DB confirms 2FA is on and
+      // it was just seeded as true (no transition to clear it).
+      expect((result as Record<string, unknown>).requiresTwoFactor).toBe(true)
+    })
+  })
+
+  describe('admin-driven changes (Issue #173)', () => {
+    it('admin role revoke -> token identity stripped', async () => {
+      // refreshJwtFromUser returns null when the user is no longer in the
+      // expected table (e.g. admin row removed).
+      mockedRefresh.mockResolvedValueOnce(null)
+
+      const token = makeToken({
+        isAdmin: true,
+        twoFactorEnabled: true,
+        requiresTwoFactor: false,
+      })
+
+      const result = (await jwtCallback({ token })) as Record<string, unknown>
+
+      expect(result.sub).toBeUndefined()
+      expect(result.isAdmin).toBe(false)
+      expect(result.mustChangePassword).toBe(false)
+      expect(result.twoFactorEnabled).toBe(false)
+      expect(result.requiresTwoFactor).toBe(false)
+    })
+
+    it('admin disables user 2FA -> requiresTwoFactor clears', async () => {
+      // Pre: user's session had 2FA verified.
+      // Admin disables 2FA on this account.
+      mockedRefresh.mockResolvedValueOnce({
+        isAdmin: false,
+        mustChangePassword: false,
+        twoFactorEnabled: false,
+        lastTwoFactorVerifiedAt: null,
+      })
+
+      const token = makeToken({
+        twoFactorEnabled: true,
+        requiresTwoFactor: true,
+      })
+
+      const result = (await jwtCallback({ token })) as Record<string, unknown>
+
+      expect(result.twoFactorEnabled).toBe(false)
+      // Cleared so the user is not stuck on a 2FA gate they can no longer pass.
+      expect(result.requiresTwoFactor).toBe(false)
+    })
+
+    it('admin sets mustChangePassword=true -> token reflects it', async () => {
+      mockedRefresh.mockResolvedValueOnce({
+        isAdmin: false,
+        mustChangePassword: true,
+        twoFactorEnabled: false,
+        lastTwoFactorVerifiedAt: null,
+      })
+
+      const token = makeToken({ mustChangePassword: false })
+
+      const result = (await jwtCallback({ token })) as Record<string, unknown>
+
+      expect(result.mustChangePassword).toBe(true)
+    })
+
+    it('2FA newly enabled while session is active -> requiresTwoFactor set true', async () => {
+      mockedRefresh.mockResolvedValueOnce({
+        isAdmin: false,
+        mustChangePassword: false,
+        twoFactorEnabled: true,
+        lastTwoFactorVerifiedAt: null,
+      })
+
+      const token = makeToken({
+        twoFactorEnabled: false,
+        requiresTwoFactor: false,
+      })
+
+      const result = (await jwtCallback({ token })) as Record<string, unknown>
+
+      expect(result.twoFactorEnabled).toBe(true)
+      // Defense in depth: a transition from off to on forces re-verification
+      // even though no `trigger === 'update'` was involved.
+      expect(result.requiresTwoFactor).toBe(true)
+    })
+
+    it('preserves requiresTwoFactor=false when 2FA stays enabled (mid-session refetch)', async () => {
+      // The user verified 2FA earlier in this session and is now making
+      // another request. Refresh sees 2FA still on; we must not re-arm
+      // requiresTwoFactor or every request after verification would
+      // bounce the user back to the 2FA gate.
+      mockedRefresh.mockResolvedValueOnce({
+        isAdmin: false,
+        mustChangePassword: false,
+        twoFactorEnabled: true,
+        lastTwoFactorVerifiedAt: new Date(),
+      })
+
+      const token = makeToken({
+        twoFactorEnabled: true,
+        requiresTwoFactor: false,
+      })
+
+      const result = (await jwtCallback({ token })) as Record<string, unknown>
+
+      expect(result.requiresTwoFactor).toBe(false)
+    })
+  })
+
+  describe('Issue #135 (password rotation) still rejects stale tokens', () => {
+    it('returns a stripped-identity token when refresh returns null', async () => {
+      // session-validation returns null when the token's iat predates the
+      // user's passwordChangedAt. The callback must clear identity.
+      mockedRefresh.mockResolvedValueOnce(null)
+
+      const token = makeToken({
+        isAdmin: true,
+        mustChangePassword: false,
+        twoFactorEnabled: true,
+        requiresTwoFactor: false,
+      })
+
+      const result = (await jwtCallback({ token })) as Record<string, unknown>
+
+      expect(result.sub).toBeUndefined()
+      expect(result.isAdmin).toBe(false)
+    })
+  })
+
+  describe('Issue #123 (5-minute 2FA verification window)', () => {
+    const now = 1_700_000_000_000 // ms
+
+    beforeEach(() => {
+      jest.spyOn(Date, 'now').mockReturnValue(now)
+    })
+
+    afterEach(() => {
+      jest.restoreAllMocks()
+    })
+
+    it('clears requiresTwoFactor when trigger=update and server saw a recent verification', async () => {
+      mockedRefresh.mockResolvedValueOnce({
+        isAdmin: false,
+        mustChangePassword: false,
+        twoFactorEnabled: true,
+        // Verified 1 minute ago -> within the 5 minute window.
+        lastTwoFactorVerifiedAt: new Date(now - 60_000),
+      })
+
+      const token = makeToken({
+        twoFactorEnabled: true,
+        requiresTwoFactor: true,
+      })
+
+      const result = (await jwtCallback({
+        token,
+        trigger: 'update',
+        session: { twoFactorVerified: true },
+      })) as Record<string, unknown>
+
+      expect(result.requiresTwoFactor).toBe(false)
+    })
+
+    it('keeps requiresTwoFactor=true when server has no fresh verification', async () => {
+      mockedRefresh.mockResolvedValueOnce({
+        isAdmin: false,
+        mustChangePassword: false,
+        twoFactorEnabled: true,
+        // Verified 10 minutes ago -> outside the 5 minute window.
+        lastTwoFactorVerifiedAt: new Date(now - 10 * 60_000),
+      })
+
+      const token = makeToken({
+        twoFactorEnabled: true,
+        requiresTwoFactor: true,
+      })
+
+      const result = (await jwtCallback({
+        token,
+        trigger: 'update',
+        session: { twoFactorVerified: true },
+      })) as Record<string, unknown>
+
+      // Client-forged twoFactorVerified must not bypass an absent / stale
+      // server-side record.
+      expect(result.requiresTwoFactor).toBe(true)
+    })
+
+    it('ignores client twoFactorVerified outside trigger=update', async () => {
+      mockedRefresh.mockResolvedValueOnce({
+        isAdmin: false,
+        mustChangePassword: false,
+        twoFactorEnabled: true,
+        lastTwoFactorVerifiedAt: new Date(now),
+      })
+
+      const token = makeToken({
+        twoFactorEnabled: true,
+        requiresTwoFactor: true,
+      })
+
+      const result = (await jwtCallback({
+        token,
+        // No trigger='update' -> the verification-window branch is not entered.
+        session: { twoFactorVerified: true },
+      })) as Record<string, unknown>
+
+      expect(result.requiresTwoFactor).toBe(true)
+    })
+  })
+
+  describe('refresh-call wiring', () => {
+    it('passes the token sub, isAdmin claim, and iat to refreshJwtFromUser', async () => {
+      mockedRefresh.mockResolvedValueOnce({
+        isAdmin: true,
+        mustChangePassword: false,
+        twoFactorEnabled: false,
+        lastTwoFactorVerifiedAt: null,
+      })
+
+      const token = makeToken({
+        sub: 'admin-42',
+        iat: 1_700_000_500,
+        isAdmin: true,
+      })
+
+      await jwtCallback({ token })
+
+      expect(mockedRefresh).toHaveBeenCalledWith(
+        'admin-42',
+        true,
+        1_700_000_500,
+      )
+    })
+
+    it('skips refresh entirely when token.sub is missing', async () => {
+      const token = makeToken({ sub: undefined })
+
+      const result = await jwtCallback({ token })
+
+      expect(mockedRefresh).not.toHaveBeenCalled()
+      expect(result).toBe(token)
+    })
+  })
+})

--- a/src/lib/auth-jwt.ts
+++ b/src/lib/auth-jwt.ts
@@ -1,0 +1,113 @@
+/**
+ * JWT callback for NextAuth (Issue #173 / #135).
+ *
+ * Lives in its own module so it can be unit-tested without booting the
+ * NextAuth runtime in `auth.ts`. The function is bound into the authConfig
+ * at `src/lib/auth.ts`.
+ *
+ * Responsibilities:
+ *  - On initial sign-in (the `user` parameter is set), seed token claims
+ *    from the value returned by `authorize()`.
+ *  - On every subsequent validation, mirror security-critical fields from
+ *    the database onto the token via `refreshJwtFromUser`. This makes
+ *    admin-driven changes (role revoke, 2FA disable, mustChangePassword
+ *    set) take effect on the next request rather than waiting for token
+ *    expiry (#173).
+ *  - Reject tokens whose `iat` predates the user's `passwordChangedAt`
+ *    (#135), by clearing identity claims so downstream guards treat the
+ *    request as unauthenticated.
+ *  - Honour the client-driven 5-minute 2FA verification window only when
+ *    the server has actually recorded a recent verification (#123).
+ */
+
+import { refreshJwtFromUser } from '@/lib/session-validation'
+import type { User } from 'next-auth'
+import type { JWT } from 'next-auth/jwt'
+
+export async function jwtCallback({
+  token,
+  user,
+  trigger,
+  session: updateData,
+}: {
+  token: JWT
+  user?: User
+  trigger?: 'signIn' | 'signUp' | 'update'
+  session?: unknown
+}): Promise<JWT> {
+  // Initial sign-in: seed the token from authorize()'s return value.
+  if (user) {
+    ;(token as Record<string, unknown>).isAdmin = user.isAdmin
+    ;(token as Record<string, unknown>).mustChangePassword =
+      user.mustChangePassword
+    ;(token as Record<string, unknown>).twoFactorEnabled = user.twoFactorEnabled
+    ;(token as Record<string, unknown>).requiresTwoFactor =
+      user.requiresTwoFactor
+  }
+
+  if (!token.sub) return token
+
+  const isAdminHint = (token as Record<string, unknown>).isAdmin === true
+  const tokenIatSec = typeof token.iat === 'number' ? token.iat : undefined
+  const refreshed = await refreshJwtFromUser(
+    token.sub,
+    isAdminHint,
+    tokenIatSec,
+  )
+
+  if (!refreshed) {
+    // User no longer exists, was demoted out of the expected table, or the
+    // token predates a password change (#135). Strip identity so downstream
+    // guards treat the request as unauthenticated.
+    return {
+      ...token,
+      sub: undefined,
+      isAdmin: false,
+      mustChangePassword: false,
+      twoFactorEnabled: false,
+      requiresTwoFactor: false,
+    } as JWT
+  }
+
+  const wasTwoFactorEnabled =
+    (token as Record<string, unknown>).twoFactorEnabled === true
+
+  ;(token as Record<string, unknown>).isAdmin = refreshed.isAdmin
+  ;(token as Record<string, unknown>).mustChangePassword =
+    refreshed.mustChangePassword
+  ;(token as Record<string, unknown>).twoFactorEnabled =
+    refreshed.twoFactorEnabled
+
+  // requiresTwoFactor transitions driven by DB state:
+  //  - admin disabled the user's 2FA => clear the requirement so the user
+  //    is not locked out of every gated route until they re-login.
+  //  - 2FA was just enabled while a session was active => require a fresh
+  //    verification before granting access.
+  //  - otherwise preserve the existing flag so the 5-minute verification
+  //    window granted by `trigger === 'update'` is not erased.
+  if (!refreshed.twoFactorEnabled) {
+    ;(token as Record<string, unknown>).requiresTwoFactor = false
+  } else if (!wasTwoFactorEnabled) {
+    ;(token as Record<string, unknown>).requiresTwoFactor = true
+  }
+
+  // Client-driven session refresh after 2FA verification (#123). Clearing
+  // requiresTwoFactor here is conditional on the server having recorded a
+  // verification within the last 5 minutes so a client-forged
+  // `twoFactorVerified` cannot bypass 2FA.
+  if (
+    trigger === 'update' &&
+    refreshed.twoFactorEnabled &&
+    updateData &&
+    typeof updateData === 'object' &&
+    'twoFactorVerified' in updateData &&
+    (updateData as { twoFactorVerified?: unknown }).twoFactorVerified ===
+      true &&
+    refreshed.lastTwoFactorVerifiedAt &&
+    Date.now() - refreshed.lastTwoFactorVerifiedAt.getTime() < 5 * 60 * 1000
+  ) {
+    ;(token as Record<string, unknown>).requiresTwoFactor = false
+  }
+
+  return token
+}

--- a/src/lib/auth-jwt.ts
+++ b/src/lib/auth-jwt.ts
@@ -35,7 +35,16 @@ export async function jwtCallback({
   trigger?: 'signIn' | 'signUp' | 'update'
   session?: unknown
 }): Promise<JWT> {
-  // Initial sign-in: seed the token from authorize()'s return value.
+  // Initial sign-in: seed the token from authorize()'s return value and
+  // return immediately.
+  //
+  // The refresh path below depends on `token.iat`, but NextAuth populates
+  // `iat` *after* this callback returns on the first call. Feeding an
+  // undefined `iat` into `refreshJwtFromUser` makes `isTokenIatAcceptable`
+  // reject the token for any user whose `passwordChangedAt` is set,
+  // locking them out the moment they re-authenticate (regression caught
+  // in PR #220 review). authorize() has just read the DB, so the values
+  // we seeded are current — there is nothing to refresh on this hop.
   if (user) {
     ;(token as Record<string, unknown>).isAdmin = user.isAdmin
     ;(token as Record<string, unknown>).mustChangePassword =
@@ -43,6 +52,7 @@ export async function jwtCallback({
     ;(token as Record<string, unknown>).twoFactorEnabled = user.twoFactorEnabled
     ;(token as Record<string, unknown>).requiresTwoFactor =
       user.requiresTwoFactor
+    return token
   }
 
   if (!token.sub) return token

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -2,13 +2,13 @@
  * NextAuth.js configuration for Private Instance Mode (Issue #4)
  */
 
+import { jwtCallback } from '@/lib/auth-jwt'
 import { prisma } from '@/lib/prisma'
 import {
   checkRateLimitAsync,
   clearAttemptsAsync,
   recordFailedAttemptAsync,
 } from '@/lib/rate-limit'
-import { isJwtValidForUser } from '@/lib/session-validation'
 import { PrismaAdapter } from '@auth/prisma-adapter'
 import bcrypt from 'bcryptjs'
 import NextAuth, { type NextAuthConfig } from 'next-auth'
@@ -127,100 +127,7 @@ const authConfig: NextAuthConfig = {
     strategy: 'jwt',
   },
   callbacks: {
-    async jwt({ token, user, trigger, session: updateData }) {
-      if (user) {
-        ;(token as Record<string, unknown>).isAdmin = user.isAdmin
-        ;(token as Record<string, unknown>).mustChangePassword =
-          user.mustChangePassword
-        ;(token as Record<string, unknown>).twoFactorEnabled =
-          user.twoFactorEnabled
-        ;(token as Record<string, unknown>).requiresTwoFactor =
-          user.requiresTwoFactor
-      }
-      // Handle session update - always refresh from database for security
-      // Never trust client-sent values for security-critical flags
-      if (trigger === 'update' && token.sub) {
-        const admin = await prisma.admin.findUnique({
-          where: { id: token.sub },
-          select: {
-            mustChangePassword: true,
-            twoFactorEnabled: true,
-            lastTwoFactorVerifiedAt: true,
-          },
-        })
-        if (admin) {
-          ;(token as Record<string, unknown>).mustChangePassword =
-            admin.mustChangePassword
-          ;(token as Record<string, unknown>).twoFactorEnabled =
-            admin.twoFactorEnabled ?? false
-          // Clear requiresTwoFactor only if server-side 2FA verification is recent (Issue #123)
-          // Never trust client-sent twoFactorVerified flag alone
-          if (
-            updateData &&
-            typeof updateData === 'object' &&
-            'twoFactorVerified' in updateData &&
-            updateData.twoFactorVerified === true &&
-            admin.lastTwoFactorVerifiedAt &&
-            Date.now() - admin.lastTwoFactorVerifiedAt.getTime() < 5 * 60 * 1000
-          ) {
-            ;(token as Record<string, unknown>).requiresTwoFactor = false
-          }
-        } else {
-          const whitelistUser = await prisma.whitelistUser.findUnique({
-            where: { id: token.sub },
-            select: {
-              mustChangePassword: true,
-              twoFactorEnabled: true,
-              lastTwoFactorVerifiedAt: true,
-            },
-          })
-          if (whitelistUser) {
-            ;(token as Record<string, unknown>).mustChangePassword =
-              whitelistUser.mustChangePassword
-            ;(token as Record<string, unknown>).twoFactorEnabled =
-              whitelistUser.twoFactorEnabled ?? false
-            // Clear requiresTwoFactor only if server-side 2FA verification is recent (Issue #123)
-            if (
-              updateData &&
-              typeof updateData === 'object' &&
-              'twoFactorVerified' in updateData &&
-              updateData.twoFactorVerified === true &&
-              whitelistUser.lastTwoFactorVerifiedAt &&
-              Date.now() - whitelistUser.lastTwoFactorVerifiedAt.getTime() <
-                5 * 60 * 1000
-            ) {
-              ;(token as Record<string, unknown>).requiresTwoFactor = false
-            }
-          }
-        }
-      }
-
-      // Invalidate the token if the user's password has been changed since the
-      // token was issued (Issue #135). The check runs on every JWT callback,
-      // backed by a single indexed DB lookup. Users that never changed their
-      // password since the migration have `passwordChangedAt = null` and are
-      // unaffected. When invalid, we clear the auth-relevant fields so the
-      // session callback yields a session without a user id, which causes
-      // downstream guards (publicProcedure, adminProcedure, route handlers)
-      // that test `session?.user?.id` to treat the request as unauthenticated.
-      if (token.sub && typeof token.iat === 'number') {
-        const isAdmin = (token as Record<string, unknown>).isAdmin === true
-        const ok = await isJwtValidForUser(token.sub, isAdmin, token.iat)
-        if (!ok) {
-          return {
-            // Preserve only the bare token shell; strip identity and roles.
-            ...token,
-            sub: undefined,
-            isAdmin: false,
-            mustChangePassword: false,
-            twoFactorEnabled: false,
-            requiresTwoFactor: false,
-          } as typeof token
-        }
-      }
-
-      return token
-    },
+    jwt: jwtCallback,
     async session({ session, token }) {
       // When the jwt callback invalidates a token (e.g. password changed after
       // issuance, Issue #135), `token.sub` is cleared. We drop `session.user`

--- a/src/lib/session-validation.test.ts
+++ b/src/lib/session-validation.test.ts
@@ -14,10 +14,7 @@ jest.mock('./prisma', () => ({
 }))
 
 import { prisma } from './prisma'
-import {
-  isTokenIatAcceptable,
-  refreshJwtFromUser,
-} from './session-validation'
+import { isTokenIatAcceptable, refreshJwtFromUser } from './session-validation'
 
 const mockedAdminFind = prisma.admin.findUnique as jest.Mock
 const mockedWhitelistFind = prisma.whitelistUser.findUnique as jest.Mock

--- a/src/lib/session-validation.test.ts
+++ b/src/lib/session-validation.test.ts
@@ -2,11 +2,6 @@
  * @jest-environment node
  */
 
-import {
-  isTokenIatAcceptable,
-  refreshJwtFromUser,
-} from './session-validation'
-
 jest.mock('./prisma', () => ({
   prisma: {
     admin: {
@@ -19,6 +14,10 @@ jest.mock('./prisma', () => ({
 }))
 
 import { prisma } from './prisma'
+import {
+  isTokenIatAcceptable,
+  refreshJwtFromUser,
+} from './session-validation'
 
 const mockedAdminFind = prisma.admin.findUnique as jest.Mock
 const mockedWhitelistFind = prisma.whitelistUser.findUnique as jest.Mock

--- a/src/lib/session-validation.test.ts
+++ b/src/lib/session-validation.test.ts
@@ -1,4 +1,27 @@
-import { isTokenIatAcceptable } from './session-validation'
+/**
+ * @jest-environment node
+ */
+
+import {
+  isTokenIatAcceptable,
+  refreshJwtFromUser,
+} from './session-validation'
+
+jest.mock('./prisma', () => ({
+  prisma: {
+    admin: {
+      findUnique: jest.fn(),
+    },
+    whitelistUser: {
+      findUnique: jest.fn(),
+    },
+  },
+}))
+
+import { prisma } from './prisma'
+
+const mockedAdminFind = prisma.admin.findUnique as jest.Mock
+const mockedWhitelistFind = prisma.whitelistUser.findUnique as jest.Mock
 
 describe('isTokenIatAcceptable (Issue #135)', () => {
   const tokenIat = 1_700_000_000 // arbitrary seconds-since-epoch
@@ -61,6 +84,180 @@ describe('isTokenIatAcceptable (Issue #135)', () => {
       const passwordChangedAt = new Date(1_700_000_000 * 1000) // T
       const freshIat = 1_700_000_000 + 300 // T+5min (seconds)
       expect(isTokenIatAcceptable(freshIat, passwordChangedAt)).toBe(true)
+    })
+  })
+})
+
+describe('refreshJwtFromUser (Issue #173)', () => {
+  const tokenIat = 1_700_000_000
+
+  beforeEach(() => {
+    mockedAdminFind.mockReset()
+    mockedWhitelistFind.mockReset()
+  })
+
+  it('returns null when userId is empty', async () => {
+    const result = await refreshJwtFromUser('', true, tokenIat)
+    expect(result).toBeNull()
+    // Neither table should be queried for an empty userId.
+    expect(mockedAdminFind).not.toHaveBeenCalled()
+    expect(mockedWhitelistFind).not.toHaveBeenCalled()
+  })
+
+  describe('isAdminHint = true', () => {
+    it('returns refreshed values when the admin row exists', async () => {
+      mockedAdminFind.mockResolvedValueOnce({
+        mustChangePassword: false,
+        twoFactorEnabled: true,
+        lastTwoFactorVerifiedAt: new Date(tokenIat * 1000),
+        passwordChangedAt: null,
+      })
+
+      const result = await refreshJwtFromUser('admin-1', true, tokenIat)
+
+      expect(result).toEqual({
+        isAdmin: true,
+        mustChangePassword: false,
+        twoFactorEnabled: true,
+        lastTwoFactorVerifiedAt: new Date(tokenIat * 1000),
+      })
+      // Only the admin table is queried — whitelist remains untouched.
+      expect(mockedWhitelistFind).not.toHaveBeenCalled()
+    })
+
+    it('reflects admin-driven changes to mustChangePassword and twoFactorEnabled', async () => {
+      mockedAdminFind.mockResolvedValueOnce({
+        mustChangePassword: true,
+        twoFactorEnabled: false,
+        lastTwoFactorVerifiedAt: null,
+        passwordChangedAt: null,
+      })
+
+      const result = await refreshJwtFromUser('admin-1', true, tokenIat)
+
+      expect(result?.mustChangePassword).toBe(true)
+      expect(result?.twoFactorEnabled).toBe(false)
+    })
+
+    it('returns null when the admin was demoted (no admin row)', async () => {
+      // Admin demotion: the row is removed from the admin table, so the
+      // stale "isAdmin: true" token claim no longer matches any row.
+      mockedAdminFind.mockResolvedValueOnce(null)
+
+      const result = await refreshJwtFromUser('admin-1', true, tokenIat)
+
+      expect(result).toBeNull()
+      // Whitelist lookup is intentionally not attempted — the caller will
+      // strip identity and the user re-authenticates next request.
+      expect(mockedWhitelistFind).not.toHaveBeenCalled()
+    })
+
+    it('rejects the token when iat predates passwordChangedAt (Issue #135)', async () => {
+      mockedAdminFind.mockResolvedValueOnce({
+        mustChangePassword: false,
+        twoFactorEnabled: false,
+        lastTwoFactorVerifiedAt: null,
+        passwordChangedAt: new Date((tokenIat + 3600) * 1000), // 1h after iat
+      })
+
+      const result = await refreshJwtFromUser('admin-1', true, tokenIat)
+
+      expect(result).toBeNull()
+    })
+
+    it('coerces null twoFactorEnabled to false', async () => {
+      // Defense in depth: even if the column was somehow null, the
+      // returned shape must use a strict boolean.
+      mockedAdminFind.mockResolvedValueOnce({
+        mustChangePassword: false,
+        twoFactorEnabled: null,
+        lastTwoFactorVerifiedAt: null,
+        passwordChangedAt: null,
+      })
+
+      const result = await refreshJwtFromUser('admin-1', true, tokenIat)
+
+      expect(result?.twoFactorEnabled).toBe(false)
+    })
+  })
+
+  describe('isAdminHint = false', () => {
+    it('returns refreshed values when the whitelist row exists', async () => {
+      mockedWhitelistFind.mockResolvedValueOnce({
+        mustChangePassword: true,
+        twoFactorEnabled: false,
+        lastTwoFactorVerifiedAt: null,
+        passwordChangedAt: null,
+      })
+
+      const result = await refreshJwtFromUser('user-1', false, tokenIat)
+
+      expect(result).toEqual({
+        isAdmin: false,
+        mustChangePassword: true,
+        twoFactorEnabled: false,
+        lastTwoFactorVerifiedAt: null,
+      })
+      expect(mockedAdminFind).not.toHaveBeenCalled()
+    })
+
+    it('returns null when the whitelist user no longer exists', async () => {
+      mockedWhitelistFind.mockResolvedValueOnce(null)
+
+      const result = await refreshJwtFromUser('user-1', false, tokenIat)
+
+      expect(result).toBeNull()
+    })
+
+    it('rejects the token when iat predates passwordChangedAt', async () => {
+      mockedWhitelistFind.mockResolvedValueOnce({
+        mustChangePassword: false,
+        twoFactorEnabled: false,
+        lastTwoFactorVerifiedAt: null,
+        passwordChangedAt: new Date((tokenIat + 1) * 1000), // 1s after iat
+      })
+
+      const result = await refreshJwtFromUser('user-1', false, tokenIat)
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('attack and admin-action scenarios', () => {
+    it('admin revokes admin role -> session invalidated on next request', async () => {
+      // Pre-condition: the JWT was issued while the user was admin.
+      // Admin removes them from the admin table.
+      mockedAdminFind.mockResolvedValueOnce(null)
+
+      const result = await refreshJwtFromUser('revoked-1', true, tokenIat)
+
+      expect(result).toBeNull()
+    })
+
+    it('admin disables 2FA -> twoFactorEnabled reflects the new state', async () => {
+      mockedAdminFind.mockResolvedValueOnce({
+        mustChangePassword: false,
+        twoFactorEnabled: false,
+        lastTwoFactorVerifiedAt: null,
+        passwordChangedAt: null,
+      })
+
+      const result = await refreshJwtFromUser('admin-1', true, tokenIat)
+
+      expect(result?.twoFactorEnabled).toBe(false)
+    })
+
+    it('admin sets mustChangePassword=true -> reflected on next request', async () => {
+      mockedWhitelistFind.mockResolvedValueOnce({
+        mustChangePassword: true,
+        twoFactorEnabled: false,
+        lastTwoFactorVerifiedAt: null,
+        passwordChangedAt: null,
+      })
+
+      const result = await refreshJwtFromUser('user-1', false, tokenIat)
+
+      expect(result?.mustChangePassword).toBe(true)
     })
   })
 })

--- a/src/lib/session-validation.ts
+++ b/src/lib/session-validation.ts
@@ -1,16 +1,25 @@
 /**
- * Session validation helpers for invalidating JWTs after password change (Issue #135)
+ * Session validation helpers for the JWT callback (Issues #135, #173).
  *
- * When a user changes their password, all previously-issued JWTs should be
- * rejected so a stolen token cannot continue to be used. This is achieved by:
- *  1. Storing `passwordChangedAt` on the user record at password change time.
- *  2. On every JWT validation, comparing the token's `iat` (issued-at) with
- *     the user's current `passwordChangedAt`. If the token predates the
- *     password change, it is considered invalid.
+ * Two concerns live here:
  *
- * Backward compatibility: users that have never changed their password since
- * this column was added have `passwordChangedAt = null`, in which case the
- * check always passes (no constraint).
+ *  1. Invalidating JWTs after a password change (#135). When a user changes
+ *     their password, all previously-issued JWTs should be rejected so a
+ *     stolen token cannot continue to be used. This is achieved by storing
+ *     `passwordChangedAt` on the user record at password change time and
+ *     comparing it to the token's `iat` (issued-at) on every validation.
+ *
+ *  2. Reflecting admin-driven changes on the next request (#173). The JWT
+ *     stays alive until token expiry, so admin actions that revoke the
+ *     admin role, disable a user's 2FA, or set `mustChangePassword` would
+ *     otherwise not take effect until the user re-authenticates. We refresh
+ *     these security-critical fields from the database on every JWT
+ *     validation. This piggy-backs on the same DB lookup that #135 already
+ *     performed, so no additional round trip is added.
+ *
+ * Backward compatibility for #135: users that have never changed their
+ * password since the column was added have `passwordChangedAt = null`, in
+ * which case the timestamp check always passes.
  */
 
 import { prisma } from './prisma'
@@ -36,33 +45,79 @@ export function isTokenIatAcceptable(
 }
 
 /**
- * Look up the user's `passwordChangedAt` and decide whether the JWT is still
- * acceptable. Queries only the table indicated by `isAdmin` to keep this a
+ * Snapshot of the security-critical user fields the JWT callback overlays
+ * onto the token on every validation.
+ */
+export type RefreshedUser = {
+  isAdmin: boolean
+  mustChangePassword: boolean
+  twoFactorEnabled: boolean
+  lastTwoFactorVerifiedAt: Date | null
+}
+
+/**
+ * Look up the user indicated by the JWT and return the current values for
+ * the security-critical fields the JWT callback mirrors into the token.
+ *
+ * Returns `null` (= reject the token) when:
+ *  - `userId` is empty.
+ *  - The user no longer exists in the table indicated by `isAdminHint`. For
+ *    `isAdminHint === true` this includes admin demotion (admin row deleted
+ *    or moved to whitelist).
+ *  - The token's `iat` predates the user's `passwordChangedAt` (#135).
+ *
+ * `isAdmin` in the result is derived from which table the lookup succeeded
+ * in, not from the (possibly stale) token claim.
+ *
+ * Queries only the one table indicated by `isAdminHint` to keep this a
  * single indexed lookup per request.
  */
-export async function isJwtValidForUser(
+export async function refreshJwtFromUser(
   userId: string,
-  isAdmin: boolean,
+  isAdminHint: boolean,
   tokenIatSeconds: number | undefined,
-): Promise<boolean> {
-  if (!userId) return false
+): Promise<RefreshedUser | null> {
+  if (!userId) return null
 
-  let passwordChangedAt: Date | null = null
-  if (isAdmin) {
+  if (isAdminHint) {
     const admin = await prisma.admin.findUnique({
       where: { id: userId },
-      select: { passwordChangedAt: true },
+      select: {
+        mustChangePassword: true,
+        twoFactorEnabled: true,
+        lastTwoFactorVerifiedAt: true,
+        passwordChangedAt: true,
+      },
     })
-    if (!admin) return false
-    passwordChangedAt = admin.passwordChangedAt
-  } else {
-    const user = await prisma.whitelistUser.findUnique({
-      where: { id: userId },
-      select: { passwordChangedAt: true },
-    })
-    if (!user) return false
-    passwordChangedAt = user.passwordChangedAt
+    if (!admin) return null
+    if (!isTokenIatAcceptable(tokenIatSeconds, admin.passwordChangedAt)) {
+      return null
+    }
+    return {
+      isAdmin: true,
+      mustChangePassword: admin.mustChangePassword,
+      twoFactorEnabled: admin.twoFactorEnabled ?? false,
+      lastTwoFactorVerifiedAt: admin.lastTwoFactorVerifiedAt ?? null,
+    }
   }
 
-  return isTokenIatAcceptable(tokenIatSeconds, passwordChangedAt)
+  const user = await prisma.whitelistUser.findUnique({
+    where: { id: userId },
+    select: {
+      mustChangePassword: true,
+      twoFactorEnabled: true,
+      lastTwoFactorVerifiedAt: true,
+      passwordChangedAt: true,
+    },
+  })
+  if (!user) return null
+  if (!isTokenIatAcceptable(tokenIatSeconds, user.passwordChangedAt)) {
+    return null
+  }
+  return {
+    isAdmin: false,
+    mustChangePassword: user.mustChangePassword,
+    twoFactorEnabled: user.twoFactorEnabled ?? false,
+    lastTwoFactorVerifiedAt: user.lastTwoFactorVerifiedAt ?? null,
+  }
 }


### PR DESCRIPTION
## Summary

The JWT callback only refreshed security-critical user fields when `trigger === 'update'` was fired by the client. Admin actions taken while a user's session was alive — **revoking the admin role**, **disabling the user's 2FA**, **setting `mustChangePassword=true`** — would not take effect until the user's token expired or they explicitly logged out. A user whose privileges had been revoked could continue to act on the cached token claims, including admin-only routes, defeating the point of having an admin revocation in the first place.

## Approach

Issue #135 already performs a per-request DB lookup to validate the token's `iat` against `passwordChangedAt`. This PR **extends that same lookup** so it also returns the user's current `isAdmin` (implicit in which table the row is found in), `mustChangePassword`, `twoFactorEnabled`, and `lastTwoFactorVerifiedAt`. The JWT callback mirrors those values onto the token on every validation. **No additional DB round trip.**

## Changes

- `src/lib/session-validation.ts`
  - Remove `isJwtValidForUser` (sole caller was the JWT callback).
  - Add `refreshJwtFromUser` performing the same indexed lookup but returning the refreshed user snapshot, or `null` when the token should be rejected (user not found in the expected table, or token predates `passwordChangedAt`).
  - Keep `isTokenIatAcceptable` (pure helper, still unit-tested).
- `src/lib/auth-jwt.ts` (new)
  - Extracts the JWT callback from `auth.ts` so it can be unit-tested without booting the NextAuth runtime.
  - Always overlays the refreshed fields onto the token.
  - Handles `requiresTwoFactor` transitions when 2FA is toggled mid-session (admin-disable clears, off→on re-arms, otherwise preserves so the 5-minute window isn't erased).
  - Preserves the existing 5-minute server-side verification window (#123) for the `trigger === 'update'` path.
- `src/lib/auth.ts`
  - Imports `jwtCallback` from the new module and binds it into `authConfig.callbacks.jwt`; the previous inline implementation is removed.
- Tests
  - `src/lib/session-validation.test.ts`: prisma-mocked coverage for `refreshJwtFromUser` — admin found / admin demoted / whitelist found / whitelist missing / iat predates `passwordChangedAt` / empty userId / null `twoFactorEnabled` coerced to false.
  - `src/__tests__/jwt-refresh-stale-role.test.ts` (new): regression tests pinning the callback orchestration — admin revoke strips identity, admin 2FA-disable clears requiresTwoFactor, newly enabled 2FA mid-session re-arms requiresTwoFactor, the 5-minute verification window is honoured only when the server saw a recent verification, and #135 still rejects tokens issued before a password change.

## Security properties preserved

- A client-forged `twoFactorVerified` flag still cannot clear `requiresTwoFactor` unless the server has recorded a verification within the last 5 minutes (#123).
- Stolen tokens issued before a password change are still rejected (#135) — the same DB hit now drives both gates.
- `isAdmin` in the returned snapshot is derived from **which table the row was found in**, not from the (possibly stale) token claim. This means an admin demotion (admin row removed) causes the next request to see `refreshJwtFromUser → null`, which strips identity and forces re-authentication.

## Behaviour change for end users

- After a sysadmin revokes an admin role, the affected user's very next request will see no `session.user.id` and downstream guards will treat them as unauthenticated.
- After a sysadmin disables a user's 2FA, the affected user's next request will see `requiresTwoFactor: false` instead of being stuck on a 2FA gate they can no longer pass.
- After a sysadmin sets `mustChangePassword=true` on a user, the affected user's next request will see `mustChangePassword: true` and the password-change gate engages.

## Testing

Local node not available; relying on CI:

- [ ] `lint-and-typecheck` (tsc --noEmit, eslint, prettier)
- [ ] `test` (jest, includes the new unit + regression tests)
- [ ] `build` (next build)
- [ ] Vercel preview build

Closes #173