### PR TITLE
fix(perf): cache decrypted aggregate via revision probe (closes #225)

### DIFF
--- a/prisma/migrations/20260518100000_add_group_expenses_revision/migration.sql
+++ b/prisma/migrations/20260518100000_add_group_expenses_revision/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Group" ADD COLUMN     "expensesRevision" INTEGER NOT NULL DEFAULT 0;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -26,6 +26,12 @@ model Group {
   passwordSalt String?       // Salt for PBKDF2 key derivation (base64 encoded)
   passwordHint String?       // Encrypted password hint
 
+  // Issue #225: bumped in the same transaction as any mutation that affects
+  // the listAll payload (expense CRUD, recurring expense creation, group
+  // participant changes). The client uses this to decide whether its
+  // decrypted-aggregate cache is still fresh.
+  expensesRevision Int @default(0)
+
   // Indexes for performance
   @@index([createdAt])  // For auto-delete inactive groups query
   @@index([deletedAt])  // For grace period cleanup query

--- a/src/app/groups/[groupId]/expenses/create-expense-form.test.tsx
+++ b/src/app/groups/[groupId]/expenses/create-expense-form.test.tsx
@@ -8,6 +8,9 @@ jest.mock('@/components/encryption-provider', () => ({
 jest.mock('@/lib/encrypt-helpers', () => ({
   encryptExpenseFormValues: jest.fn(),
 }))
+jest.mock('@/lib/hooks/aggregateCache', () => ({
+  invalidateAggregate: jest.fn(),
+}))
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
 }))
@@ -53,6 +56,7 @@ jest.mock('@/trpc/client', () => {
 
 import { useEncryption } from '@/components/encryption-provider'
 import { encryptExpenseFormValues } from '@/lib/encrypt-helpers'
+import { invalidateAggregate } from '@/lib/hooks/aggregateCache'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { useRouter } from 'next/navigation'
 import { useCurrentGroup } from '../current-group-context'
@@ -65,6 +69,9 @@ const mockEncryptExpenseFormValues =
   encryptExpenseFormValues as jest.MockedFunction<
     typeof encryptExpenseFormValues
   >
+const mockInvalidateAggregate = invalidateAggregate as jest.MockedFunction<
+  typeof invalidateAggregate
+>
 const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
 const mockUseCurrentGroup = useCurrentGroup as jest.MockedFunction<
   typeof useCurrentGroup
@@ -87,6 +94,7 @@ beforeEach(() => {
   trpcMocks.__mockCategoriesQuery.mockReturnValue({
     data: { categories: [{ id: 0, grouping: 'g', name: 'cat' }] },
   })
+  mockInvalidateAggregate.mockReset()
 
   mockUseEncryption.mockReset()
   mockUseEncryption.mockReturnValue({
@@ -153,5 +161,28 @@ describe('CreateExpenseForm', () => {
       expect.any(Error),
     )
     warnSpy.mockRestore()
+  })
+
+  it('calls invalidateAggregate before awaiting utils.invalidate (Issue #225)', async () => {
+    let resolveInvalidate: () => void = () => {}
+    trpcMocks.__mockInvalidate.mockImplementation(
+      () => new Promise<void>((r) => (resolveInvalidate = r)),
+    )
+
+    const { getByText } = render(<CreateExpenseForm groupId="g1" />)
+    await waitFor(() => getByText('submit'))
+    fireEvent.click(getByText('submit'))
+
+    await waitFor(() =>
+      expect(mockInvalidateAggregate).toHaveBeenCalledWith('g1'),
+    )
+    // L2 cache must be evicted BEFORE we await the react-query invalidate so
+    // a rejected invalidate cannot leave a stale aggregate visible on the
+    // next balances/stats visit.
+    const aggrOrder = mockInvalidateAggregate.mock.invocationCallOrder[0]
+    const utilOrder = trpcMocks.__mockInvalidate.mock.invocationCallOrder[0]
+    expect(aggrOrder).toBeLessThan(utilOrder)
+
+    resolveInvalidate()
   })
 })

--- a/src/app/groups/[groupId]/expenses/create-expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/create-expense-form.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEncryption } from '@/components/encryption-provider'
 import { encryptExpenseFormValues } from '@/lib/encrypt-helpers'
+import { invalidateAggregate } from '@/lib/hooks/aggregateCache'
 import { trpc } from '@/trpc/client'
 import { useRouter } from 'next/navigation'
 import { useCurrentGroup } from '../current-group-context'
@@ -43,6 +44,10 @@ export function CreateExpenseForm({
           expenseFormValues: dataToSend,
           participantId,
         })
+        // Issue #225: drop the decrypted-aggregate cache BEFORE awaiting the
+        // react-query invalidate so a rejected invalidate cannot leave a
+        // stale cache entry visible on the next balances/stats visit.
+        invalidateAggregate(groupId)
         try {
           await utils.groups.expenses.invalidate()
         } catch (error) {

--- a/src/app/groups/[groupId]/expenses/edit-expense-form.test.tsx
+++ b/src/app/groups/[groupId]/expenses/edit-expense-form.test.tsx
@@ -9,6 +9,9 @@ jest.mock('@/lib/encrypt-helpers', () => ({
   decryptExpense: jest.fn(),
   encryptExpenseFormValues: jest.fn(),
 }))
+jest.mock('@/lib/hooks/aggregateCache', () => ({
+  invalidateAggregate: jest.fn(),
+}))
 jest.mock('next/navigation', () => ({
   useRouter: jest.fn(),
 }))
@@ -74,6 +77,7 @@ jest.mock('@/trpc/client', () => {
 
 import { useEncryption } from '@/components/encryption-provider'
 import { decryptExpense, encryptExpenseFormValues } from '@/lib/encrypt-helpers'
+import { invalidateAggregate } from '@/lib/hooks/aggregateCache'
 import { fireEvent, render, waitFor } from '@testing-library/react'
 import { useRouter } from 'next/navigation'
 import { useCurrentGroup } from '../current-group-context'
@@ -89,6 +93,9 @@ const mockEncryptExpenseFormValues =
   encryptExpenseFormValues as jest.MockedFunction<
     typeof encryptExpenseFormValues
   >
+const mockInvalidateAggregate = invalidateAggregate as jest.MockedFunction<
+  typeof invalidateAggregate
+>
 const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
 const mockUseCurrentGroup = useCurrentGroup as jest.MockedFunction<
   typeof useCurrentGroup
@@ -141,6 +148,7 @@ beforeEach(() => {
     data: { categories: [{ id: 0, grouping: 'g', name: 'cat' }] },
   })
   trpcMocks.__mockExpenseQuery.mockReset()
+  mockInvalidateAggregate.mockReset()
 
   mockUseEncryption.mockReset()
   mockUseEncryption.mockReturnValue({
@@ -303,5 +311,55 @@ describe('EditExpenseForm', () => {
     await waitFor(() =>
       expect(routerPushMock).toHaveBeenCalledWith('/groups/g1'),
     )
+  })
+
+  it('calls invalidateAggregate before awaiting utils.invalidate on update (Issue #225)', async () => {
+    trpcMocks.__mockExpenseQuery.mockReturnValue({
+      data: { expense: fakeExpense('exp1', 'cipher') },
+    })
+    let resolveInvalidate: () => void = () => {}
+    trpcMocks.__mockInvalidate.mockImplementation(
+      () => new Promise<void>((r) => (resolveInvalidate = r)),
+    )
+
+    const { getByText } = render(
+      <EditExpenseForm groupId="g1" expenseId="exp1" />,
+    )
+    await waitFor(() => getByText('submit'))
+    fireEvent.click(getByText('submit'))
+
+    await waitFor(() =>
+      expect(mockInvalidateAggregate).toHaveBeenCalledWith('g1'),
+    )
+    const aggrOrder = mockInvalidateAggregate.mock.invocationCallOrder[0]
+    const utilOrder = trpcMocks.__mockInvalidate.mock.invocationCallOrder[0]
+    expect(aggrOrder).toBeLessThan(utilOrder)
+
+    resolveInvalidate()
+  })
+
+  it('calls invalidateAggregate before awaiting utils.invalidate on delete (Issue #225)', async () => {
+    trpcMocks.__mockExpenseQuery.mockReturnValue({
+      data: { expense: fakeExpense('exp1', 'cipher') },
+    })
+    let resolveInvalidate: () => void = () => {}
+    trpcMocks.__mockInvalidate.mockImplementation(
+      () => new Promise<void>((r) => (resolveInvalidate = r)),
+    )
+
+    const { getByText } = render(
+      <EditExpenseForm groupId="g1" expenseId="exp1" />,
+    )
+    await waitFor(() => getByText('delete'))
+    fireEvent.click(getByText('delete'))
+
+    await waitFor(() =>
+      expect(mockInvalidateAggregate).toHaveBeenCalledWith('g1'),
+    )
+    const aggrOrder = mockInvalidateAggregate.mock.invocationCallOrder[0]
+    const utilOrder = trpcMocks.__mockInvalidate.mock.invocationCallOrder[0]
+    expect(aggrOrder).toBeLessThan(utilOrder)
+
+    resolveInvalidate()
   })
 })

--- a/src/app/groups/[groupId]/expenses/edit-expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/edit-expense-form.tsx
@@ -1,6 +1,7 @@
 'use client'
 import { useEncryption } from '@/components/encryption-provider'
 import { decryptExpense, encryptExpenseFormValues } from '@/lib/encrypt-helpers'
+import { invalidateAggregate } from '@/lib/hooks/aggregateCache'
 import { trpc } from '@/trpc/client'
 import { useRouter } from 'next/navigation'
 import { useEffect, useState } from 'react'
@@ -99,6 +100,10 @@ export function EditExpenseForm({
           expenseFormValues: dataToSend,
           participantId,
         })
+        // Issue #225: drop the decrypted-aggregate cache BEFORE awaiting the
+        // react-query invalidate so a rejected invalidate cannot leave a
+        // stale cache entry visible on the next balances/stats visit.
+        invalidateAggregate(groupId)
         try {
           await utils.groups.expenses.invalidate()
         } catch (error) {
@@ -116,6 +121,10 @@ export function EditExpenseForm({
           groupId,
           participantId,
         })
+        // Issue #225: drop the decrypted-aggregate cache BEFORE awaiting the
+        // react-query invalidate so a rejected invalidate cannot leave a
+        // stale cache entry visible on the next balances/stats visit.
+        invalidateAggregate(groupId)
         try {
           await utils.groups.expenses.invalidate()
         } catch (error) {

--- a/src/app/groups/[groupId]/export-button.tsx
+++ b/src/app/groups/[groupId]/export-button.tsx
@@ -56,8 +56,10 @@ export default function ExportButton({ groupId }: { groupId: string }) {
     setIsExporting(true)
     try {
       // Use the RETURN VALUE of fetchAll (not the hook's React state) so this
-      // closure cannot read a stale `expenses` snapshot.
-      const decrypted = await fetchAll()
+      // closure cannot read a stale `expenses` snapshot. `forceFresh` bypasses
+      // the L2 decrypted-aggregate cache — race detection (revBefore/revAfter)
+      // still runs so a partial-snapshot CSV/JSON cannot ship (Issue #225).
+      const decrypted = await fetchAll({ forceFresh: true })
       const group = currentGroup.group as unknown as ExportGroup
       const expenses = decrypted as unknown as ExportExpense[]
       const date = new Date().toISOString().split('T')[0]

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -763,5 +763,86 @@ describe('API data access layer', () => {
         }),
       )
     })
+
+    it('createRecurringExpenses bumps Group.expensesRevision in the same transaction', async () => {
+      jest.useFakeTimers()
+      jest.setSystemTime(new Date('2026-05-18T00:00:00.000Z'))
+      try {
+        const txGroupUpdate = jest.fn().mockResolvedValue({})
+        const txExpenseCreate = jest.fn().mockResolvedValue({
+          id: 'new-exp-1',
+          createdAt: new Date('2026-05-17T00:00:00.000Z'),
+          expenseDate: new Date('2026-05-17T00:00:00.000Z'),
+          groupId: 'g1',
+          paidById: 'p1',
+          paidFor: [{ participantId: 'p1', shares: '1' }],
+          paidBy: { id: 'p1', name: 'Alice' },
+          recurrenceRule: 'DAILY',
+          categoryId: '0',
+          title: 't',
+          amount: '100',
+          splitMode: 'EVENLY',
+          isReimbursement: false,
+          notes: null,
+          originalAmount: null,
+          originalCurrency: null,
+          conversionRate: null,
+          recurringExpenseLinkId: 'new-link-1',
+        })
+        const txRecurringLinkUpdate = jest.fn().mockResolvedValue({})
+        ;(prisma.$transaction as jest.Mock).mockImplementation(
+          async (callback: (tx: unknown) => Promise<unknown>) =>
+            callback({
+              expense: { create: txExpenseCreate },
+              recurringExpenseLink: { update: txRecurringLinkUpdate },
+              group: { update: txGroupUpdate },
+            }),
+        )
+        // Single eligible link with nextExpenseDate = today - 1d.
+        // DAILY rule -> the inner while-loop runs exactly once (next date
+        // matches today and exits the loop).
+        ;(mockRecurringExpenseLink.findMany as jest.Mock).mockResolvedValue([
+          {
+            id: 'link-1',
+            nextExpenseDate: new Date('2026-05-17T00:00:00.000Z'),
+            currentFrameExpense: {
+              id: 'orig-1',
+              groupId: 'g1',
+              paidById: 'p1',
+              paidFor: [{ participantId: 'p1', shares: '1' }],
+              paidBy: { id: 'p1', name: 'Alice' },
+              recurrenceRule: 'DAILY',
+              categoryId: '0',
+              expenseDate: new Date('2026-05-17T00:00:00.000Z'),
+              title: 't',
+              amount: '100',
+              splitMode: 'EVENLY',
+              isReimbursement: false,
+              notes: null,
+              originalAmount: null,
+              originalCurrency: null,
+              conversionRate: null,
+              recurringExpenseLinkId: 'link-1',
+              createdAt: new Date('2026-05-16T00:00:00.000Z'),
+            },
+          },
+        ])
+
+        await createRecurringExpenses('g1')
+
+        expect(txExpenseCreate).toHaveBeenCalledTimes(1)
+        expect(txGroupUpdate).toHaveBeenCalledWith({
+          where: { id: 'g1' },
+          data: { expensesRevision: { increment: 1 } },
+        })
+        // The revision bump runs inside the same $transaction as the
+        // expense.create, after the new expense exists.
+        const expenseOrder = txExpenseCreate.mock.invocationCallOrder[0]
+        const groupOrder = txGroupUpdate.mock.invocationCallOrder[0]
+        expect(expenseOrder).toBeLessThan(groupOrder)
+      } finally {
+        jest.useRealTimers()
+      }
+    })
   })
 })

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -44,8 +44,10 @@ jest.mock('nanoid', () => ({
 
 import { ActivityType } from '@prisma/client'
 import {
+  createExpense,
   createGroup,
   createRecurringExpenses,
+  deleteExpense,
   deleteGroup,
   getActivities,
   getCategories,
@@ -57,6 +59,8 @@ import {
   permanentlyDeleteGroup,
   randomId,
   restoreGroup,
+  updateExpense,
+  updateGroup,
 } from './api'
 import { prisma } from './prisma'
 
@@ -626,6 +630,138 @@ describe('API data access layer', () => {
       await createRecurringExpenses()
 
       expect(mock$transaction).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('expensesRevision bump (Issue #225)', () => {
+    function setupTransactionMock() {
+      const txGroupUpdate = jest.fn().mockResolvedValue({})
+      const txExpenseCreate = jest.fn().mockResolvedValue({
+        id: 'e1',
+        createdAt: new Date(),
+      })
+      const txExpenseUpdate = jest.fn().mockResolvedValue({})
+      const txExpenseDelete = jest.fn().mockResolvedValue({})
+      const txActivityCreate = jest.fn().mockResolvedValue({})
+      ;(prisma.$transaction as jest.Mock).mockImplementation(
+        async (callback: (tx: unknown) => Promise<unknown>) =>
+          callback({
+            group: { update: txGroupUpdate },
+            expense: {
+              create: txExpenseCreate,
+              update: txExpenseUpdate,
+              delete: txExpenseDelete,
+            },
+            activity: { create: txActivityCreate },
+          }),
+      )
+      return {
+        txGroupUpdate,
+        txExpenseCreate,
+        txExpenseUpdate,
+        txExpenseDelete,
+        txActivityCreate,
+      }
+    }
+
+    const fakeFormValues = {
+      title: 't',
+      amount: 100,
+      category: 0,
+      paidBy: 'p1',
+      paidFor: [{ participant: 'p1', shares: 1 }],
+      expenseDate: new Date('2026-05-10T00:00:00.000Z'),
+      splitMode: 'EVENLY' as const,
+      recurrenceRule: 'NONE' as const,
+      isReimbursement: false,
+      notes: null,
+    }
+
+    it('createExpense bumps Group.expensesRevision in the same transaction', async () => {
+      const { txGroupUpdate, txExpenseCreate, txActivityCreate } =
+        setupTransactionMock()
+      ;(mockGroup.findUnique as jest.Mock).mockResolvedValue({
+        id: 'g1',
+        participants: [{ id: 'p1' }],
+      })
+
+      await createExpense(fakeFormValues as never, 'g1')
+
+      expect(txGroupUpdate).toHaveBeenCalledWith({
+        where: { id: 'g1' },
+        data: { expensesRevision: { increment: 1 } },
+      })
+      // Order: activity → revision bump → expense create.
+      const activityOrder = txActivityCreate.mock.invocationCallOrder[0]
+      const groupOrder = txGroupUpdate.mock.invocationCallOrder[0]
+      const expenseOrder = txExpenseCreate.mock.invocationCallOrder[0]
+      expect(activityOrder).toBeLessThan(groupOrder)
+      expect(groupOrder).toBeLessThan(expenseOrder)
+    })
+
+    it('updateExpense bumps Group.expensesRevision in the same transaction', async () => {
+      const { txGroupUpdate, txExpenseUpdate } = setupTransactionMock()
+      ;(mockGroup.findUnique as jest.Mock).mockResolvedValue({
+        id: 'g1',
+        participants: [{ id: 'p1' }],
+      })
+      ;(mockExpense.findFirst as jest.Mock).mockResolvedValue({
+        id: 'e1',
+        title: 't',
+        expenseDate: new Date('2026-05-10T00:00:00.000Z'),
+        recurrenceRule: 'NONE',
+        recurringExpenseLink: null,
+        paidFor: [{ participantId: 'p1', shares: 1 }],
+      })
+
+      await updateExpense('g1', 'e1', fakeFormValues as never)
+
+      expect(txGroupUpdate).toHaveBeenCalledWith({
+        where: { id: 'g1' },
+        data: { expensesRevision: { increment: 1 } },
+      })
+      expect(txExpenseUpdate).toHaveBeenCalledTimes(1)
+    })
+
+    it('deleteExpense bumps Group.expensesRevision in the same transaction', async () => {
+      const { txGroupUpdate, txExpenseDelete } = setupTransactionMock()
+      ;(mockExpense.findFirst as jest.Mock).mockResolvedValue({
+        id: 'e1',
+        title: 't',
+        groupId: 'g1',
+      })
+
+      await deleteExpense('g1', 'e1')
+
+      expect(txGroupUpdate).toHaveBeenCalledWith({
+        where: { id: 'g1' },
+        data: { expensesRevision: { increment: 1 } },
+      })
+      expect(txExpenseDelete).toHaveBeenCalledTimes(1)
+    })
+
+    it('updateGroup bumps Group.expensesRevision in the same update', async () => {
+      ;(mockGroup.findUnique as jest.Mock).mockResolvedValue({
+        id: 'g1',
+        participants: [{ id: 'p1', name: 'Alice' }],
+      })
+      ;(mockExpense.findMany as jest.Mock).mockResolvedValue([])
+      ;(mockGroup.update as jest.Mock).mockResolvedValue({ id: 'g1' })
+
+      await updateGroup('g1', {
+        name: 'new',
+        currency: '$',
+        participants: [{ id: 'p1', name: 'Alice renamed' }],
+      } as never)
+
+      expect(mockGroup.update).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: 'g1' },
+          data: expect.objectContaining({
+            expensesRevision: { increment: 1 },
+          }),
+        }),
+      )
     })
   })
 })

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -74,6 +74,12 @@ export async function createExpense(
       },
     })
 
+    // Issue #225: bump aggregate-cache revision in the same transaction.
+    await tx.group.update({
+      where: { id: groupId },
+      data: { expensesRevision: { increment: 1 } },
+    })
+
     return tx.expense.create({
       data: {
         id: expenseId,
@@ -140,6 +146,12 @@ export async function deleteExpense(
     await tx.expense.delete({
       where: { id: expenseId },
       include: { paidFor: true, paidBy: true },
+    })
+
+    // Issue #225: bump aggregate-cache revision in the same transaction.
+    await tx.group.update({
+      where: { id: groupId },
+      data: { expensesRevision: { increment: 1 } },
     })
   })
 }
@@ -227,6 +239,12 @@ export async function updateExpense(
         expenseId,
         data: expenseFormValues.title,
       },
+    })
+
+    // Issue #225: bump aggregate-cache revision in the same transaction.
+    await tx.group.update({
+      where: { id: groupId },
+      data: { expensesRevision: { increment: 1 } },
     })
 
     return tx.expense.update({
@@ -386,6 +404,9 @@ export async function updateGroup(
       information: groupFormValues.information,
       currency: groupFormValues.currency,
       currencyCode: groupFormValues.currencyCode,
+      // Issue #225: participant rename affects paidBy.name / paidFor.participant.name
+      // in the listAll payload, so bump revision unconditionally on updateGroup.
+      expensesRevision: { increment: 1 },
       participants: {
         deleteMany: existingGroup.participants.filter(
           (p) => !groupFormValues.participants.some((p2) => p2.id === p.id),
@@ -737,6 +758,12 @@ export async function createRecurringExpenses(groupId?: string) {
             data: {
               nextExpenseCreatedAt: newExpense.createdAt,
             },
+          })
+
+          // Issue #225: bump aggregate-cache revision in the same transaction.
+          await transaction.group.update({
+            where: { id: currentExpenseRecord.groupId },
+            data: { expensesRevision: { increment: 1 } },
           })
 
           return newExpense

--- a/src/lib/hooks/aggregateCache.test.ts
+++ b/src/lib/hooks/aggregateCache.test.ts
@@ -1,0 +1,176 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  __resetAggregateCacheForTest,
+  computeFingerprint,
+  getAggregate,
+  invalidateAggregate,
+  setAggregate,
+  type GroupExpense,
+} from './aggregateCache'
+
+function fakeExpenses(n: number): GroupExpense[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `e${i}`,
+  })) as GroupExpense[]
+}
+
+beforeEach(() => {
+  __resetAggregateCacheForTest()
+})
+
+afterEach(() => {
+  __resetAggregateCacheForTest()
+})
+
+describe('aggregateCache (Issue #225)', () => {
+  describe('get / set basics', () => {
+    it('returns the stored aggregate on a fresh hit', () => {
+      const xs = fakeExpenses(3)
+      setAggregate('g1', 'fp1', 1, xs)
+      expect(getAggregate('g1', 'fp1', 1)).toBe(xs)
+    })
+
+    it('returns undefined on miss', () => {
+      expect(getAggregate('g1', 'fp1', 1)).toBeUndefined()
+    })
+  })
+
+  describe('TTL (hit validity)', () => {
+    it('treats a 60s+ old entry as a miss and deletes it', () => {
+      jest.useFakeTimers()
+      try {
+        jest.setSystemTime(new Date('2026-05-18T00:00:00.000Z'))
+        setAggregate('g1', 'fp1', 1, fakeExpenses(2))
+        jest.setSystemTime(new Date('2026-05-18T00:01:01.000Z'))
+        expect(getAggregate('g1', 'fp1', 1)).toBeUndefined()
+        // After eviction-on-access, a fresh set should work normally.
+        setAggregate('g1', 'fp1', 2, fakeExpenses(3))
+        expect(getAggregate('g1', 'fp1', 2)).toHaveLength(3)
+      } finally {
+        jest.useRealTimers()
+      }
+    })
+  })
+
+  describe('revision mismatch', () => {
+    it('returns undefined and deletes the entry on revision mismatch', () => {
+      setAggregate('g1', 'fp1', 1, fakeExpenses(2))
+      expect(getAggregate('g1', 'fp1', 2)).toBeUndefined()
+      // The entry was deleted, so re-querying the original revision misses too.
+      expect(getAggregate('g1', 'fp1', 1)).toBeUndefined()
+    })
+  })
+
+  describe('invalidateAggregate', () => {
+    it('removes all entries for the target groupId, leaves other groups alone', () => {
+      setAggregate('g1', 'fpA', 1, fakeExpenses(1))
+      setAggregate('g1', 'fpB', 1, fakeExpenses(1))
+      setAggregate('g2', 'fpA', 1, fakeExpenses(1))
+      invalidateAggregate('g1')
+      expect(getAggregate('g1', 'fpA', 1)).toBeUndefined()
+      expect(getAggregate('g1', 'fpB', 1)).toBeUndefined()
+      expect(getAggregate('g2', 'fpA', 1)).toHaveLength(1)
+    })
+  })
+
+  describe('LRU eviction (MAX_ENTRIES=16)', () => {
+    it('evicts least-recently-used, not just oldest insertion', () => {
+      for (let i = 0; i < 16; i++) {
+        setAggregate(`g${i}`, 'fp', 1, fakeExpenses(1))
+      }
+      // Recency-promote g0.
+      expect(getAggregate('g0', 'fp', 1)).toBeDefined()
+      // The next insert triggers eviction — the victim must be g1 (oldest
+      // after g0 was promoted), NOT g0.
+      setAggregate('g16', 'fp', 1, fakeExpenses(1))
+      expect(getAggregate('g0', 'fp', 1)).toBeDefined()
+      expect(getAggregate('g1', 'fp', 1)).toBeUndefined()
+      expect(getAggregate('g16', 'fp', 1)).toBeDefined()
+    })
+  })
+
+  describe('computeFingerprint', () => {
+    it('returns "no-key" when hasKey is false', async () => {
+      expect(await computeFingerprint(null, false)).toBe('no-key')
+      expect(await computeFingerprint(new Uint8Array([1, 2]), false)).toBe(
+        'no-key',
+      )
+    })
+
+    it('returns a stable hex digest for the same key', async () => {
+      const fp1 = await computeFingerprint(new Uint8Array([1, 2, 3, 4]), true)
+      const fp2 = await computeFingerprint(new Uint8Array([1, 2, 3, 4]), true)
+      expect(fp1).toBe(fp2)
+      expect(fp1).toMatch(/^[0-9a-f]{32}$/)
+    })
+
+    it('returns different digests for different keys', async () => {
+      const fp1 = await computeFingerprint(new Uint8Array([1]), true)
+      const fp2 = await computeFingerprint(new Uint8Array([2]), true)
+      expect(fp1).not.toBe(fp2)
+    })
+
+    it('"no-key" cannot collide with an encrypted partition', async () => {
+      const fp = await computeFingerprint(new Uint8Array([0]), true)
+      expect(fp).toHaveLength(32)
+      expect(fp).not.toBe('no-key')
+    })
+  })
+
+  // jsdom does not ship BroadcastChannel by default; skip the cross-tab
+  // integration test when the global is missing. The "works without
+  // BroadcastChannel" test below still runs and proves the fail-safe path.
+  const hasBroadcastChannel = typeof BroadcastChannel !== 'undefined'
+  const itIfBC = hasBroadcastChannel ? it : it.skip
+
+  describe('BroadcastChannel cross-tab', () => {
+    itIfBC(
+      'posts groupId on invalidateAggregate and other tabs receive it',
+      async () => {
+        setAggregate('g1', 'fp', 1, fakeExpenses(1))
+        const remote = new BroadcastChannel('anon-spliit:aggregate-invalidate')
+        const recv = jest.fn()
+        remote.onmessage = recv
+        try {
+          invalidateAggregate('g1')
+          await new Promise((resolve) => setTimeout(resolve, 0))
+          expect(recv).toHaveBeenCalledWith(
+            expect.objectContaining({ data: { groupId: 'g1' } }),
+          )
+        } finally {
+          remote.close()
+        }
+      },
+    )
+
+    it('works in environments without BroadcastChannel (no throw)', () => {
+      const original = (globalThis as { BroadcastChannel?: unknown })
+        .BroadcastChannel
+      ;(globalThis as { BroadcastChannel?: unknown }).BroadcastChannel =
+        undefined
+      try {
+        __resetAggregateCacheForTest()
+        setAggregate('g1', 'fp', 1, fakeExpenses(1))
+        expect(getAggregate('g1', 'fp', 1)).toHaveLength(1)
+        invalidateAggregate('g1')
+        expect(getAggregate('g1', 'fp', 1)).toBeUndefined()
+      } finally {
+        ;(globalThis as { BroadcastChannel?: unknown }).BroadcastChannel =
+          original
+      }
+    })
+  })
+
+  describe('__resetAggregateCacheForTest', () => {
+    it('clears all cached entries', () => {
+      setAggregate('g1', 'fp', 1, fakeExpenses(1))
+      setAggregate('g2', 'fp', 1, fakeExpenses(1))
+      __resetAggregateCacheForTest()
+      expect(getAggregate('g1', 'fp', 1)).toBeUndefined()
+      expect(getAggregate('g2', 'fp', 1)).toBeUndefined()
+    })
+  })
+})

--- a/src/lib/hooks/aggregateCache.ts
+++ b/src/lib/hooks/aggregateCache.ts
@@ -1,0 +1,149 @@
+import type { AppRouterOutput } from '@/trpc/routers/_app'
+
+type ListAllPage = AppRouterOutput['groups']['expenses']['listAll']
+export type GroupExpense = ListAllPage['expenses'][number]
+
+type Entry = {
+  expenses: GroupExpense[]
+  storedAt: number
+  revision: number
+}
+
+const TTL_MS = 60 * 1000
+const MAX_ENTRIES = 16
+const CHANNEL_NAME = 'anon-spliit:aggregate-invalidate'
+
+const cache = new Map<string, Entry>()
+let channel: BroadcastChannel | null = null
+
+function makeKey(groupId: string, fingerprint: string): string {
+  return `${groupId}::${fingerprint}`
+}
+
+function pruneExpired(): void {
+  const now = Date.now()
+  const keysToDelete: string[] = []
+  cache.forEach((entry, k) => {
+    if (now - entry.storedAt > TTL_MS) keysToDelete.push(k)
+  })
+  keysToDelete.forEach((k) => cache.delete(k))
+}
+
+function invalidateInternal(groupId: string): void {
+  const prefix = `${groupId}::`
+  const keysToDelete: string[] = []
+  cache.forEach((_, k) => {
+    if (k.startsWith(prefix)) keysToDelete.push(k)
+  })
+  keysToDelete.forEach((k) => cache.delete(k))
+}
+
+function getChannel(): BroadcastChannel | null {
+  if (typeof window === 'undefined') return null
+  if (typeof BroadcastChannel === 'undefined') return null
+  if (channel) return channel
+  channel = new BroadcastChannel(CHANNEL_NAME)
+  channel.onmessage = (event: MessageEvent) => {
+    const data = event.data as { groupId?: unknown }
+    if (data && typeof data.groupId === 'string') {
+      invalidateInternal(data.groupId)
+    }
+  }
+  return channel
+}
+
+/**
+ * Stable identity for an encryption key (or `'no-key'` for unencrypted
+ * groups). SHA-256 truncated to 16 bytes (32 hex chars) — 128-bit collision
+ * space is far more than enough given O(1) live groups per session, and
+ * the raw key never enters the cache partition map.
+ */
+export async function computeFingerprint(
+  key: Uint8Array | null,
+  hasKey: boolean,
+): Promise<string> {
+  if (!hasKey || !key) return 'no-key'
+  // Wrap in a fresh Uint8Array so the input matches BufferSource regardless
+  // of how the caller produced it (mirrors `crypto.subtle.importKey` usage
+  // in `src/lib/crypto.ts`).
+  const digest = await crypto.subtle.digest('SHA-256', new Uint8Array(key))
+  return Array.from(new Uint8Array(digest).slice(0, 16))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+/**
+ * Returns the cached decrypted aggregate iff it is within TTL AND its
+ * stored revision matches `currentRevision`. Expired or revision-mismatched
+ * entries are deleted on access.
+ *
+ * On a hit the entry is bumped to the end of the Map so the LRU eviction
+ * in {@link setAggregate} evicts the *actually* least-recently-used entry
+ * rather than just the oldest insertion (FIFO).
+ *
+ * TTL is hit validity only — idle entries can remain in memory up to
+ * `MAX_ENTRIES` until a subsequent `setAggregate`, `invalidateAggregate`,
+ * or `__resetAggregateCacheForTest` call reaps them.
+ */
+export function getAggregate(
+  groupId: string,
+  fingerprint: string,
+  currentRevision: number,
+): GroupExpense[] | undefined {
+  pruneExpired()
+  const key = makeKey(groupId, fingerprint)
+  const entry = cache.get(key)
+  if (!entry) return undefined
+  if (entry.revision !== currentRevision) {
+    cache.delete(key)
+    return undefined
+  }
+  // LRU recency: move to end of Map.
+  cache.delete(key)
+  cache.set(key, entry)
+  return entry.expenses
+}
+
+export function setAggregate(
+  groupId: string,
+  fingerprint: string,
+  revision: number,
+  expenses: GroupExpense[],
+): void {
+  pruneExpired()
+  const key = makeKey(groupId, fingerprint)
+  cache.delete(key)
+  cache.set(key, { expenses, storedAt: Date.now(), revision })
+  while (cache.size > MAX_ENTRIES) {
+    const oldest = cache.keys().next().value
+    if (oldest === undefined) break
+    cache.delete(oldest)
+  }
+  // Lazy-initialize the channel so cross-tab invalidate messages can be
+  // received as soon as we have something worth invalidating.
+  getChannel()
+}
+
+/**
+ * Drop every entry for `groupId` in this tab and broadcast the same
+ * invalidate to other tabs of the same browser/origin. Cross-device
+ * freshness is handled by the server-side revision probe in the hook,
+ * not by this channel.
+ */
+export function invalidateAggregate(groupId: string): void {
+  invalidateInternal(groupId)
+  const ch = getChannel()
+  if (ch) ch.postMessage({ groupId })
+}
+
+export function __resetAggregateCacheForTest(): void {
+  cache.clear()
+  if (channel) {
+    try {
+      channel.close()
+    } catch {
+      // jsdom mock channels may not implement close; safe to ignore.
+    }
+    channel = null
+  }
+}

--- a/src/lib/hooks/useAllGroupExpenses.test.ts
+++ b/src/lib/hooks/useAllGroupExpenses.test.ts
@@ -8,11 +8,13 @@ jest.mock('@/lib/encrypt-helpers', () => ({
 // (memoized internally). Our mock must mirror that, otherwise the hook's
 // `fetchAll` useCallback dep keeps changing and triggers infinite re-fetches.
 jest.mock('@/trpc/client', () => {
-  const fetchFn = jest.fn()
+  const listAllFetch = jest.fn()
+  const revisionFetch = jest.fn()
   const utils = {
     groups: {
       expenses: {
-        listAll: { fetch: fetchFn },
+        listAll: { fetch: listAllFetch },
+        revision: { fetch: revisionFetch },
       },
     },
   }
@@ -20,13 +22,18 @@ jest.mock('@/trpc/client', () => {
     trpc: {
       useUtils: () => utils,
     },
-    __mockListAllFetch: fetchFn,
+    __mockListAllFetch: listAllFetch,
+    __mockRevisionFetch: revisionFetch,
   }
 })
 
 import { useEncryption } from '@/components/encryption-provider'
 import { decryptExpenses } from '@/lib/encrypt-helpers'
 import { act, renderHook, waitFor } from '@testing-library/react'
+import {
+  __resetAggregateCacheForTest,
+  invalidateAggregate,
+} from './aggregateCache'
 import { useAllGroupExpenses } from './useAllGroupExpenses'
 
 const mockUseEncryption = useEncryption as jest.MockedFunction<
@@ -35,9 +42,12 @@ const mockUseEncryption = useEncryption as jest.MockedFunction<
 const mockDecryptExpenses = decryptExpenses as jest.MockedFunction<
   typeof decryptExpenses
 >
-const mockListAllFetch = (
-  jest.requireMock('@/trpc/client') as { __mockListAllFetch: jest.Mock }
-).__mockListAllFetch
+const trpcMocks = jest.requireMock('@/trpc/client') as {
+  __mockListAllFetch: jest.Mock
+  __mockRevisionFetch: jest.Mock
+}
+const mockListAllFetch = trpcMocks.__mockListAllFetch
+const mockRevisionFetch = trpcMocks.__mockRevisionFetch
 
 type FakeExpense = {
   id: string
@@ -77,10 +87,18 @@ function makePage(
 }
 
 beforeEach(() => {
+  __resetAggregateCacheForTest()
   mockListAllFetch.mockReset()
   mockDecryptExpenses.mockReset()
-  // Default: identity passthrough decrypt
+  mockRevisionFetch.mockReset()
+  // Default: identity passthrough decrypt and a stable revision so existing
+  // tests do not need to know about race detection.
   mockDecryptExpenses.mockImplementation(async (rows) => rows as never)
+  mockRevisionFetch.mockResolvedValue({ revision: 1 })
+})
+
+afterEach(() => {
+  __resetAggregateCacheForTest()
 })
 
 describe('useAllGroupExpenses (Issue #170)', () => {
@@ -440,6 +458,153 @@ describe('useAllGroupExpenses (Issue #170)', () => {
       expect((caught as Error).message).toMatch(/boom/)
       expect(result.current.queryError?.message).toMatch(/boom/)
       expect(result.current.decryptionError).toBeNull()
+    })
+  })
+
+  describe('aggregate cache + race detection (Issue #225)', () => {
+    it('does NOT re-drain on remount when revision is unchanged', async () => {
+      withKey()
+      mockListAllFetch.mockResolvedValue(
+        makePage([{ id: 'a', title: 't', amount: '1' }]),
+      )
+      mockRevisionFetch.mockResolvedValue({ revision: 5 })
+
+      const { result, unmount } = renderHook(() => useAllGroupExpenses('g1'))
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+      expect(result.current.expenses).toHaveLength(1)
+
+      const fetchCountBefore = mockListAllFetch.mock.calls.length
+      const decryptCountBefore = mockDecryptExpenses.mock.calls.length
+
+      unmount()
+
+      // New mount with the same (groupId, key) and unchanged server revision
+      // must serve the cached aggregate without a single page fetch or
+      // decrypt call.
+      const { result: result2 } = renderHook(() => useAllGroupExpenses('g1'))
+      await waitFor(() => expect(result2.current.isLoading).toBe(false))
+      expect(result2.current.expenses).toHaveLength(1)
+
+      expect(mockListAllFetch.mock.calls.length).toBe(fetchCountBefore)
+      expect(mockDecryptExpenses.mock.calls.length).toBe(decryptCountBefore)
+    })
+
+    it('re-drains on remount when revision changes', async () => {
+      withKey()
+      mockListAllFetch.mockResolvedValue(
+        makePage([{ id: 'a', title: 't', amount: '1' }]),
+      )
+      mockRevisionFetch.mockResolvedValue({ revision: 5 })
+
+      const { result, unmount } = renderHook(() => useAllGroupExpenses('g1'))
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+
+      const fetchCountBefore = mockListAllFetch.mock.calls.length
+      unmount()
+      mockRevisionFetch.mockResolvedValue({ revision: 6 })
+
+      const { result: result2 } = renderHook(() => useAllGroupExpenses('g1'))
+      await waitFor(() => expect(result2.current.isLoading).toBe(false))
+      expect(mockListAllFetch.mock.calls.length).toBeGreaterThan(
+        fetchCountBefore,
+      )
+    })
+
+    it('forceFresh bypasses cache get/set but keeps race detection', async () => {
+      withKey()
+      mockListAllFetch.mockResolvedValue(
+        makePage([{ id: 'a', title: 't', amount: '1' }]),
+      )
+      mockRevisionFetch.mockResolvedValue({ revision: 5 })
+
+      // Step 1: imperative forceFresh on an empty cache — drain runs and
+      // race detection (revBefore + revAfter) must still fire.
+      const { result: imperative } = renderHook(() =>
+        useAllGroupExpenses('g1', { enabled: false, autoDrain: false }),
+      )
+      await act(async () => {
+        await imperative.current.fetchAll({ forceFresh: true })
+      })
+
+      const fetchAfterForceFresh = mockListAllFetch.mock.calls.length
+      expect(fetchAfterForceFresh).toBeGreaterThan(0)
+      // revBefore + revAfter at minimum (forceFresh skips the cache-check
+      // revision fetch, but the race detector still issues two).
+      expect(mockRevisionFetch.mock.calls.length).toBeGreaterThanOrEqual(2)
+
+      // Step 2: autoDrain at the SAME revision should NOT cache-hit because
+      // forceFresh must not populate L2 — confirm via a second drain.
+      const { result: autoResult } = renderHook(() => useAllGroupExpenses('g1'))
+      await waitFor(() => expect(autoResult.current.isLoading).toBe(false))
+      expect(mockListAllFetch.mock.calls.length).toBeGreaterThan(
+        fetchAfterForceFresh,
+      )
+    })
+
+    it('retries on revision race and fails closed after two consecutive races', async () => {
+      withKey()
+      mockListAllFetch.mockResolvedValue(
+        makePage([{ id: 'a', title: 't', amount: '1' }]),
+      )
+      // Each revision fetch returns a different number, so every
+      // revBefore !== revAfter pair forces a retry and ultimately fails
+      // closed after two attempts.
+      let call = 0
+      mockRevisionFetch.mockImplementation(async () => {
+        call++
+        return { revision: call }
+      })
+
+      const { result } = renderHook(() => useAllGroupExpenses('g1'))
+      await waitFor(() => expect(result.current.queryError).not.toBeNull())
+      expect(result.current.queryError?.message).toMatch(/Concurrent mutation/)
+      // Stale snapshot must NOT be exposed.
+      expect(result.current.expenses).toBeUndefined()
+      // isLoading flips to false so consumers render their error state.
+      expect(result.current.isLoading).toBe(false)
+    })
+
+    it('fails closed when revision fetch throws (does NOT serve cached aggregate)', async () => {
+      withKey()
+      mockListAllFetch.mockResolvedValue(
+        makePage([{ id: 'a', title: 't', amount: '1' }]),
+      )
+      mockRevisionFetch.mockResolvedValue({ revision: 5 })
+
+      // Prime the cache.
+      const { result, unmount } = renderHook(() => useAllGroupExpenses('g1'))
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+      unmount()
+
+      mockRevisionFetch.mockReset()
+      mockRevisionFetch.mockRejectedValue(new Error('revision boom'))
+
+      const { result: result2 } = renderHook(() => useAllGroupExpenses('g1'))
+      await waitFor(() =>
+        expect(result2.current.queryError?.message).toMatch(/revision boom/),
+      )
+      expect(result2.current.expenses).toBeUndefined()
+    })
+
+    it('re-drains after invalidateAggregate', async () => {
+      withKey()
+      mockListAllFetch.mockResolvedValue(
+        makePage([{ id: 'a', title: 't', amount: '1' }]),
+      )
+      mockRevisionFetch.mockResolvedValue({ revision: 5 })
+
+      const { result, unmount } = renderHook(() => useAllGroupExpenses('g1'))
+      await waitFor(() => expect(result.current.isLoading).toBe(false))
+      unmount()
+
+      invalidateAggregate('g1')
+
+      const fetchCountBefore = mockListAllFetch.mock.calls.length
+      const { result: result2 } = renderHook(() => useAllGroupExpenses('g1'))
+      await waitFor(() => expect(result2.current.isLoading).toBe(false))
+      expect(mockListAllFetch.mock.calls.length).toBeGreaterThan(
+        fetchCountBefore,
+      )
     })
   })
 })

--- a/src/lib/hooks/useAllGroupExpenses.ts
+++ b/src/lib/hooks/useAllGroupExpenses.ts
@@ -2,6 +2,11 @@
 
 import { useEncryption } from '@/components/encryption-provider'
 import { decryptExpenses } from '@/lib/encrypt-helpers'
+import {
+  computeFingerprint,
+  getAggregate,
+  setAggregate,
+} from '@/lib/hooks/aggregateCache'
 import { trpc } from '@/trpc/client'
 import { AppRouterOutput } from '@/trpc/routers/_app'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -11,6 +16,19 @@ const PAGE_SIZE = 200
 type ListAllPage = AppRouterOutput['groups']['expenses']['listAll']
 type Cursor = NonNullable<ListAllPage['nextCursor']>
 export type GroupExpense = ListAllPage['expenses'][number]
+
+/**
+ * Internal sentinel error used to abandon a drain whose epoch / identity
+ * has been superseded. Caught and suppressed by the autoDrain useEffect;
+ * imperative callers (e.g. export) see a normal Error and surface it via
+ * their own catch path.
+ */
+class StaleDrainError extends Error {
+  constructor() {
+    super('Stale drain abandoned')
+    this.name = 'StaleDrainError'
+  }
+}
 
 export interface UseAllGroupExpensesOptions {
   /**
@@ -46,11 +64,18 @@ export interface UseAllGroupExpensesResult {
   decryptionError: Error | null
   /**
    * Imperative drain. Returns the fully decrypted array on success;
-   * throws on either fetch or decryption failure. Callers must use the
-   * return value (NOT the hook `expenses` state) to avoid reading stale
-   * React state inside the same closure.
+   * throws on fetch / decryption failure, on revision-fetch failure, or
+   * after two consecutive concurrent-mutation races.
+   *
+   * Pass `{ forceFresh: true }` to bypass the L2 decrypted-aggregate cache
+   * (both get and set). Race detection — revBefore / revAfter comparison
+   * with one retry — still runs to keep cursor-paginated drains internally
+   * consistent.
+   *
+   * Callers must use the return value (NOT the hook `expenses` state) to
+   * avoid reading stale React state inside the same closure.
    */
-  fetchAll: () => Promise<GroupExpense[]>
+  fetchAll: (opts?: { forceFresh?: boolean }) => Promise<GroupExpense[]>
 }
 
 /**
@@ -124,74 +149,151 @@ export function useAllGroupExpenses(
     [encryptionKey, hasKey, isKeyLoading],
   )
 
-  const fetchAll = useCallback(async (): Promise<GroupExpense[]> => {
-    const myEpoch = ++epochRef.current
-    const isCurrent = () => isMountedRef.current && myEpoch === epochRef.current
+  const fetchAll = useCallback(
+    async (fetchOpts?: { forceFresh?: boolean }): Promise<GroupExpense[]> => {
+      const myEpoch = ++epochRef.current
+      const isCurrent = () =>
+        isMountedRef.current &&
+        myEpoch === epochRef.current &&
+        resetKeyRef.current === resetKey
+      const ensureCurrent = () => {
+        if (!isCurrent()) throw new StaleDrainError()
+      }
 
-    if (isKeyLoading) {
-      const err = new Error('Encryption key is still loading')
-      if (isCurrent()) setQueryError(err)
-      throw err
-    }
+      if (isKeyLoading) {
+        const err = new Error('Encryption key is still loading')
+        if (isCurrent()) setQueryError(err)
+        throw err
+      }
 
-    if (isCurrent()) {
-      setIsWorking(true)
-      setQueryError(null)
-      setDecryptionError(null)
-    }
+      if (isCurrent()) {
+        setIsWorking(true)
+        setQueryError(null)
+        setDecryptionError(null)
+      }
 
-    const accumulated: GroupExpense[] = []
-    let cursor: Cursor | undefined = undefined
+      const drainLoop = async (): Promise<GroupExpense[]> => {
+        const accumulated: GroupExpense[] = []
+        let cursor: Cursor | undefined = undefined
+        while (true) {
+          if (isCurrent()) setIsFetchingNextPage(true)
+          let page: ListAllPage
+          try {
+            // staleTime: 0 forces a network fetch on every page. The
+            // default query-client staleTime would otherwise let a cached
+            // page slip into the drain mid-flight and break the
+            // revBefore / revAfter race-detection contract.
+            page = await utils.groups.expenses.listAll.fetch(
+              { groupId, limit: PAGE_SIZE, cursor },
+              { staleTime: 0 },
+            )
+          } catch (err) {
+            const error = err instanceof Error ? err : new Error(String(err))
+            if (isCurrent()) setQueryError(error)
+            throw error
+          } finally {
+            if (isCurrent()) setIsFetchingNextPage(false)
+          }
+          ensureCurrent()
 
-    try {
-      while (true) {
-        if (isCurrent()) setIsFetchingNextPage(true)
-        let page: ListAllPage
+          let decryptedPage: GroupExpense[]
+          try {
+            decryptedPage = await decryptPage(page.expenses)
+          } catch (err) {
+            const error = err instanceof Error ? err : new Error(String(err))
+            if (isCurrent()) setDecryptionError(error)
+            // CRITICAL (Issue #80): never push encrypted ciphertext into
+            // `accumulated`. Re-throw so imperative callers (export) also
+            // fail closed and never receive encrypted data.
+            throw error
+          }
+          ensureCurrent()
+
+          accumulated.push(...decryptedPage)
+          if (!page.nextCursor) break
+          cursor = page.nextCursor
+        }
+        return accumulated
+      }
+
+      const fetchRevision = async (): Promise<number> => {
         try {
-          // staleTime: 0 forces a network fetch on every page. The default
-          // query-client staleTime (30s) would otherwise let an invalidate()
-          // be raced by a cached-response read, or let a quick re-visit serve
-          // stale balances/export after a cross-device update.
-          page = await utils.groups.expenses.listAll.fetch(
-            {
-              groupId,
-              limit: PAGE_SIZE,
-              cursor,
-            },
+          const { revision } = await utils.groups.expenses.revision.fetch(
+            { groupId },
             { staleTime: 0 },
           )
+          return revision
         } catch (err) {
           const error = err instanceof Error ? err : new Error(String(err))
           if (isCurrent()) setQueryError(error)
-          throw error
-        } finally {
-          if (isCurrent()) setIsFetchingNextPage(false)
-        }
-
-        let decryptedPage: GroupExpense[]
-        try {
-          decryptedPage = await decryptPage(page.expenses)
-        } catch (err) {
-          const error = err instanceof Error ? err : new Error(String(err))
-          if (isCurrent()) setDecryptionError(error)
-          // CRITICAL (Issue #80): do NOT push encrypted ciphertext into
-          // `accumulated`. Re-throw so the imperative caller (e.g. export)
-          // also fails closed and never receives encrypted data.
+          // Fail closed: never serve a cached aggregate when we cannot
+          // confirm freshness from the server-truth revision counter.
           throw error
         }
-
-        accumulated.push(...decryptedPage)
-
-        if (!page.nextCursor) break
-        cursor = page.nextCursor
       }
 
-      if (isCurrent()) setExpenses(accumulated)
-      return accumulated
-    } finally {
-      if (isCurrent()) setIsWorking(false)
-    }
-  }, [decryptPage, groupId, isKeyLoading, utils])
+      try {
+        const fingerprint = await computeFingerprint(
+          encryptionKey ?? null,
+          hasKey,
+        )
+        ensureCurrent()
+
+        if (!fetchOpts?.forceFresh) {
+          const currentRev = await fetchRevision()
+          ensureCurrent()
+          const cached = getAggregate(groupId, fingerprint, currentRev)
+          if (cached) {
+            if (isCurrent()) setExpenses(cached)
+            return cached
+          }
+        }
+
+        // Drain with race detection (max 2 attempts). forceFresh keeps
+        // race detection on so cursor pagination cannot stitch a snapshot
+        // across mutations — partial-snapshot CSV/JSON exports were the
+        // motivating concern.
+        let raceErr: Error | null = null
+        for (let attempt = 0; attempt < 2; attempt++) {
+          const revBefore = await fetchRevision()
+          ensureCurrent()
+          const accumulated = await drainLoop()
+          ensureCurrent()
+          const revAfter = await fetchRevision()
+          ensureCurrent()
+
+          if (revBefore === revAfter) {
+            if (!fetchOpts?.forceFresh) {
+              setAggregate(groupId, fingerprint, revAfter, accumulated)
+            }
+            if (isCurrent()) setExpenses(accumulated)
+            return accumulated
+          }
+          raceErr = new Error(
+            `Concurrent mutation during drain (attempt ${attempt + 1})`,
+          )
+        }
+
+        // Two consecutive races — fail closed. setExpenses is intentionally
+        // NOT called so a stale snapshot never reaches the UI; queryError
+        // flips isLoading to false and consumers render their error state.
+        const err = raceErr ?? new Error('Concurrent mutations during drain')
+        if (isCurrent()) setQueryError(err)
+        throw err
+      } finally {
+        if (isCurrent()) setIsWorking(false)
+      }
+    },
+    [
+      decryptPage,
+      encryptionKey,
+      groupId,
+      hasKey,
+      isKeyLoading,
+      resetKey,
+      utils,
+    ],
+  )
 
   // autoDrain path: kick off a full drain whenever the (groupId, key) identity
   // changes. Stale drains are abandoned via the epoch check inside fetchAll.
@@ -206,7 +308,8 @@ export function useAllGroupExpenses(
       setDecryptionError(null)
     }
 
-    void fetchAll().catch(() => {
+    void fetchAll().catch((err) => {
+      if (err instanceof StaleDrainError) return
       // queryError / decryptionError are already populated inside fetchAll.
     })
   }, [enabled, autoDrain, isKeyLoading, resetKey, fetchAll])

--- a/src/trpc/routers/groups/expenses/index.ts
+++ b/src/trpc/routers/groups/expenses/index.ts
@@ -4,11 +4,13 @@ import { deleteGroupExpenseProcedure } from '@/trpc/routers/groups/expenses/dele
 import { getGroupExpenseProcedure } from '@/trpc/routers/groups/expenses/get.procedure'
 import { listGroupExpensesProcedure } from '@/trpc/routers/groups/expenses/list.procedure'
 import { listAllGroupExpensesProcedure } from '@/trpc/routers/groups/expenses/listAll.procedure'
+import { revisionGroupExpensesProcedure } from '@/trpc/routers/groups/expenses/revision.procedure'
 import { updateGroupExpenseProcedure } from '@/trpc/routers/groups/expenses/update.procedure'
 
 export const groupExpensesRouter = createTRPCRouter({
   list: listGroupExpensesProcedure,
   listAll: listAllGroupExpensesProcedure,
+  revision: revisionGroupExpensesProcedure,
   get: getGroupExpenseProcedure,
   create: createGroupExpenseProcedure,
   update: updateGroupExpenseProcedure,

--- a/src/trpc/routers/groups/expenses/revision.procedure.test.ts
+++ b/src/trpc/routers/groups/expenses/revision.procedure.test.ts
@@ -1,0 +1,48 @@
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    group: {
+      findUnique: jest.fn(),
+    },
+  },
+}))
+// Avoid pulling auth.ts (and its ESM @auth/prisma-adapter dep) into jest by
+// stubbing the procedure builder. The handler itself doesn't need it.
+jest.mock('@/trpc/init', () => ({
+  publicProcedure: {
+    input: () => ({ query: () => ({}) }),
+  },
+}))
+
+import { prisma } from '@/lib/prisma'
+import { TRPCError } from '@trpc/server'
+import { revisionHandler } from './revision.procedure'
+
+const mockFindUnique = prisma.group.findUnique as jest.MockedFunction<
+  typeof prisma.group.findUnique
+>
+
+describe('revisionGroupExpensesProcedure handler (Issue #225)', () => {
+  beforeEach(() => {
+    mockFindUnique.mockReset()
+  })
+
+  it('returns the current revision for an existing group', async () => {
+    mockFindUnique.mockResolvedValue({ expensesRevision: 42 } as never)
+    const result = await revisionHandler({ input: { groupId: 'g1' } })
+    expect(result).toEqual({ revision: 42 })
+    expect(mockFindUnique).toHaveBeenCalledWith({
+      where: { id: 'g1' },
+      select: { expensesRevision: true },
+    })
+  })
+
+  it('throws NOT_FOUND when the group does not exist', async () => {
+    mockFindUnique.mockResolvedValue(null)
+    await expect(
+      revisionHandler({ input: { groupId: 'missing' } }),
+    ).rejects.toThrow(TRPCError)
+    await expect(
+      revisionHandler({ input: { groupId: 'missing' } }),
+    ).rejects.toMatchObject({ code: 'NOT_FOUND' })
+  })
+})

--- a/src/trpc/routers/groups/expenses/revision.procedure.ts
+++ b/src/trpc/routers/groups/expenses/revision.procedure.ts
@@ -1,0 +1,43 @@
+import { prisma } from '@/lib/prisma'
+import { publicProcedure } from '@/trpc/init'
+import { TRPCError } from '@trpc/server'
+import { z } from 'zod'
+
+const revisionInputSchema = z.object({
+  groupId: z.string().min(1).max(30),
+})
+
+/**
+ * Resolver for {@link revisionGroupExpensesProcedure}, exported separately
+ * so unit tests can drive it without spinning up the full tRPC router.
+ */
+export async function revisionHandler({
+  input: { groupId },
+}: {
+  input: z.infer<typeof revisionInputSchema>
+}): Promise<{ revision: number }> {
+  const group = await prisma.group.findUnique({
+    where: { id: groupId },
+    select: { expensesRevision: true },
+  })
+  if (!group) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Group not found' })
+  }
+  return { revision: group.expensesRevision }
+}
+
+/**
+ * Cheap single-row SELECT that returns the current `Group.expensesRevision`
+ * counter (Issue #225). Clients use this to decide whether their locally
+ * cached decrypted expense aggregate is still fresh — matching revision
+ * means the cached aggregate is identical to what a full `listAll` drain
+ * would produce.
+ *
+ * The counter is bumped server-side, in the same transaction, by every
+ * mutation that affects the `listAll` payload: expense create / update /
+ * delete, recurring expense creation, and `updateGroup` (participant
+ * renames change `paidBy.name` / `paidFor.participant.name`).
+ */
+export const revisionGroupExpensesProcedure = publicProcedure
+  .input(revisionInputSchema)
+  .query(revisionHandler)


### PR DESCRIPTION
## Summary

- balances/stats の毎 mount/remount で全 page fetch + 全 page 復号が走る問題 (#225) を解消。 server-side `Group.expensesRevision` カウンタ + client memory 上の復号済み aggregate cache で、 cache hit 時は drain 完全 skip
- mutation 5 箇所 (createExpense / updateExpense / deleteExpense / createRecurringExpenses / updateGroup) で **同 transaction 内** に revision を +1。 updateGroup は participant rename が listAll payload に影響するため無条件 bump
- export は `fetchAll({ forceFresh: true })` で L2 cache を bypass、 race detection (revBefore/revAfter) は維持して CSV/JSON が page 間 snapshot 混在しないことを保証

## Design notes

- **Migration**: small additive — `Group.expensesRevision Int @default(0)`、 backfill 不要、 DDL lock は短時間 (PG では metadata-only)
- **Cache TTL**: hit validity (60s) — 60s+ entry は次回 access で miss 扱い + 削除。 memory 実滞在は次の cache access / reset 時まで、 MAX 16 LRU (get hit で末尾移動による真の LRU) で有界
- **Cross-tab**: lazy `BroadcastChannel`、 `typeof window !== 'undefined'` + `typeof BroadcastChannel !== 'undefined'` 両 guard で SSR / 非対応環境で fail-safe
- **Cross-device**: client-only BroadcastChannel では検知不可なので、 毎 mount で 1 行 select の server revision probe を実行 (`publicProcedure` 経由で auth + 2FA + password-change guard 通過)
- **Fail closed**: revision fetch が throw した場合は queryError set + cache を返さない (server-truth を確認できない時に stale 出さない)。 race detection retry が 2 attempts 連続 race なら同じく queryError + setExpenses しない
- **Stale identity**: epoch + resetKey の両 guard で StaleDrainError sentinel を throw。 fetchAll の `Promise<GroupExpense[]>` 契約を維持しつつ、 autoDrain effect が catch で suppress、 imperative caller (export) は通常の Error として扱う
- **Fingerprint**: SHA-256(key) 先頭 16 bytes hex (32 文字)、 `hasKey=false` は `'no-key'` で encrypted partition (32 hex) と衝突回避

## Test plan

- [x] \`pnpm prettier -c src\` (in podman: node:20-alpine)
- [x] \`pnpm check-types\` (tsc --noEmit)
- [x] \`pnpm test\` — 31 suites / 449 pass / 1 skipped (BroadcastChannel cross-tab test on environments without the global; complementary fail-safe test still runs)
- New tests:
  - \`aggregateCache.test.ts\` — get/set, TTL, revision mismatch, invalidateAggregate, LRU recency-on-get, fingerprint partitioning, BroadcastChannel post (conditional skip), no-BroadcastChannel fail-safe
  - \`useAllGroupExpenses.test.ts\` — cache hit on remount with unchanged revision, re-drain on revision change, forceFresh bypass with race detection still active, race retry + fail-closed on exhaustion, revision-fetch failure fail-closed, invalidateAggregate -> re-drain
  - \`revision.procedure.test.ts\` — happy path + NOT_FOUND
  - \`api.test.ts\` — revision +1 in same transaction for createExpense / updateExpense / deleteExpense / updateGroup / createRecurringExpenses (order assertion for createExpense and createRecurringExpenses)
  - \`create-expense-form.test.tsx\` / \`edit-expense-form.test.tsx\` — invalidateAggregate fires BEFORE awaiting utils.invalidate (create / update / delete)

## Related

- Closes #225 (PR #226 派生 scope-out: balances/stats の毎 mount/remount full drain)
- Tracking #214