### PR TITLE
fix(security): bind /api/2fa/verify to private-instance JWT subject (closes #174)

### DIFF
--- a/src/__tests__/rate-limit-callers.test.ts
+++ b/src/__tests__/rate-limit-callers.test.ts
@@ -73,7 +73,9 @@ const mockedCheckRateLimitAsync = checkRateLimitAsync as jest.MockedFunction<
   typeof checkRateLimitAsync
 >
 
-function makeSession() {
+function makeSession({
+  requiresTwoFactor = false,
+}: { requiresTwoFactor?: boolean } = {}) {
   return {
     user: {
       id: 'u1',
@@ -81,7 +83,7 @@ function makeSession() {
       isAdmin: false,
       mustChangePassword: false,
       twoFactorEnabled: true,
-      requiresTwoFactor: false,
+      requiresTwoFactor,
     },
     expires: '2099-01-01T00:00:00.000Z',
   } as never
@@ -121,6 +123,10 @@ describe('rate-limit async callers (Issue #167)', () => {
   })
 
   it('POST /api/2fa/verify returns 429 from the async rate limit', async () => {
+    // After Issue #174 the verify endpoint gates on auth() + email match +
+    // requiresTwoFactor=true BEFORE the rate-limit check. Set up a session
+    // that passes those gates so we actually reach the rate-limit branch.
+    mockedAuth.mockResolvedValue(makeSession({ requiresTwoFactor: true }))
     mockedCheckRateLimitAsync.mockResolvedValueOnce({
       isLimited: true,
       retryAfter: 30,

--- a/src/__tests__/two-factor-verify-pre-auth.test.ts
+++ b/src/__tests__/two-factor-verify-pre-auth.test.ts
@@ -1,0 +1,368 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Subject-binding tests for `/api/2fa/verify` (Issue #174).
+ *
+ * Verifies the 8-stage gate (`isPrivateInstance` → JSON parse → type
+ * validation → `auth()` session → email match → `requiresTwoFactor` →
+ * token format → subject-id rate limit) returns early with NO side
+ * effects on failure, and that DB lookup goes through `session.user.id` +
+ * `session.user.isAdmin` (NOT the body email) on the happy path.
+ */
+
+jest.mock('@/lib/auth', () => ({
+  auth: jest.fn(),
+  isPrivateInstance: jest.fn(() => true),
+}))
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    admin: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+    whitelistUser: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('@/lib/two-factor', () => ({
+  decryptSecret: jest.fn(() => 'DECRYPTED_SECRET'),
+  decryptBackupCodes: jest.fn(() => ['CODE1', 'CODE2']),
+  encryptBackupCodes: jest.fn(() => 'enc-codes'),
+  normalizeToken: jest.fn((t: string) => t),
+  timingSafeCompare: jest.fn(() => false),
+  verifyTOTP: jest.fn(() => false),
+}))
+
+jest.mock('@/lib/rate-limit', () => ({
+  checkRateLimitAsync: jest.fn(() =>
+    Promise.resolve({ isLimited: false, remainingAttempts: 5 }),
+  ),
+  recordFailedAttemptAsync: jest.fn(() => Promise.resolve()),
+  clearAttemptsAsync: jest.fn(() => Promise.resolve()),
+}))
+
+import { auth, isPrivateInstance } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import {
+  checkRateLimitAsync,
+  clearAttemptsAsync,
+  recordFailedAttemptAsync,
+} from '@/lib/rate-limit'
+import { timingSafeCompare, verifyTOTP } from '@/lib/two-factor'
+
+const mockedAuth = auth as jest.MockedFunction<typeof auth>
+const mockedIsPrivateInstance = isPrivateInstance as jest.MockedFunction<
+  typeof isPrivateInstance
+>
+const mockedCheckRateLimitAsync = checkRateLimitAsync as jest.MockedFunction<
+  typeof checkRateLimitAsync
+>
+const mockedRecordFailedAttemptAsync =
+  recordFailedAttemptAsync as jest.MockedFunction<
+    typeof recordFailedAttemptAsync
+  >
+const mockedClearAttemptsAsync = clearAttemptsAsync as jest.MockedFunction<
+  typeof clearAttemptsAsync
+>
+const mockedVerifyTOTP = verifyTOTP as jest.MockedFunction<typeof verifyTOTP>
+const mockedTimingSafeCompare = timingSafeCompare as jest.MockedFunction<
+  typeof timingSafeCompare
+>
+const mockedPrisma = prisma as unknown as {
+  admin: { findUnique: jest.Mock; update: jest.Mock }
+  whitelistUser: { findUnique: jest.Mock; update: jest.Mock }
+}
+
+function makeSession({
+  id = 'u1',
+  email = 'user@example.com',
+  isAdmin = false,
+  requiresTwoFactor = true,
+}: {
+  id?: string
+  email?: string
+  isAdmin?: boolean
+  requiresTwoFactor?: boolean
+} = {}) {
+  return {
+    user: {
+      id,
+      email,
+      isAdmin,
+      mustChangePassword: false,
+      twoFactorEnabled: true,
+      requiresTwoFactor,
+    },
+    expires: '2099-01-01T00:00:00.000Z',
+  } as never
+}
+
+function makeRequest(body: unknown): Request {
+  return new Request('http://localhost/api/2fa/verify', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  })
+}
+
+function expectZeroSideEffects() {
+  expect(mockedPrisma.admin.findUnique).not.toHaveBeenCalled()
+  expect(mockedPrisma.admin.update).not.toHaveBeenCalled()
+  expect(mockedPrisma.whitelistUser.findUnique).not.toHaveBeenCalled()
+  expect(mockedPrisma.whitelistUser.update).not.toHaveBeenCalled()
+  expect(mockedRecordFailedAttemptAsync).not.toHaveBeenCalled()
+  expect(mockedClearAttemptsAsync).not.toHaveBeenCalled()
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockedIsPrivateInstance.mockReturnValue(true)
+  mockedCheckRateLimitAsync.mockResolvedValue({
+    isLimited: false,
+    remainingAttempts: 5,
+  })
+  mockedVerifyTOTP.mockReturnValue(false)
+  mockedTimingSafeCompare.mockReturnValue(false)
+})
+
+describe('POST /api/2fa/verify — subject binding (Issue #174)', () => {
+  it('1: returns 404 when private instance is disabled (no side effects, auth not called)', async () => {
+    mockedIsPrivateInstance.mockReturnValue(false)
+    const { POST } = await import('@/app/api/2fa/verify/route')
+    const res = await POST(
+      makeRequest({ email: 'u@example.com', token: '123456' }),
+    )
+    expect(res.status).toBe(404)
+    expect(mockedAuth).not.toHaveBeenCalled()
+    expect(mockedCheckRateLimitAsync).not.toHaveBeenCalled()
+    expectZeroSideEffects()
+  })
+
+  it('2: returns 400 on malformed JSON (no side effects)', async () => {
+    const { POST } = await import('@/app/api/2fa/verify/route')
+    const req = new Request('http://localhost/api/2fa/verify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{',
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Invalid request' })
+    expect(mockedAuth).not.toHaveBeenCalled()
+    expect(mockedCheckRateLimitAsync).not.toHaveBeenCalled()
+    expectZeroSideEffects()
+  })
+
+  it('3: returns 400 when body.email is not a string', async () => {
+    const { POST } = await import('@/app/api/2fa/verify/route')
+    const res = await POST(makeRequest({ email: 123, token: '123456' }))
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Invalid request' })
+    expect(mockedAuth).not.toHaveBeenCalled()
+    expect(mockedCheckRateLimitAsync).not.toHaveBeenCalled()
+    expectZeroSideEffects()
+  })
+
+  it('4: returns 400 when body.token is not a string', async () => {
+    const { POST } = await import('@/app/api/2fa/verify/route')
+    const res = await POST(
+      makeRequest({ email: 'u@example.com', token: 123456 }),
+    )
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Invalid request' })
+    expect(mockedAuth).not.toHaveBeenCalled()
+    expect(mockedCheckRateLimitAsync).not.toHaveBeenCalled()
+    expectZeroSideEffects()
+  })
+
+  it('5: returns 401 when there is no session', async () => {
+    mockedAuth.mockResolvedValue(null as never)
+    const { POST } = await import('@/app/api/2fa/verify/route')
+    const res = await POST(
+      makeRequest({ email: 'u@example.com', token: '123456' }),
+    )
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: 'Invalid request' })
+    expect(mockedCheckRateLimitAsync).not.toHaveBeenCalled()
+    expectZeroSideEffects()
+  })
+
+  it('6: returns 401 when session email does not match body email', async () => {
+    mockedAuth.mockResolvedValue(makeSession({ email: 'real@example.com' }))
+    const { POST } = await import('@/app/api/2fa/verify/route')
+    const res = await POST(
+      makeRequest({ email: 'attacker@example.com', token: '123456' }),
+    )
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: 'Invalid request' })
+    expect(mockedCheckRateLimitAsync).not.toHaveBeenCalled()
+    expectZeroSideEffects()
+  })
+
+  it('7: returns 400 Already verified when requiresTwoFactor is false', async () => {
+    mockedAuth.mockResolvedValue(
+      makeSession({ email: 'u@example.com', requiresTwoFactor: false }),
+    )
+    const { POST } = await import('@/app/api/2fa/verify/route')
+    const res = await POST(
+      makeRequest({ email: 'u@example.com', token: '123456' }),
+    )
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Already verified' })
+    expect(mockedCheckRateLimitAsync).not.toHaveBeenCalled()
+    expectZeroSideEffects()
+  })
+
+  it('8: returns 400 when token format is invalid (rate-limit untouched)', async () => {
+    mockedAuth.mockResolvedValue(makeSession({ email: 'u@example.com' }))
+    const { POST } = await import('@/app/api/2fa/verify/route')
+    const res = await POST(
+      makeRequest({ email: 'u@example.com', token: 'bad-format' }),
+    )
+    expect(res.status).toBe(400)
+    expect(mockedCheckRateLimitAsync).not.toHaveBeenCalled()
+    expectZeroSideEffects()
+  })
+
+  it('9: returns 429 when rate limited (no DB side effects)', async () => {
+    mockedAuth.mockResolvedValue(makeSession({ email: 'u@example.com' }))
+    mockedCheckRateLimitAsync.mockResolvedValue({
+      isLimited: true,
+      retryAfter: 600,
+    })
+    const { POST } = await import('@/app/api/2fa/verify/route')
+    const res = await POST(
+      makeRequest({ email: 'u@example.com', token: '123456' }),
+    )
+    expect(res.status).toBe(429)
+    expect(res.headers.get('Retry-After')).toBe('600')
+    expect(mockedPrisma.admin.findUnique).not.toHaveBeenCalled()
+    expect(mockedPrisma.whitelistUser.findUnique).not.toHaveBeenCalled()
+    expect(mockedRecordFailedAttemptAsync).not.toHaveBeenCalled()
+    expect(mockedClearAttemptsAsync).not.toHaveBeenCalled()
+  })
+
+  it('10: happy TOTP for Admin uses admin.findUnique by id and clears attempts', async () => {
+    mockedAuth.mockResolvedValue(
+      makeSession({ id: 'a1', email: 'admin@example.com', isAdmin: true }),
+    )
+    mockedPrisma.admin.findUnique.mockResolvedValue({
+      id: 'a1',
+      twoFactorEnabled: true,
+      twoFactorSecret: 'enc-secret',
+      twoFactorBackupCodes: null,
+    })
+    mockedVerifyTOTP.mockReturnValue(true)
+    const { POST } = await import('@/app/api/2fa/verify/route')
+    const res = await POST(
+      makeRequest({ email: 'admin@example.com', token: '123456' }),
+    )
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      success: true,
+      verified: true,
+      usedBackupCode: false,
+    })
+    expect(mockedPrisma.admin.findUnique).toHaveBeenCalledWith({
+      where: { id: 'a1' },
+      select: {
+        id: true,
+        twoFactorEnabled: true,
+        twoFactorSecret: true,
+        twoFactorBackupCodes: true,
+      },
+    })
+    expect(mockedPrisma.admin.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'a1' },
+        data: expect.objectContaining({
+          lastTwoFactorVerifiedAt: expect.any(Date),
+        }),
+      }),
+    )
+    expect(mockedPrisma.whitelistUser.findUnique).not.toHaveBeenCalled()
+    expect(mockedPrisma.whitelistUser.update).not.toHaveBeenCalled()
+    expect(mockedClearAttemptsAsync).toHaveBeenCalledWith('2fa-verify:a1')
+    expect(mockedRecordFailedAttemptAsync).not.toHaveBeenCalled()
+  })
+
+  it('11: happy backup code for WhitelistUser splices + updates + clears attempts', async () => {
+    mockedAuth.mockResolvedValue(
+      makeSession({ id: 'u1', email: 'user@example.com', isAdmin: false }),
+    )
+    mockedPrisma.whitelistUser.findUnique.mockResolvedValue({
+      id: 'u1',
+      twoFactorEnabled: true,
+      twoFactorSecret: 'enc-secret',
+      twoFactorBackupCodes: 'enc-codes',
+    })
+    // First timingSafeCompare returns true → codeIndex=0 → consume.
+    mockedTimingSafeCompare.mockImplementationOnce(() => true)
+    const { POST } = await import('@/app/api/2fa/verify/route')
+    const res = await POST(
+      makeRequest({ email: 'user@example.com', token: 'ABCD1234' }),
+    )
+    expect(res.status).toBe(200)
+    expect(await res.json()).toEqual({
+      success: true,
+      verified: true,
+      usedBackupCode: true,
+    })
+    expect(mockedPrisma.whitelistUser.findUnique).toHaveBeenCalledWith({
+      where: { id: 'u1' },
+      select: {
+        id: true,
+        twoFactorEnabled: true,
+        twoFactorSecret: true,
+        twoFactorBackupCodes: true,
+      },
+    })
+    // Two updates: backup-codes splice then lastTwoFactorVerifiedAt.
+    expect(mockedPrisma.whitelistUser.update).toHaveBeenCalledTimes(2)
+    expect(mockedPrisma.whitelistUser.update).toHaveBeenCalledWith({
+      where: { id: 'u1' },
+      data: { twoFactorBackupCodes: 'enc-codes' },
+    })
+    expect(mockedPrisma.whitelistUser.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'u1' },
+        data: expect.objectContaining({
+          lastTwoFactorVerifiedAt: expect.any(Date),
+        }),
+      }),
+    )
+    expect(mockedPrisma.admin.findUnique).not.toHaveBeenCalled()
+    expect(mockedPrisma.admin.update).not.toHaveBeenCalled()
+    expect(mockedClearAttemptsAsync).toHaveBeenCalledWith('2fa-verify:u1')
+    expect(mockedRecordFailedAttemptAsync).not.toHaveBeenCalled()
+  })
+
+  it('12: returns 401 Invalid token when verify fails (recordFailedAttempt called, no updates)', async () => {
+    mockedAuth.mockResolvedValue(
+      makeSession({ id: 'u1', email: 'user@example.com', isAdmin: false }),
+    )
+    mockedPrisma.whitelistUser.findUnique.mockResolvedValue({
+      id: 'u1',
+      twoFactorEnabled: true,
+      twoFactorSecret: 'enc-secret',
+      twoFactorBackupCodes: null,
+    })
+    mockedVerifyTOTP.mockReturnValue(false)
+    const { POST } = await import('@/app/api/2fa/verify/route')
+    const res = await POST(
+      makeRequest({ email: 'user@example.com', token: '000000' }),
+    )
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: 'Invalid token' })
+    expect(mockedRecordFailedAttemptAsync).toHaveBeenCalledWith('2fa-verify:u1')
+    expect(mockedPrisma.whitelistUser.update).not.toHaveBeenCalled()
+    expect(mockedPrisma.admin.update).not.toHaveBeenCalled()
+    expect(mockedClearAttemptsAsync).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/2fa/verify/route.ts
+++ b/src/app/api/2fa/verify/route.ts
@@ -1,11 +1,24 @@
 /**
  * 2FA Verify API Endpoint (Login Flow)
  *
- * This endpoint verifies a TOTP token or backup code during login.
- * Called BEFORE full authentication - only requires email to identify the user.
- * Does not require session authentication since user hasn't completed login yet.
+ * Post-password / pre-2FA verification. Requires a NextAuth JWT session
+ * issued by `authorize()` after password verification (Issue #4). The
+ * endpoint is bound to the JWT subject:
+ *
+ *   - `body.email` must match `session.user.email` (client tamper check).
+ *   - DB lookup uses `session.user.id` + `session.user.isAdmin` — the real
+ *     subject pin. Email alone is insufficient because Admin and
+ *     WhitelistUser tables are not cross-table email-unique at the DB
+ *     constraint level.
+ *
+ * Failure of any pre-DB gate (private-instance, JSON parse, type, session,
+ * email match, `requiresTwoFactor`, token format) returns early with no
+ * side effects: no rate-limit store touch, no DB read/write, no failed
+ * attempt recorded. The rate-limit key is also subject-id based, so an
+ * attacker cannot lock out a third party (Issue #174).
  */
 
+import { auth, isPrivateInstance } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
 import {
   checkRateLimitAsync,
@@ -25,30 +38,70 @@ import { NextResponse } from 'next/server'
 // Backup code format: 8 alphanumeric characters (uppercase)
 const BACKUP_CODE_REGEX = /^[A-Z0-9]{8}$/
 
-// Rate limit key prefix for 2FA verification (separate from login attempts)
+// Rate-limit key prefix for 2FA verification (separate from login attempts).
+// The full key is `${RATE_LIMIT_PREFIX}${session.user.id}` — keyed by the
+// JWT subject id, NOT the request body email. This prevents an attacker
+// from locking out a third party by submitting failed verifications under
+// their email (Issue #174).
 const RATE_LIMIT_PREFIX = '2fa-verify:'
 
 export async function POST(request: Request) {
   try {
-    // 1. Accept { email, token } in request body
-    const body = (await request.json()) as {
-      email?: string
-      token?: string
-    }
-    const { email, token } = body
-
-    if (!email) {
-      return NextResponse.json({ error: 'Email is required' }, { status: 400 })
+    // 1. Private-instance gate — endpoint must not exist on public mode.
+    //    Placed before `request.json()` so even malformed bodies see 404.
+    if (!isPrivateInstance()) {
+      return new NextResponse(null, { status: 404 })
     }
 
-    if (!token) {
-      return NextResponse.json({ error: 'Token is required' }, { status: 400 })
+    // 2. JSON parse — malformed bodies return 400 (not the outer-catch 500)
+    //    and touch nothing else.
+    let body: unknown
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
     }
 
-    // Check rate limit before processing (5 attempts per minute per email)
-    const rateLimitKey = `${RATE_LIMIT_PREFIX}${email}`
+    // 3. Type validation — `typeof string` is required; truthy is not enough
+    //    for a security endpoint.
+    const email = (body as { email?: unknown }).email
+    const token = (body as { token?: unknown }).token
+    if (typeof email !== 'string' || typeof token !== 'string') {
+      return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
+    }
+
+    // 4. Pre-2FA session must exist (issued by `authorize()` after password
+    //    verification).
+    const session = await auth()
+    if (!session?.user?.email || !session.user.id) {
+      return NextResponse.json({ error: 'Invalid request' }, { status: 401 })
+    }
+
+    // 5. `body.email` must match the session subject (client tamper check).
+    if (session.user.email !== email) {
+      return NextResponse.json({ error: 'Invalid request' }, { status: 401 })
+    }
+
+    // 6. Session must still require 2FA — if `requiresTwoFactor` is false
+    //    the user has already completed verification for this login.
+    if (!session.user.requiresTwoFactor) {
+      return NextResponse.json({ error: 'Already verified' }, { status: 400 })
+    }
+
+    // 7. Token format — normalize then validate shape.
+    const normalizedToken = normalizeToken(token)
+    const isTOTPToken = /^\d{6}$/.test(normalizedToken)
+    const isBackupCode = BACKUP_CODE_REGEX.test(normalizedToken)
+    if (!isTOTPToken && !isBackupCode) {
+      return NextResponse.json(
+        { error: 'Token must be a 6-digit code or an 8-character backup code' },
+        { status: 400 },
+      )
+    }
+
+    // 8. Rate limit — keyed by the JWT subject id (NOT the body email).
+    const rateLimitKey = `${RATE_LIMIT_PREFIX}${session.user.id}`
     const rateLimitResult = await checkRateLimitAsync(rateLimitKey)
-
     if (rateLimitResult.isLimited) {
       return NextResponse.json(
         {
@@ -64,35 +117,20 @@ export async function POST(request: Request) {
       )
     }
 
-    // Normalize token (trim whitespace, uppercase, remove non-alphanumeric)
-    const normalizedToken = normalizeToken(token)
-
-    // Determine if this is a TOTP token (6 digits) or backup code (8 alphanumeric)
-    const isTOTPToken = /^\d{6}$/.test(normalizedToken)
-    const isBackupCode = BACKUP_CODE_REGEX.test(normalizedToken)
-
-    if (!isTOTPToken && !isBackupCode) {
-      return NextResponse.json(
-        { error: 'Token must be a 6-digit code or an 8-character backup code' },
-        { status: 400 },
-      )
-    }
-
-    // 2. Find user by email in Admin or WhitelistUser tables
-    const admin = await prisma.admin.findUnique({
-      where: { email },
-      select: {
-        id: true,
-        twoFactorEnabled: true,
-        twoFactorSecret: true,
-        twoFactorBackupCodes: true,
-      },
-    })
-
-    const whitelistUser = admin
-      ? null
+    // 9. DB lookup by session subject (id + isAdmin) — NOT by email.
+    const isAdmin = session.user.isAdmin
+    const user = isAdmin
+      ? await prisma.admin.findUnique({
+          where: { id: session.user.id },
+          select: {
+            id: true,
+            twoFactorEnabled: true,
+            twoFactorSecret: true,
+            twoFactorBackupCodes: true,
+          },
+        })
       : await prisma.whitelistUser.findUnique({
-          where: { email },
+          where: { id: session.user.id },
           select: {
             id: true,
             twoFactorEnabled: true,
@@ -101,32 +139,20 @@ export async function POST(request: Request) {
           },
         })
 
-    const user = admin || whitelistUser
-    const isAdmin = !!admin
-
-    if (!user) {
-      // Don't reveal whether the email exists or not for security
+    if (!user || !user.twoFactorEnabled || !user.twoFactorSecret) {
+      // Generic error — do not reveal whether the subject exists or whether
+      // 2FA is enabled (Issue #42).
       return NextResponse.json(
         { error: 'Invalid email or token' },
         { status: 401 },
       )
     }
 
-    // 3. Check if twoFactorEnabled is true
-    // Return generic error to prevent user enumeration (Issue #42)
-    if (!user.twoFactorEnabled || !user.twoFactorSecret) {
-      return NextResponse.json(
-        { error: 'Invalid email or token' },
-        { status: 401 },
-      )
-    }
-
-    // 4. Decrypt twoFactorSecret and verify the TOTP token OR check backup codes
+    // 10. Verify the TOTP token OR check backup codes.
     let verified = false
     let usedBackupCode = false
 
     if (isTOTPToken) {
-      // Verify TOTP token
       let decryptedSecret: string
       try {
         decryptedSecret = decryptSecret(user.twoFactorSecret)
@@ -136,10 +162,8 @@ export async function POST(request: Request) {
           { status: 500 },
         )
       }
-
       verified = verifyTOTP(decryptedSecret, normalizedToken)
     } else if (isBackupCode && user.twoFactorBackupCodes) {
-      // Verify backup code
       let backupCodes: string[]
       try {
         backupCodes = decryptBackupCodes(user.twoFactorBackupCodes)
@@ -150,7 +174,6 @@ export async function POST(request: Request) {
         )
       }
 
-      // Check if the backup code exists using timing-safe comparison
       let codeIndex = -1
       for (let i = 0; i < backupCodes.length; i++) {
         if (timingSafeCompare(backupCodes[i], normalizedToken)) {
@@ -163,11 +186,9 @@ export async function POST(request: Request) {
         verified = true
         usedBackupCode = true
 
-        // 5. If backup code is used, remove it from the list
+        // 11a. Consume the used backup code (DB side effect #1).
         backupCodes.splice(codeIndex, 1)
         const encryptedBackupCodes = encryptBackupCodes(backupCodes)
-
-        // Update the user's backup codes
         if (isAdmin) {
           await prisma.admin.update({
             where: { id: user.id },
@@ -183,16 +204,14 @@ export async function POST(request: Request) {
     }
 
     if (!verified) {
-      // Record failed attempt for rate limiting
+      // 12. Verification failed — record the failed attempt for rate limiting.
       await recordFailedAttemptAsync(rateLimitKey)
       return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
     }
 
-    // Clear rate limit attempts on successful verification
-    await clearAttemptsAsync(rateLimitKey)
-
-    // Record server-side 2FA verification timestamp (Issue #123)
-    // This prevents client-side bypass of twoFactorVerified flag
+    // 11b. Record server-side 2FA verification timestamp (Issue #123). The
+    //      JWT callback clears `requiresTwoFactor` when this is within the
+    //      5-minute freshness window.
     const now = new Date()
     if (isAdmin) {
       await prisma.admin.update({
@@ -206,7 +225,11 @@ export async function POST(request: Request) {
       })
     }
 
-    // 6. Return { success: true, verified: true } on success
+    // 11c. Clear rate-limit attempts only AFTER DB side effects have
+    //      completed — if a DB update fails, the rate-limit entry stays so
+    //      retries are still throttled.
+    await clearAttemptsAsync(rateLimitKey)
+
     return NextResponse.json({
       success: true,
       verified: true,

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -38,9 +38,11 @@ export function passwordChangeRequiredResponse(
  * (`src/trpc/init.ts`, Issue #166). REST API handlers must call this BEFORE
  * `passwordChangeRequiredResponse` so the 2FA gate matches the tRPC ordering.
  *
- * The pre-auth 2FA verify endpoint (`/api/2fa/verify`, which runs without a
- * full session) is intentionally exempt — calling this helper there would
- * block the very flow that clears the flag.
+ * The 2FA verify endpoint (`/api/2fa/verify`) is intentionally exempt:
+ * `requiresTwoFactor=true` is the very pre-condition that endpoint needs to
+ * clear, so calling this helper would self-block the flow. That endpoint
+ * performs its own subject binding via `session.user.id` + `isAdmin` and a
+ * subject-id rate-limit key instead (Issue #174).
  */
 export function requiresTwoFactorResponse(
   session: Session | null,

--- a/src/lib/auth-helpers.ts
+++ b/src/lib/auth-helpers.ts
@@ -13,9 +13,11 @@ import { NextResponse } from 'next/server'
  * their password before performing other actions, or null otherwise.
  *
  * Mirrors the `mustChangePassword` check in publicProcedure / adminProcedure
- * (Issue #142). The change-password endpoint and the pre-auth 2FA verify
- * endpoint (which has no session) are intentionally exempt and should not
- * call this helper.
+ * (Issue #142). The change-password endpoint and the 2FA verify endpoint
+ * (`/api/2fa/verify`) are intentionally exempt and should not call this
+ * helper. The verify endpoint runs its own subject-bound pre-2FA gate
+ * (Issue #174); blocking on `mustChangePassword` would self-block users
+ * who must complete 2FA before reaching the change-password flow.
  */
 export function passwordChangeRequiredResponse(
   session: Session | null,


### PR DESCRIPTION
## Summary

- **Before**: `/api/2fa/verify` accepted arbitrary `email` in the request body without a session check or private-instance gate. An attacker who knew an email + one valid TOTP/backup code could consume the backup code and update `lastTwoFactorVerifiedAt` for that email.
- **After**: an 8-stage gate runs before any DB lookup — `isPrivateInstance()` 404 → JSON parse (own try/catch → 400, not outer 500) → `typeof email/token === 'string'` → `auth()` session → `session.user.email === body.email` → `requiresTwoFactor === true` → token format → subject-id rate-limit. The DB lookup then routes through `session.user.id` + `session.user.isAdmin` (NOT the body email), since Admin and WhitelistUser tables are not cross-table email-unique at the DB constraint level.
- **Zero side effects on gate failure**: rate-limit store, DB read/write, and `recordFailedAttempt` are all untouched when any pre-DB gate trips.
- **Rate-limit key is `2fa-verify:${session.user.id}`** — an attacker can no longer lock out a third party; only self-lockout remains (intended UX trade-off).
- **Success ordering**: DB side effects (backup-code splice + `lastTwoFactorVerifiedAt` update) complete first, then `clearAttemptsAsync` — if a DB update fails, rate-limit attempts stay throttled.
- `body.email` becomes a client-tamper check; the real subject pin is `session.user.id` + `session.user.isAdmin`.

## Changes

- `src/app/api/2fa/verify/route.ts`: 8-stage gate, JSON-parse-only try/catch, subject-id DB lookup, subject-id rate-limit key, header / `RATE_LIMIT_PREFIX` comments refreshed.
- `src/lib/auth-helpers.ts`: refresh `requiresTwoFactorResponse` doc comment — the verify-endpoint exempt explanation now reflects the post-#174 design (subject-id binding, not "no full session").
- `src/__tests__/two-factor-verify-pre-auth.test.ts` (new): 12 cases covering every gate's zero-side-effect behavior, plus Admin (TOTP) and WhitelistUser (backup code) happy paths and the invalid-token recordFailedAttempt path.
- `src/__tests__/rate-limit-callers.test.ts`: extend the existing `/api/2fa/verify returns 429` test with the session mock now required to reach the rate-limit branch under the new order.

## Test plan

- [x] podman + node:20-alpine: \`prettier --check\` passes on all 4 target files.
- [x] podman + node:20-alpine: \`tsc --noEmit\` passes with no error.
- [x] podman + node:20-alpine: full \`jest\` suite — **32 suites / 461 passed / 1 skipped**, no regression.
- [x] 12 new test cases:
  - 1: private-instance off → 404; \`auth()\` not called; all side-effect mocks untouched.
  - 2: malformed JSON (\`body: '{'\`) → 400 \`Invalid request\`; zero side effects.
  - 3–4: non-string email / token → 400; zero side effects.
  - 5: no session → 401 \`Invalid request\`; rate-limit untouched.
  - 6: session email ≠ body email → 401 \`Invalid request\`; rate-limit untouched.
  - 7: \`requiresTwoFactor=false\` → 400 \`Already verified\`; zero side effects.
  - 8: invalid token format → 400; rate-limit untouched.
  - 9: rate-limited → 429 + \`Retry-After\`; no DB / recordFailed / clearAttempts.
  - 10: happy TOTP for **Admin** → 200; \`admin.findUnique({id})\` + \`admin.update(lastTwoFactorVerifiedAt)\` + \`clearAttemptsAsync('2fa-verify:a1')\`; \`whitelistUser.*\` and \`recordFailed\` untouched.
  - 11: happy backup code for **WhitelistUser** → 200 \`usedBackupCode=true\`; \`whitelistUser.findUnique({id})\` + two \`whitelistUser.update\` (backup-code splice then \`lastTwoFactorVerifiedAt\`) + \`clearAttemptsAsync('2fa-verify:u1')\`; \`admin.*\` and \`recordFailed\` untouched.
  - 12: invalid token (session/email/requiresTF/format OK, verify fails) → 401 \`Invalid token\`; \`recordFailedAttemptAsync('2fa-verify:u1')\` called; update / clearAttempts untouched.

## Notes

- E2EE invariant: unaffected. This endpoint authenticates 2FA, not encrypted data.
- Migration / Prisma schema / i18n / docs / changelog: no change.
- Scope: arbitrary-email lockout DoS is now infeasible (rate-limit key is subject-id based); only self-lockout remains, which is the intended behavior.