### PR TITLE
fix(security): zod input validation + streaming body-size cap + per-admin rate-limit for /api/admin/whitelist POST (closes #176)

### DIFF
--- a/src/__tests__/admin-whitelist-validation.test.ts
+++ b/src/__tests__/admin-whitelist-validation.test.ts
@@ -432,4 +432,27 @@ describe('POST /api/admin/whitelist — section H (rate-limit key separation)', 
       expect(call[2]).toBe(60 * 60 * 1000)
     }
   })
+
+  it('reserves the limiter slot synchronously after CHECK (no awaited mock invocation between them)', async () => {
+    const res = await POST(makeRequest(streamBody('{"email":"a@b.co"}')))
+    expect(res.status).toBe(200)
+    expect(mockCheck).toHaveBeenCalledTimes(1)
+    expect(mockRecord).toHaveBeenCalledTimes(1)
+    // jest tracks a monotonic, cross-mock invocationCallOrder. If
+    // `recordOperationAttempt` is the very next mock invocation after
+    // `checkOperationRateLimit`, then no other awaited dependency
+    // (prisma, bcrypt, body reader, etc.) ran between them — proving
+    // the slot is reserved before any await. Without this, a
+    // concurrent burst of admin POSTs could all pass CHECK at low
+    // counts before any of them awaited record (Codex review iter 1
+    // on PR #231).
+    //
+    // Note: Node 20 buffers ReadableStream request bodies during
+    // `new Request(...)` construction, so a pull()-based ordering
+    // probe would fire before the route ever ran. invocationCallOrder
+    // sidesteps that quirk by working off jest's own mock counters.
+    const checkOrder = mockCheck.mock.invocationCallOrder[0]
+    const recordOrder = mockRecord.mock.invocationCallOrder[0]
+    expect(recordOrder).toBe(checkOrder + 1)
+  })
 })

--- a/src/__tests__/admin-whitelist-validation.test.ts
+++ b/src/__tests__/admin-whitelist-validation.test.ts
@@ -1,0 +1,435 @@
+/**
+ * @jest-environment node
+ *
+ * Route tests for /api/admin/whitelist POST (Issue #176).
+ *
+ * Strategy: mock @/lib/auth, @/lib/rate-limit, @/lib/prisma, and bcryptjs;
+ * use the real @/lib/auth-helpers module so session-shape regressions in
+ * the 2FA / password-change gates are picked up. The 60/61 limiter
+ * boundary itself is covered by src/lib/rate-limit.test.ts — these tests
+ * only verify the route's invocation contract.
+ */
+
+jest.mock('@/lib/auth', () => ({
+  __esModule: true,
+  auth: jest.fn(),
+  isPrivateInstance: jest.fn(),
+}))
+
+jest.mock('@/lib/rate-limit', () => ({
+  __esModule: true,
+  checkOperationRateLimit: jest.fn(),
+  recordOperationAttempt: jest.fn(),
+}))
+
+jest.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  prisma: {
+    whitelistUser: {
+      findUnique: jest.fn(),
+      create: jest.fn(),
+    },
+    admin: {
+      findUnique: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('bcryptjs', () => ({
+  __esModule: true,
+  default: {
+    hash: jest.fn(),
+  },
+}))
+
+import { POST } from '@/app/api/admin/whitelist/route'
+import { auth, isPrivateInstance } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import {
+  checkOperationRateLimit,
+  recordOperationAttempt,
+} from '@/lib/rate-limit'
+import bcrypt from 'bcryptjs'
+
+// MockedFunction<typeof X> chokes on NextAuth's overloaded `auth` and on
+// PrismaPromise return types, so each mock is cast to the wide jest.Mock
+// signature. Tests work with mock return values directly, not with the
+// real call signatures, so the loss of type safety is acceptable.
+const mockAuth = auth as unknown as jest.Mock
+const mockIsPrivateInstance = isPrivateInstance as unknown as jest.Mock
+const mockCheck = checkOperationRateLimit as unknown as jest.Mock
+const mockRecord = recordOperationAttempt as unknown as jest.Mock
+const mockBcryptHash = bcrypt.hash as unknown as jest.Mock
+const mockWhitelistFindUnique = prisma.whitelistUser
+  .findUnique as unknown as jest.Mock
+const mockWhitelistCreate = prisma.whitelistUser.create as unknown as jest.Mock
+const mockAdminFindUnique = prisma.admin.findUnique as unknown as jest.Mock
+
+type SessionUser = {
+  id: string
+  email: string
+  name: string
+  isAdmin: boolean
+  mustChangePassword: boolean
+  twoFactorEnabled: boolean
+  requiresTwoFactor: boolean
+}
+
+const DEFAULT_USER: SessionUser = {
+  id: 'admin-id-1',
+  email: 'admin@example.com',
+  name: 'Admin',
+  isAdmin: true,
+  mustChangePassword: false,
+  twoFactorEnabled: false,
+  requiresTwoFactor: false,
+}
+
+function makeSession(
+  overrides: Partial<SessionUser> = {},
+): Awaited<ReturnType<typeof auth>> {
+  return {
+    user: { ...DEFAULT_USER, ...overrides },
+    expires: new Date(Date.now() + 60 * 1000).toISOString(),
+  } as unknown as Awaited<ReturnType<typeof auth>>
+}
+
+function streamBody(content: string): ReadableStream<Uint8Array> {
+  const encoded = new TextEncoder().encode(content)
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(encoded)
+      controller.close()
+    },
+  })
+}
+
+function makeRequest(body: BodyInit | null): Request {
+  // `duplex: 'half'` is required by Node 20's fetch API when sending a
+  // streaming Request body. RequestInit's static typing does not include
+  // `duplex` in every TS version, so the minimal cast is test-side only.
+  return new Request('http://localhost/api/admin/whitelist', {
+    method: 'POST',
+    body,
+    ...({ duplex: 'half' } as Record<string, unknown>),
+  })
+}
+
+function setupValidSession(overrides: Partial<SessionUser> = {}) {
+  mockIsPrivateInstance.mockReturnValue(true)
+  mockAuth.mockResolvedValue(makeSession(overrides))
+  mockCheck.mockReturnValue({ isLimited: false, remainingAttempts: 60 })
+}
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('POST /api/admin/whitelist — section A (gates do not touch limiter)', () => {
+  it('returns 400 when private instance is disabled', async () => {
+    mockIsPrivateInstance.mockReturnValue(false)
+    const res = await POST(makeRequest(streamBody('{}')))
+    expect(res.status).toBe(400)
+    expect(mockCheck).not.toHaveBeenCalled()
+    expect(mockRecord).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when session is missing', async () => {
+    mockIsPrivateInstance.mockReturnValue(true)
+    mockAuth.mockResolvedValue(null)
+    const res = await POST(makeRequest(streamBody('{}')))
+    expect(res.status).toBe(401)
+    expect(mockCheck).not.toHaveBeenCalled()
+    expect(mockRecord).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when user is not admin', async () => {
+    mockIsPrivateInstance.mockReturnValue(true)
+    mockAuth.mockResolvedValue(makeSession({ isAdmin: false }))
+    const res = await POST(makeRequest(streamBody('{}')))
+    expect(res.status).toBe(401)
+    expect(mockCheck).not.toHaveBeenCalled()
+    expect(mockRecord).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when 2FA is still required', async () => {
+    mockIsPrivateInstance.mockReturnValue(true)
+    mockAuth.mockResolvedValue(makeSession({ requiresTwoFactor: true }))
+    const res = await POST(makeRequest(streamBody('{}')))
+    expect(res.status).toBe(401)
+    expect(mockCheck).not.toHaveBeenCalled()
+    expect(mockRecord).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 when password change is required', async () => {
+    mockIsPrivateInstance.mockReturnValue(true)
+    mockAuth.mockResolvedValue(makeSession({ mustChangePassword: true }))
+    const res = await POST(makeRequest(streamBody('{}')))
+    expect(res.status).toBe(403)
+    expect(mockCheck).not.toHaveBeenCalled()
+    expect(mockRecord).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/admin/whitelist — section B (CHECK limited)', () => {
+  it('returns 429 + Retry-After when limiter is exhausted; record is not called', async () => {
+    mockIsPrivateInstance.mockReturnValue(true)
+    mockAuth.mockResolvedValue(makeSession())
+    mockCheck.mockReturnValue({ isLimited: true, retryAfter: 1234 })
+    const res = await POST(makeRequest(streamBody('{}')))
+    expect(res.status).toBe(429)
+    expect(res.headers.get('retry-after')).toBe('1234')
+    expect(mockRecord).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/admin/whitelist — section C (body-size / parse, record once)', () => {
+  it('returns 413 when streamed body exceeds 4 KB', async () => {
+    setupValidSession()
+    const huge = 'x'.repeat(5000)
+    const res = await POST(makeRequest(streamBody(huge)))
+    expect(res.status).toBe(413)
+    expect(mockRecord).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns 400 when the request has no body', async () => {
+    setupValidSession()
+    const res = await POST(makeRequest(null))
+    expect(res.status).toBe(400)
+    expect(mockRecord).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns 400 on malformed JSON', async () => {
+    setupValidSession()
+    const res = await POST(makeRequest(streamBody('{invalid')))
+    expect(res.status).toBe(400)
+    expect(mockRecord).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('POST /api/admin/whitelist — section D (zod, record once)', () => {
+  beforeEach(() => {
+    setupValidSession()
+  })
+
+  it('returns 400 when email is missing', async () => {
+    const res = await POST(makeRequest(streamBody('{}')))
+    expect(res.status).toBe(400)
+    expect(mockRecord).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns 400 when email is not a string', async () => {
+    const res = await POST(makeRequest(streamBody('{"email":42}')))
+    expect(res.status).toBe(400)
+    expect(mockRecord).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns 400 on invalid email format', async () => {
+    const res = await POST(makeRequest(streamBody('{"email":"not-an-email"}')))
+    expect(res.status).toBe(400)
+    expect(mockRecord).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns 400 when email exceeds 254 chars', async () => {
+    const localPart = 'a'.repeat(255 - '@example.com'.length)
+    const longEmail = `${localPart}@example.com`
+    const res = await POST(
+      makeRequest(streamBody(JSON.stringify({ email: longEmail }))),
+    )
+    expect(res.status).toBe(400)
+    expect(mockRecord).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns 400 when name is not a string', async () => {
+    const res = await POST(
+      makeRequest(streamBody('{"email":"a@b.co","name":42}')),
+    )
+    expect(res.status).toBe(400)
+    expect(mockRecord).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns 400 when name exceeds 100 chars', async () => {
+    const body = JSON.stringify({
+      email: 'a@b.co',
+      name: 'x'.repeat(101),
+    })
+    const res = await POST(makeRequest(streamBody(body)))
+    expect(res.status).toBe(400)
+    expect(mockRecord).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('POST /api/admin/whitelist — section E (name backward compat → null)', () => {
+  beforeEach(() => {
+    setupValidSession()
+    mockWhitelistFindUnique.mockResolvedValue(null)
+    mockAdminFindUnique.mockResolvedValue(null)
+    mockBcryptHash.mockResolvedValue('hashed' as never)
+    mockWhitelistCreate.mockImplementation(
+      async ({ data }) =>
+        ({
+          id: 'u1',
+          email: data.email,
+          name: data.name ?? null,
+          createdAt: new Date('2026-05-20T00:00:00Z'),
+        }) as never,
+    )
+  })
+
+  it('normalizes omitted name to null', async () => {
+    const res = await POST(makeRequest(streamBody('{"email":"a@b.co"}')))
+    expect(res.status).toBe(200)
+    expect(mockWhitelistCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ name: null }),
+      }),
+    )
+  })
+
+  it('normalizes empty-string name to null', async () => {
+    const res = await POST(
+      makeRequest(streamBody('{"email":"a@b.co","name":""}')),
+    )
+    expect(res.status).toBe(200)
+    expect(mockWhitelistCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ name: null }),
+      }),
+    )
+  })
+
+  it('normalizes null name to null', async () => {
+    const res = await POST(
+      makeRequest(streamBody('{"email":"a@b.co","name":null}')),
+    )
+    expect(res.status).toBe(200)
+    expect(mockWhitelistCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ name: null }),
+      }),
+    )
+  })
+})
+
+describe('POST /api/admin/whitelist — section F (business duplicates, record once)', () => {
+  beforeEach(() => {
+    setupValidSession()
+  })
+
+  it('returns 400 when the email is already a whitelist user', async () => {
+    mockWhitelistFindUnique.mockResolvedValue({
+      id: 'existing',
+      email: 'a@b.co',
+    } as never)
+    const res = await POST(makeRequest(streamBody('{"email":"a@b.co"}')))
+    expect(res.status).toBe(400)
+    expect(mockRecord).toHaveBeenCalledTimes(1)
+    expect(mockWhitelistCreate).not.toHaveBeenCalled()
+  })
+
+  it('returns 400 when the email is already an admin', async () => {
+    mockWhitelistFindUnique.mockResolvedValue(null)
+    mockAdminFindUnique.mockResolvedValue({
+      id: 'admin-1',
+      email: 'a@b.co',
+    } as never)
+    const res = await POST(makeRequest(streamBody('{"email":"a@b.co"}')))
+    expect(res.status).toBe(400)
+    expect(mockRecord).toHaveBeenCalledTimes(1)
+    expect(mockWhitelistCreate).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/admin/whitelist — section G (success + 500, finally semantics)', () => {
+  beforeEach(() => {
+    setupValidSession()
+  })
+
+  it('returns 200 + initialPassword and persists name on success', async () => {
+    mockWhitelistFindUnique.mockResolvedValue(null)
+    mockAdminFindUnique.mockResolvedValue(null)
+    mockBcryptHash.mockResolvedValue('hashed' as never)
+    mockWhitelistCreate.mockResolvedValue({
+      id: 'u1',
+      email: 'a@b.co',
+      name: 'Alice',
+      createdAt: new Date('2026-05-20T00:00:00Z'),
+    } as never)
+
+    const res = await POST(
+      makeRequest(streamBody('{"email":"a@b.co","name":"Alice"}')),
+    )
+    expect(res.status).toBe(200)
+    const json = (await res.json()) as {
+      user: { email: string; name: string | null }
+      initialPassword: string
+    }
+    expect(json.user.email).toBe('a@b.co')
+    expect(json.user.name).toBe('Alice')
+    expect(typeof json.initialPassword).toBe('string')
+    expect(json.initialPassword.length).toBeGreaterThan(0)
+    expect(mockRecord).toHaveBeenCalledTimes(1)
+  })
+
+  it('records an attempt even when bcrypt.hash throws (outer-catch 500)', async () => {
+    mockWhitelistFindUnique.mockResolvedValue(null)
+    mockAdminFindUnique.mockResolvedValue(null)
+    mockBcryptHash.mockRejectedValue(new Error('boom') as never)
+
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => {})
+
+    const res = await POST(
+      makeRequest(streamBody('{"email":"a@b.co","name":"Alice"}')),
+    )
+    expect(res.status).toBe(500)
+    expect(mockRecord).toHaveBeenCalledTimes(1)
+
+    consoleErrorSpy.mockRestore()
+  })
+})
+
+describe('POST /api/admin/whitelist — section H (rate-limit key separation)', () => {
+  beforeEach(() => {
+    setupValidSession()
+    mockWhitelistFindUnique.mockResolvedValue(null)
+    mockAdminFindUnique.mockResolvedValue(null)
+    mockBcryptHash.mockResolvedValue('hashed' as never)
+    mockWhitelistCreate.mockImplementation(
+      async ({ data }) =>
+        ({
+          id: 'u1',
+          email: data.email,
+          name: data.name ?? null,
+          createdAt: new Date('2026-05-20T00:00:00Z'),
+        }) as never,
+    )
+  })
+
+  it('keys check/record by session.user.id (not by body email/name) and separates per admin', async () => {
+    mockAuth.mockResolvedValue(makeSession({ id: 'admin-A' }))
+    await POST(makeRequest(streamBody('{"email":"victim1@e.x","name":"X"}')))
+    await POST(makeRequest(streamBody('{"email":"victim2@e.x","name":"Y"}')))
+
+    mockAuth.mockResolvedValue(makeSession({ id: 'admin-B' }))
+    await POST(makeRequest(streamBody('{"email":"victim3@e.x","name":"Z"}')))
+
+    const recordKeys = mockRecord.mock.calls.map((call) => call[0])
+    expect(recordKeys).toEqual([
+      'admin-whitelist:admin-A',
+      'admin-whitelist:admin-A',
+      'admin-whitelist:admin-B',
+    ])
+    const checkKeys = mockCheck.mock.calls.map((call) => call[0])
+    expect(checkKeys).toEqual([
+      'admin-whitelist:admin-A',
+      'admin-whitelist:admin-A',
+      'admin-whitelist:admin-B',
+    ])
+    for (const call of mockRecord.mock.calls) {
+      expect(call[1]).toBe(60)
+      expect(call[2]).toBe(60 * 60 * 1000)
+    }
+  })
+})

--- a/src/__tests__/admin-whitelist-validation.test.ts
+++ b/src/__tests__/admin-whitelist-validation.test.ts
@@ -340,7 +340,7 @@ describe('POST /api/admin/whitelist — section F (business duplicates, record o
   })
 })
 
-describe('POST /api/admin/whitelist — section G (success + 500, finally semantics)', () => {
+describe('POST /api/admin/whitelist — section G (success + 500, reserved-slot semantics)', () => {
   beforeEach(() => {
     setupValidSession()
   })

--- a/src/app/api/admin/whitelist/route.ts
+++ b/src/app/api/admin/whitelist/route.ts
@@ -1,5 +1,20 @@
 /**
  * Whitelist User Management API (Issue #4)
+ *
+ * POST hardening (Issue #176):
+ *   - streaming body-size cap (4 KB) before JSON.parse, defending against
+ *     `Content-Length` omission / under-declaration
+ *   - zod schema for `email` (RFC 5321 max 254, format) and `name`
+ *     (max 100, nullish for backward compatibility with `name || null`)
+ *   - per-admin operation rate limit (60/h) keyed by the JWT subject
+ *     (`session.user.id`), via the existing in-memory limiter from
+ *     Issue #78. Memory-only / best-effort in multi-instance deployments.
+ *
+ * Rate-limit policy: pre-auth gates (private-instance, session/admin,
+ * 2FA, password-change) and the CHECK itself never touch the limiter.
+ * Once CHECK passes, every subsequent outcome — body-size 413, parse
+ * 400, zod 400, duplicate 400, success 200, internal 500 — records one
+ * attempt via the `finally` block.
  */
 
 import { auth, isPrivateInstance } from '@/lib/auth'
@@ -8,9 +23,14 @@ import {
   requiresTwoFactorResponse,
 } from '@/lib/auth-helpers'
 import { prisma } from '@/lib/prisma'
+import {
+  checkOperationRateLimit,
+  recordOperationAttempt,
+} from '@/lib/rate-limit'
 import bcrypt from 'bcryptjs'
 import { randomBytes } from 'crypto'
 import { NextResponse } from 'next/server'
+import { z } from 'zod'
 
 /**
  * Generate a random initial password with sufficient entropy (Issue #48)
@@ -20,49 +40,155 @@ function generateInitialPassword(): string {
   return randomBytes(16).toString('base64url').slice(0, 20)
 }
 
-export async function POST(request: Request) {
+const MAX_BODY_BYTES = 4 * 1024 // 4 KB
+
+/**
+ * Streaming body reader with a hard byte-length cap.
+ *
+ * Reads `request.body` chunk by chunk and accumulates the total byte
+ * length. When the accumulated size exceeds `maxBytes`, the reader is
+ * cancelled mid-stream and `null` is returned — the caller must treat
+ * this as 413. This is stricter than checking `Content-Length` because
+ * clients may omit it (chunked transfer) or under-declare it.
+ *
+ * Returns `''` for a missing body. Throws (e.g. from `reader.read()`)
+ * propagate to the caller's `try` so the outer `finally` still records
+ * the rate-limit attempt (gate already passed).
+ */
+async function readRequestBodyWithLimit(
+  request: Request,
+  maxBytes: number,
+): Promise<string | null> {
+  const reader = request.body?.getReader()
+  if (!reader) return ''
+
+  const chunks: Uint8Array[] = []
+  let total = 0
+
   try {
-    // Check if private instance mode is enabled
-    if (!isPrivateInstance()) {
-      return NextResponse.json(
-        { error: 'Private instance mode is not enabled' },
-        { status: 400 },
-      )
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      total += value.byteLength
+      if (total > maxBytes) {
+        await reader.cancel()
+        return null
+      }
+      chunks.push(value)
+    }
+  } finally {
+    // `releaseLock()` throws if the reader has already been cancelled in
+    // some runtimes; swallow so the original control flow is preserved.
+    try {
+      reader.releaseLock()
+    } catch {
+      // ignore
+    }
+  }
+
+  if (chunks.length === 0) return ''
+  if (chunks.length === 1) return new TextDecoder().decode(chunks[0])
+
+  const combined = new Uint8Array(total)
+  let offset = 0
+  for (const chunk of chunks) {
+    combined.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return new TextDecoder().decode(combined)
+}
+
+/**
+ * Rate-limit key prefix for whitelist user creation. The full key is
+ * `${RATE_LIMIT_PREFIX}${session.user.id}` — keyed by the authenticated
+ * admin subject, not by request body fields, so it cannot be evaded by
+ * varying the input email/name.
+ */
+const RATE_LIMIT_PREFIX = 'admin-whitelist:'
+const RATE_LIMIT_MAX = 60
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000 // 1 hour
+
+const whitelistCreateSchema = z.object({
+  email: z.string().email().max(254),
+  name: z.string().max(100).nullish(),
+})
+
+export async function POST(request: Request) {
+  // 1. Private-instance gate.
+  if (!isPrivateInstance()) {
+    return NextResponse.json(
+      { error: 'Private instance mode is not enabled' },
+      { status: 400 },
+    )
+  }
+
+  // 2. Session + admin gate.
+  const session = await auth()
+  if (!session?.user?.isAdmin || !session.user.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // 3. 2FA gate (mirrors tRPC publicProcedure / adminProcedure ordering).
+  const twoFaResp = requiresTwoFactorResponse(session)
+  if (twoFaResp) return twoFaResp
+
+  // 4. Password-change gate.
+  const pwChangeResp = passwordChangeRequiredResponse(session)
+  if (pwChangeResp) return pwChangeResp
+
+  // 5. Rate-limit CHECK keyed by the admin subject.
+  //    Gates 1-4 intentionally do not touch the limiter. After this
+  //    point every outcome counts as one attempt via the finally below.
+  const rateLimitKey = `${RATE_LIMIT_PREFIX}${session.user.id}`
+  const limit = checkOperationRateLimit(
+    rateLimitKey,
+    RATE_LIMIT_MAX,
+    RATE_LIMIT_WINDOW_MS,
+  )
+  if (limit.isLimited) {
+    return NextResponse.json(
+      { error: 'Too many requests', retryAfter: limit.retryAfter },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(
+            limit.retryAfter || RATE_LIMIT_WINDOW_MS / 1000,
+          ),
+        },
+      },
+    )
+  }
+
+  try {
+    // 6. Streaming body-size cap.
+    const rawBody = await readRequestBodyWithLimit(request, MAX_BODY_BYTES)
+    if (rawBody === null) {
+      return NextResponse.json({ error: 'Payload too large' }, { status: 413 })
     }
 
-    // Check authentication
-    const session = await auth()
-    if (!session?.user?.isAdmin) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    // 7. JSON parse (dedicated try so malformed bodies do not hit the
+    //    outer-catch 500 path).
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(rawBody)
+    } catch {
+      return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
     }
 
-    const twoFaResp = requiresTwoFactorResponse(session)
-    if (twoFaResp) return twoFaResp
-
-    const pwChangeResp = passwordChangeRequiredResponse(session)
-    if (pwChangeResp) return pwChangeResp
-
-    const body = (await request.json()) as { email?: string; name?: string }
-    const { email, name } = body
-
-    if (!email) {
-      return NextResponse.json({ error: 'Email is required' }, { status: 400 })
+    // 8. zod schema (typeof string + email format + field-length caps).
+    const result = whitelistCreateSchema.safeParse(parsed)
+    if (!result.success) {
+      return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
     }
+    const { email } = result.data
+    // Preserve historical `name || null` behavior — '', null, and
+    // undefined all normalize to null.
+    const name = result.data.name || null
 
-    // Validate email format
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-    if (!emailRegex.test(email)) {
-      return NextResponse.json(
-        { error: 'Invalid email format' },
-        { status: 400 },
-      )
-    }
-
-    // Check if user already exists
+    // 9. Duplicate checks.
     const existingUser = await prisma.whitelistUser.findUnique({
       where: { email },
     })
-
     if (existingUser) {
       return NextResponse.json(
         { error: 'User already in whitelist' },
@@ -70,11 +196,9 @@ export async function POST(request: Request) {
       )
     }
 
-    // Check if email is an admin
     const existingAdmin = await prisma.admin.findUnique({
       where: { email },
     })
-
     if (existingAdmin) {
       return NextResponse.json(
         { error: 'User is already an admin' },
@@ -82,22 +206,20 @@ export async function POST(request: Request) {
       )
     }
 
-    // Generate initial password
+    // 10. Create whitelist user with initial password.
     const initialPassword = generateInitialPassword()
     const hashedPassword = await bcrypt.hash(initialPassword, 12)
 
-    // Create whitelist user with initial password
     const user = await prisma.whitelistUser.create({
       data: {
         email,
         password: hashedPassword,
-        name: name || null,
+        name,
         mustChangePassword: true,
         addedById: session.user.id,
       },
     })
 
-    // Return user with initial password (only shown once!)
     return NextResponse.json({
       user: {
         id: user.id,
@@ -105,7 +227,7 @@ export async function POST(request: Request) {
         name: user.name,
         createdAt: user.createdAt,
       },
-      initialPassword, // This should be shown to admin to share with user
+      initialPassword,
     })
   } catch (error) {
     console.error('Error adding whitelist user:', error)
@@ -113,6 +235,8 @@ export async function POST(request: Request) {
       { error: 'Internal server error' },
       { status: 500 },
     )
+  } finally {
+    recordOperationAttempt(rateLimitKey, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS)
   }
 }
 

--- a/src/app/api/admin/whitelist/route.ts
+++ b/src/app/api/admin/whitelist/route.ts
@@ -55,8 +55,9 @@ const MAX_BODY_BYTES = 4 * 1024 // 4 KB
  * clients may omit it (chunked transfer) or under-declare it.
  *
  * Returns `''` for a missing body. Throws (e.g. from `reader.read()`)
- * propagate to the caller's `try` so the outer `finally` still records
- * the rate-limit attempt (gate already passed).
+ * propagate to the caller's `try`; the limiter slot has already been
+ * reserved synchronously before body reading begins, so an outer-catch
+ * 500 still consumes the attempt.
  */
 async function readRequestBodyWithLimit(
   request: Request,

--- a/src/app/api/admin/whitelist/route.ts
+++ b/src/app/api/admin/whitelist/route.ts
@@ -11,10 +11,13 @@
  *     Issue #78. Memory-only / best-effort in multi-instance deployments.
  *
  * Rate-limit policy: pre-auth gates (private-instance, session/admin,
- * 2FA, password-change) and the CHECK itself never touch the limiter.
- * Once CHECK passes, every subsequent outcome — body-size 413, parse
- * 400, zod 400, duplicate 400, success 200, internal 500 — records one
- * attempt via the `finally` block.
+ * 2FA, password-change) and the CHECK itself never touch the limiter,
+ * so a third party cannot be locked out by failed requests. Once CHECK
+ * passes the slot is reserved synchronously — before any await — so a
+ * concurrent burst cannot all observe `count<MAX` and bypass the 60/h
+ * cap. Every subsequent outcome (body-size 413, parse 400, zod 400,
+ * duplicate 400, success 200, internal 500) has therefore already
+ * consumed one attempt.
  */
 
 import { auth, isPrivateInstance } from '@/lib/auth'
@@ -136,9 +139,9 @@ export async function POST(request: Request) {
   const pwChangeResp = passwordChangeRequiredResponse(session)
   if (pwChangeResp) return pwChangeResp
 
-  // 5. Rate-limit CHECK keyed by the admin subject.
-  //    Gates 1-4 intentionally do not touch the limiter. After this
-  //    point every outcome counts as one attempt via the finally below.
+  // 5. Rate-limit CHECK keyed by the admin subject. Gates 1-4 do not
+  //    touch the limiter so a third party cannot be locked out via
+  //    failed requests.
   const rateLimitKey = `${RATE_LIMIT_PREFIX}${session.user.id}`
   const limit = checkOperationRateLimit(
     rateLimitKey,
@@ -158,6 +161,15 @@ export async function POST(request: Request) {
       },
     )
   }
+
+  // Reserve the limiter slot synchronously, before any await. Both
+  // `checkOperationRateLimit` and `recordOperationAttempt` are
+  // synchronous Map operations, so request N's record completes in
+  // the same event-loop tick as its check. Request N+1's check
+  // therefore always observes the incremented count — a concurrent
+  // burst of admin POSTs cannot all pass CHECK at low counts and
+  // bypass the 60/h cap (Codex review iter 1 on PR #231).
+  recordOperationAttempt(rateLimitKey, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS)
 
   try {
     // 6. Streaming body-size cap.
@@ -235,8 +247,6 @@ export async function POST(request: Request) {
       { error: 'Internal server error' },
       { status: 500 },
     )
-  } finally {
-    recordOperationAttempt(rateLimitKey, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS)
   }
 }
 

--- a/src/lib/rate-limit.test.ts
+++ b/src/lib/rate-limit.test.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  checkOperationRateLimit,
   checkRateLimit,
   checkRateLimitAsync,
   clearAttempts,
@@ -14,6 +15,7 @@ import {
   getStorageType,
   recordFailedAttempt,
   recordFailedAttemptAsync,
+  recordOperationAttempt,
 } from './rate-limit'
 
 describe('rate-limit', () => {
@@ -154,5 +156,78 @@ describe('rate-limit', () => {
     it('should export storage type function', () => {
       expect(typeof getStorageType).toBe('function')
     })
+  })
+})
+
+describe('operation limiter (Issue #78)', () => {
+  // operationAttempts is private module state with no clear() API, so
+  // each test must use a unique key to avoid cross-test pollution.
+  function keyFor(...parts: string[]): string {
+    const name = expect.getState().currentTestName ?? 'unknown'
+    return ['op-limiter-test', name, ...parts].join('::')
+  }
+
+  const WINDOW = 60 * 60 * 1000
+  const MAX = 60
+
+  beforeEach(() => {
+    jest.spyOn(Date, 'now').mockReturnValue(1700000000000)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('returns not limited with full remaining for a fresh key', () => {
+    const key = keyFor('fresh')
+    const result = checkOperationRateLimit(key, MAX, WINDOW)
+    expect(result.isLimited).toBe(false)
+    expect(result.remainingAttempts).toBe(MAX)
+  })
+
+  it('returns not limited remaining 1 after 59 records', () => {
+    const key = keyFor('59-records')
+    for (let i = 0; i < 59; i++) {
+      recordOperationAttempt(key, MAX, WINDOW)
+    }
+    const result = checkOperationRateLimit(key, MAX, WINDOW)
+    expect(result.isLimited).toBe(false)
+    expect(result.remainingAttempts).toBe(1)
+  })
+
+  it('returns limited with retryAfter > 0 once count reaches maxAttempts', () => {
+    const key = keyFor('60-records')
+    for (let i = 0; i < MAX; i++) {
+      recordOperationAttempt(key, MAX, WINDOW)
+    }
+    const result = checkOperationRateLimit(key, MAX, WINDOW)
+    expect(result.isLimited).toBe(true)
+    expect(result.retryAfter).toBeGreaterThan(0)
+  })
+
+  it('keeps counters independent across keys', () => {
+    const keyA = keyFor('independent', 'A')
+    const keyB = keyFor('independent', 'B')
+    for (let i = 0; i < MAX; i++) {
+      recordOperationAttempt(keyA, MAX, WINDOW)
+    }
+    expect(checkOperationRateLimit(keyA, MAX, WINDOW).isLimited).toBe(true)
+    const resultB = checkOperationRateLimit(keyB, MAX, WINDOW)
+    expect(resultB.isLimited).toBe(false)
+    expect(resultB.remainingAttempts).toBe(MAX)
+  })
+
+  it('resets the window after windowMs elapses', () => {
+    const key = keyFor('reset')
+    const t0 = 1700000000000
+    ;(Date.now as jest.Mock).mockReturnValue(t0)
+    for (let i = 0; i < MAX; i++) {
+      recordOperationAttempt(key, MAX, WINDOW)
+    }
+    expect(checkOperationRateLimit(key, MAX, WINDOW).isLimited).toBe(true)
+    ;(Date.now as jest.Mock).mockReturnValue(t0 + WINDOW + 1)
+    const result = checkOperationRateLimit(key, MAX, WINDOW)
+    expect(result.isLimited).toBe(false)
+    expect(result.remainingAttempts).toBe(MAX)
   })
 })


### PR DESCRIPTION
## Scope

Hardens `POST /api/admin/whitelist` (Issue #176). Other endpoints in this directory tree are explicitly out of scope (see "Scope-out" below).

## Changes

- **zod schema** (`whitelistCreateSchema`): `email` is `z.string().email().max(254)`, `name` is `z.string().max(100).nullish()`. Replaces the ad-hoc regex and missing `typeof` / length checks. `name` typing matches the historical `name || null` behavior so `''`, `null`, and `undefined` all still persist as `null`.
- **Streaming body-size cap (4 KB)**: new inline `readRequestBodyWithLimit(request, maxBytes)` reads `request.body` chunk by chunk and cancels the reader once the accumulated byte length exceeds the cap. Stricter than a `Content-Length` pre-check because clients may omit the header (chunked transfer) or under-declare it. Read throws are propagated to the outer `try`; the rate-limit slot was already reserved at that point so the failure is still counted.
- **Per-admin rate limit (60 / hour)** keyed by `session.user.id` via the existing in-memory `checkOperationRateLimit` from Issue #78. Memory-only / best-effort in multi-instance deployments — a database-backed mirror for operation limiters would be a separate issue.
- **JSON parse 400** in a dedicated `try`, so malformed bodies no longer fall through to the outer-catch 500.

## Rate-limit semantics

| step | failure status | records attempt |
| --- | --- | --- |
| 1. private-instance gate | 400 | no |
| 2. session / admin gate | 401 | no |
| 3. 2FA gate | 401 | no |
| 4. password-change gate | 403 | no |
| 5. CHECK | 429 | no |
| 6. slot reservation (synchronous, before any await) | — | yes |
| 7. body-size cap | 413 | already reserved |
| 8. JSON.parse | 400 | already reserved |
| 9. zod | 400 | already reserved |
| 10. duplicate (whitelist / admin) | 400 | already reserved |
| 11. bcrypt + prisma.create | 200 | already reserved |
| outer catch | 500 | already reserved |

Pre-auth gates and CHECK never touch the limiter, so a third party cannot be locked out by failed requests. **Immediately after CHECK passes** (before any `await`), `recordOperationAttempt` is invoked to reserve the slot synchronously. Both `checkOperationRateLimit` and `recordOperationAttempt` are synchronous Map operations, so request N's record completes in the same event-loop tick as its check — request N+1's check always observes the incremented count. This is what prevents a concurrent burst of admin POSTs from all passing CHECK at low counts before any of them awaited (Codex review iter 1 fix; v1 used a `finally` block which was vulnerable to that race).

With `count >= maxAttempts` semantics, the 60th request from a given admin passes at `count=59` then records, and the 61st sees `count=60` and is rejected with `429` + `Retry-After`.

## Scope-out

- `GET /api/admin/whitelist` (no body, validation N/A; existing gates preserved).
- `/api/admin/whitelist/[userId]` `PATCH` (entropy 64-bit is tracked separately as #177) and `DELETE`.
- Distributed rate-limit storage for operation limiters (separate from Issue #167's auth-side storage).
- 404 path-enumeration suppression (behavior change; client compatibility is preserved at 400).

## Test plan

Route test `src/__tests__/admin-whitelist-validation.test.ts` (24 cases, mock strategy; real `@/lib/auth-helpers` to pick up session-shape regressions):

- A. gates do not touch limiter (5)
- B. CHECK returns 429 + `Retry-After`, no record (1)
- C. body-size / parse — 4 KB streaming 413 / null body 400 / malformed JSON 400 (3)
- D. zod — email missing / typeof / format / >254 / name typeof / >100 (6)
- E. name backward compat — omitted / `''` / `null` → DB `null` (3)
- F. business duplicates — whitelist / admin (2)
- G. success + outer-catch 500 (both reserve the slot) (2)
- H. record key derives from `session.user.id` (not body fields), separates per admin, and is reserved synchronously after CHECK (2)

The H "synchronous reservation" case uses jest's monotonic `invocationCallOrder` counter to assert that `recordOperationAttempt` is the very next mock invocation after `checkOperationRateLimit`, with no awaited dependency between them. (Node 20 buffers ReadableStream request bodies during `new Request(...)`, so a `pull()`-based ordering probe would fire before the route ran.)

Operation-limiter unit test in `src/lib/rate-limit.test.ts` (5 cases): 0 record / 59 record / 60 record (limited) / key separation / windowMs reset. Uses unique keys per test (`expect.getState().currentTestName`) because `operationAttempts` is private module state with no clear API; `Date.now` is spied per test and restored in `afterEach`.

Boundary and key-separation correctness are verified by the colocated unit test. The route test verifies the invocation contract and the slot-reservation ordering.

## Validation

podman + `node:20-alpine` + `pnpm@9.15.9`:

- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm prisma generate`
- `pnpm check-formatting` ✓
- `pnpm lint` — 11 warnings / 0 errors, no new warnings
- `pnpm exec tsc --noEmit` ✓
- `pnpm test` — 35 suites, 499 passed, 1 skipped (29 new cases)
- `pnpm build` ✓

Live caller / runtime references to the old ad-hoc regex are gone. An unrelated `emailRegex` constant remains in `src/__tests__/private-instance.test.ts` as a standalone format-test that does not exercise the route, and is intentionally untouched.

Closes #176.