### PR TITLE
fix(perf): move recurring generation off the read path (#169)

### DIFF
--- a/docs/deployment/local.md
+++ b/docs/deployment/local.md
@@ -93,6 +93,22 @@ Visit [http://localhost:3000](http://localhost:3000)
 | `NEXT_PUBLIC_BASE_URL` | `http://localhost:3000` | Base URL for the app |
 | `NEXT_PUBLIC_DEFAULT_CURRENCY_CODE` | - | Default currency code |
 
+## Cron Jobs (Self-Hosted)
+
+Vercel users have cron handled by `vercel.json`. Self-hosted setups (e.g. `compose.yaml`) need to schedule the cron endpoints externally:
+
+- `POST /api/cron/recurring` — materializes due recurring expenses. Read paths no longer trigger materialization (Issue #169), so this endpoint is the **only** way recurring expenses are generated.
+- `POST /api/cron/auto-delete` — marks inactive groups for deletion.
+
+Both require `Authorization: Bearer $CRON_SECRET`. Example with system cron:
+
+```cron
+0 2 * * * curl -fsS -X POST -H "Authorization: Bearer $CRON_SECRET" http://localhost:3000/api/cron/recurring
+0 3 * * * curl -fsS -X POST -H "Authorization: Bearer $CRON_SECRET" http://localhost:3000/api/cron/auto-delete
+```
+
+Without scheduling these, recurring expenses will not be materialized.
+
 ## Common Commands
 
 ```bash

--- a/src/app/api/cron/recurring/route.test.ts
+++ b/src/app/api/cron/recurring/route.test.ts
@@ -1,0 +1,57 @@
+/** @jest-environment node */
+
+/**
+ * Cron endpoint tests (Issue #169)
+ *
+ * Read paths no longer trigger `createRecurringExpenses`; this endpoint
+ * is now the sole materializer of pending recurring expenses. Verify
+ * the route still invokes it on an authorized request.
+ */
+
+jest.mock('@/lib/api', () => ({
+  createRecurringExpenses: jest.fn(),
+}))
+
+jest.mock('@/lib/env', () => ({
+  env: {
+    CRON_SECRET: 'test-secret',
+  },
+}))
+
+import { createRecurringExpenses } from '@/lib/api'
+import { NextRequest } from 'next/server'
+import { POST } from './route'
+
+const mockCreateRecurringExpenses =
+  createRecurringExpenses as jest.MockedFunction<typeof createRecurringExpenses>
+
+describe('POST /api/cron/recurring', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('invokes createRecurringExpenses() with no groupId when authorized (Issue #169)', async () => {
+    mockCreateRecurringExpenses.mockResolvedValue(undefined)
+
+    const req = new NextRequest('http://localhost/api/cron/recurring', {
+      method: 'POST',
+      headers: { authorization: 'Bearer test-secret' },
+    })
+    const response = await POST(req)
+
+    expect(mockCreateRecurringExpenses).toHaveBeenCalledTimes(1)
+    expect(mockCreateRecurringExpenses).toHaveBeenCalledWith()
+    expect(response.status).toBe(200)
+  })
+
+  it('returns 401 without invoking createRecurringExpenses on bad token', async () => {
+    const req = new NextRequest('http://localhost/api/cron/recurring', {
+      method: 'POST',
+      headers: { authorization: 'Bearer wrong-secret' },
+    })
+    const response = await POST(req)
+
+    expect(mockCreateRecurringExpenses).not.toHaveBeenCalled()
+    expect(response.status).toBe(401)
+  })
+})

--- a/src/app/api/cron/recurring/route.ts
+++ b/src/app/api/cron/recurring/route.ts
@@ -6,11 +6,11 @@ import { NextRequest, NextResponse } from 'next/server'
 /**
  * Cron endpoint for processing recurring expense generation across all groups.
  *
- * Previously, `createRecurringExpenses` was invoked on every `getGroupExpenses`
- * call without a groupId filter, meaning any unauthenticated list of any group
- * triggered work for the entire instance (Issue #132). The list path now scopes
- * to the requested group only; this endpoint handles full-fleet processing for
- * groups that are not actively browsed.
+ * Read paths (e.g. `getGroupExpenses`) no longer trigger recurring
+ * generation (Issue #169); this endpoint is the sole materializer of
+ * pending recurring expenses. Reflection of new recurring expenses
+ * therefore depends on the cron schedule defined in `vercel.json`
+ * (`0 2 * * *` — daily 02:00 UTC).
  *
  * Authentication: requires CRON_SECRET in the Authorization header.
  * Usage: curl -X POST -H "Authorization: Bearer $CRON_SECRET" /api/cron/recurring

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -525,6 +525,19 @@ describe('API data access layer', () => {
     })
   })
 
+  describe('getGroupExpenses', () => {
+    it('does not trigger recurring expense generation (Issue #169)', async () => {
+      ;(mockRecurringExpenseLink.findMany as jest.Mock).mockResolvedValue([])
+      ;(mockExpense.findMany as jest.Mock).mockResolvedValue([])
+      const mock$transaction = prisma.$transaction as jest.Mock
+
+      await getGroupExpenses('g1')
+
+      expect(mockRecurringExpenseLink.findMany).not.toHaveBeenCalled()
+      expect(mock$transaction).not.toHaveBeenCalled()
+    })
+  })
+
   describe('createRecurringExpenses', () => {
     it('skips links whose group is soft-deleted (Issue #141)', async () => {
       ;(mockRecurringExpenseLink.findMany as jest.Mock).mockResolvedValue([])

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -535,11 +535,12 @@ export const MAX_GENERATIONS_PER_RUN = 100
  * Process pending recurring expense links and materialize the missed expenses.
  *
  * @param groupId - When provided, only links whose `currentFrameExpense`
- *   belongs to this group are processed. This is the path used by
- *   `getGroupExpenses` so an unauthenticated read on one group cannot
- *   trigger work for the entire instance (Issue #132).
- *   When omitted, all eligible links are processed; this mode is intended
- *   for the cron endpoint at `/api/cron/recurring`.
+ *   belongs to this group are processed. Originally added so the
+ *   `getGroupExpenses` read path could scope fan-out to a single tenant
+ *   (Issue #132); read paths no longer invoke this function since Issue
+ *   #169, so this mode is now only available for ad-hoc invocation.
+ *   When omitted, all eligible links are processed; this is the mode
+ *   used by the cron endpoint at `/api/cron/recurring`.
  */
 export async function createRecurringExpenses(groupId?: string) {
   const localDate = new Date() // Current local date

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -426,11 +426,6 @@ export async function getGroupExpenses(
   groupId: string,
   options?: { offset?: number; length?: number },
 ) {
-  // Process only this group's recurring links to avoid cross-tenant DoS via
-  // unauthenticated list calls (Issue #132). Full-fleet processing lives in
-  // the dedicated /api/cron/recurring endpoint for self-hosted setups.
-  await createRecurringExpenses(groupId)
-
   // Server-side title filtering removed (Issue #164): `title` is E2EE
   // ciphertext, so SQL LIKE/ILIKE on it can never match user-typed plaintext
   // and would leak the search term to server logs. Search is now performed

--- a/src/trpc/routers/groups/expenses/listAll.procedure.ts
+++ b/src/trpc/routers/groups/expenses/listAll.procedure.ts
@@ -29,13 +29,6 @@ export const listAllGroupExpensesProcedure = publicProcedure
     }),
   )
   .query(async ({ input: { groupId, limit } }) => {
-    // getGroupExpenses internally materializes any due recurring
-    // expenses (src/lib/api.ts:432, batched at MAX_BATCH_SIZE so a
-    // backlog may still carry over). Read totalCount strictly AFTER it
-    // returns so the count reflects the same row set as the slice —
-    // otherwise the count could be observed before the batch is
-    // inserted, defeating the truncation guard the export flow relies
-    // on (Issue #131).
     const expenses = await getGroupExpenses(groupId, { length: limit })
     const totalCount = await getGroupExpenseCount(groupId)
     return {


### PR DESCRIPTION
## Summary

- `getGroupExpenses` no longer awaits `createRecurringExpenses` (Issue #169)
- recurring expense materialization is now exclusive to `/api/cron/recurring`
- `vercel.json` schedule unchanged (daily 02:00 UTC); reflection of newly-due recurring expenses now depends on cron execution

## Why

Recurring generation responsibility is centralized in the existing daily cron; the read path's write side effect is removed. Reflection of newly-due recurring expenses now depends on cron execution.

Previously `getGroupExpenses` awaited `createRecurringExpenses(groupId)` on every read (list infinite scroll page, balances, stats, export). For a stale-DAILY group the first read after a long absence would materialize up to 100 expenses (per link, inside `$transaction`) within the HTTP request; concurrent reads amplified the cost.

## Scope

- **In scope**: remove the write side effect from the read path; centralize materialization in the cron endpoint
- **Out of scope** (separate follow-up issue to be filed): global per-cron-run cap. `MAX_GENERATIONS_PER_RUN = 100` is per link, not per run, so a sufficiently large backlog could make a single cron heavy

## Tests

- `src/lib/api.test.ts`: new assertion that `getGroupExpenses('g1')` does not call `prisma.recurringExpenseLink.findMany` or `prisma.$transaction` (#169)
- `src/app/api/cron/recurring/route.test.ts` (new): `POST` with valid `CRON_SECRET` invokes `createRecurringExpenses()` with no `groupId`; invalid token returns 401 and skips the call. Uses `/** @jest-environment node */` because `next/server` requires Web `Request` (absent under jsdom)

## Test plan

- [x] `pnpm install --frozen-lockfile --ignore-scripts`
- [x] `pnpm prisma generate`
- [x] `pnpm tsc --noEmit`
- [x] `pnpm lint` (no new warnings from #169)
- [x] `pnpm check-formatting`
- [x] `pnpm test` (382/382 pass)
- [x] `pnpm build`

Closes #169.