### PR TITLE
fix(security): unify admin whitelist password reset to 120-bit shared helper

### DIFF
--- a/src/__tests__/admin-whitelist-reset.test.ts
+++ b/src/__tests__/admin-whitelist-reset.test.ts
@@ -1,0 +1,207 @@
+/**
+ * @jest-environment node
+ *
+ * Route tests for /api/admin/whitelist/[userId] PATCH (Issue #177).
+ *
+ * Strategy: mock @/lib/auth (`auth`, `isPrivateInstance`,
+ * `generateInitialPassword`), @/lib/prisma, and bcryptjs; use the real
+ * @/lib/auth-helpers module so session-shape regressions in the 2FA /
+ * password-change gates are picked up. The entropy of the shared
+ * `generateInitialPassword` helper itself is covered by
+ * src/__tests__/private-instance.test.ts — these tests only verify the
+ * PATCH route's invocation contract.
+ */
+
+jest.mock('@/lib/auth', () => ({
+  __esModule: true,
+  auth: jest.fn(),
+  isPrivateInstance: jest.fn(),
+  generateInitialPassword: jest.fn(() => 'A'.repeat(20)),
+}))
+
+jest.mock('@/lib/prisma', () => ({
+  __esModule: true,
+  prisma: {
+    whitelistUser: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('bcryptjs', () => ({
+  __esModule: true,
+  default: {
+    hash: jest.fn(),
+  },
+}))
+
+import { PATCH } from '@/app/api/admin/whitelist/[userId]/route'
+import { auth, generateInitialPassword, isPrivateInstance } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import bcrypt from 'bcryptjs'
+
+// MockedFunction<typeof X> chokes on NextAuth's overloaded `auth` and on
+// PrismaPromise return types, so each mock is cast to the wide jest.Mock
+// signature (mirrors src/__tests__/admin-whitelist-validation.test.ts).
+const mockAuth = auth as unknown as jest.Mock
+const mockIsPrivateInstance = isPrivateInstance as unknown as jest.Mock
+const mockGenerateInitialPassword =
+  generateInitialPassword as unknown as jest.Mock
+const mockBcryptHash = bcrypt.hash as unknown as jest.Mock
+const mockWhitelistFindUnique = prisma.whitelistUser
+  .findUnique as unknown as jest.Mock
+const mockWhitelistUpdate = prisma.whitelistUser.update as unknown as jest.Mock
+
+type SessionUser = {
+  id: string
+  email: string
+  name: string
+  isAdmin: boolean
+  mustChangePassword: boolean
+  twoFactorEnabled: boolean
+  requiresTwoFactor: boolean
+}
+
+const DEFAULT_USER: SessionUser = {
+  id: 'admin-id-1',
+  email: 'admin@example.com',
+  name: 'Admin',
+  isAdmin: true,
+  mustChangePassword: false,
+  twoFactorEnabled: false,
+  requiresTwoFactor: false,
+}
+
+function makeSession(
+  overrides: Partial<SessionUser> = {},
+): Awaited<ReturnType<typeof auth>> {
+  return {
+    user: { ...DEFAULT_USER, ...overrides },
+    expires: new Date(Date.now() + 60 * 1000).toISOString(),
+  } as unknown as Awaited<ReturnType<typeof auth>>
+}
+
+const TARGET_USER_ID = 'cwhitelist-user-test-id'
+
+function makeRequest(): Request {
+  return new Request(`http://localhost/api/admin/whitelist/${TARGET_USER_ID}`, {
+    method: 'PATCH',
+  })
+}
+
+function makeContext() {
+  return { params: Promise.resolve({ userId: TARGET_USER_ID }) }
+}
+
+function setupValidSession(overrides: Partial<SessionUser> = {}) {
+  mockIsPrivateInstance.mockReturnValue(true)
+  mockAuth.mockResolvedValue(makeSession(overrides))
+  // `jest.resetAllMocks()` in beforeEach wipes the mock's initial impl,
+  // so re-establish the fixed return value per test for stability.
+  mockGenerateInitialPassword.mockReturnValue('A'.repeat(20))
+}
+
+beforeEach(() => {
+  jest.resetAllMocks()
+})
+
+describe('PATCH /api/admin/whitelist/[userId] — gates do not touch helper or DB', () => {
+  it('returns 400 when private instance is disabled', async () => {
+    mockIsPrivateInstance.mockReturnValue(false)
+    const res = await PATCH(makeRequest(), makeContext())
+    expect(res.status).toBe(400)
+    expect(mockGenerateInitialPassword).not.toHaveBeenCalled()
+    expect(mockBcryptHash).not.toHaveBeenCalled()
+    expect(mockWhitelistFindUnique).not.toHaveBeenCalled()
+    expect(mockWhitelistUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when session is missing', async () => {
+    mockIsPrivateInstance.mockReturnValue(true)
+    mockAuth.mockResolvedValue(null)
+    const res = await PATCH(makeRequest(), makeContext())
+    expect(res.status).toBe(401)
+    expect(mockGenerateInitialPassword).not.toHaveBeenCalled()
+    expect(mockWhitelistUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 when user is not admin', async () => {
+    mockIsPrivateInstance.mockReturnValue(true)
+    mockAuth.mockResolvedValue(makeSession({ isAdmin: false }))
+    const res = await PATCH(makeRequest(), makeContext())
+    expect(res.status).toBe(401)
+    expect(mockGenerateInitialPassword).not.toHaveBeenCalled()
+    expect(mockWhitelistUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns 401 with the real auth-helpers body when 2FA is required', async () => {
+    mockIsPrivateInstance.mockReturnValue(true)
+    mockAuth.mockResolvedValue(makeSession({ requiresTwoFactor: true }))
+    const res = await PATCH(makeRequest(), makeContext())
+    expect(res.status).toBe(401)
+    // Real `requiresTwoFactorResponse` body shape pin — auth-helpers is
+    // not mocked, so this catches any drift in the gate's contract.
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toBe('Two-factor authentication required')
+    expect(mockGenerateInitialPassword).not.toHaveBeenCalled()
+    expect(mockWhitelistUpdate).not.toHaveBeenCalled()
+  })
+
+  it('returns 403 with the real auth-helpers body when password change is required', async () => {
+    mockIsPrivateInstance.mockReturnValue(true)
+    mockAuth.mockResolvedValue(makeSession({ mustChangePassword: true }))
+    const res = await PATCH(makeRequest(), makeContext())
+    expect(res.status).toBe(403)
+    const body = (await res.json()) as { error: string }
+    expect(body.error).toBe('Password change required')
+    expect(mockGenerateInitialPassword).not.toHaveBeenCalled()
+    expect(mockWhitelistUpdate).not.toHaveBeenCalled()
+  })
+})
+
+describe('PATCH /api/admin/whitelist/[userId] — user lookup', () => {
+  it('returns 404 when the whitelist user does not exist', async () => {
+    setupValidSession()
+    mockWhitelistFindUnique.mockResolvedValue(null)
+    const res = await PATCH(makeRequest(), makeContext())
+    expect(res.status).toBe(404)
+    expect(mockGenerateInitialPassword).not.toHaveBeenCalled()
+    expect(mockWhitelistUpdate).not.toHaveBeenCalled()
+  })
+})
+
+describe('PATCH /api/admin/whitelist/[userId] — success contract', () => {
+  it('uses the shared helper, hashes its output, and persists mustChangePassword=true', async () => {
+    setupValidSession()
+    const HASHED_PWD = 'bcrypt-hash-output-fixed'
+    mockWhitelistFindUnique.mockResolvedValue({
+      id: TARGET_USER_ID,
+      email: 'u@example.com',
+    } as never)
+    mockBcryptHash.mockResolvedValue(HASHED_PWD as never)
+    mockWhitelistUpdate.mockResolvedValue({ id: TARGET_USER_ID } as never)
+
+    const res = await PATCH(makeRequest(), makeContext())
+    expect(res.status).toBe(200)
+
+    const json = (await res.json()) as { initialPassword: string }
+    // 1. The shared helper output flows back to the client unchanged.
+    expect(json.initialPassword).toBe('A'.repeat(20))
+    // 2. The same helper output is what bcrypt.hash sees (cost 12).
+    expect(mockBcryptHash).toHaveBeenCalledWith('A'.repeat(20), 12)
+    // 3 + 4. `where` keys on the route's `userId` param; `data` sets
+    // `password` to the bcrypt output AND `mustChangePassword: true`.
+    // The latter ensures the user is forced through the change-password
+    // flow on next login — a regression here would let a reset user log
+    // in indefinitely without changing the admin-issued password.
+    expect(mockWhitelistUpdate).toHaveBeenCalledWith({
+      where: { id: TARGET_USER_ID },
+      data: {
+        password: HASHED_PWD,
+        mustChangePassword: true,
+      },
+    })
+    expect(mockGenerateInitialPassword).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/__tests__/admin-whitelist-validation.test.ts
+++ b/src/__tests__/admin-whitelist-validation.test.ts
@@ -14,6 +14,7 @@ jest.mock('@/lib/auth', () => ({
   __esModule: true,
   auth: jest.fn(),
   isPrivateInstance: jest.fn(),
+  generateInitialPassword: jest.fn(() => 'A'.repeat(20)),
 }))
 
 jest.mock('@/lib/rate-limit', () => ({
@@ -43,7 +44,7 @@ jest.mock('bcryptjs', () => ({
 }))
 
 import { POST } from '@/app/api/admin/whitelist/route'
-import { auth, isPrivateInstance } from '@/lib/auth'
+import { auth, generateInitialPassword, isPrivateInstance } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
 import {
   checkOperationRateLimit,
@@ -57,6 +58,8 @@ import bcrypt from 'bcryptjs'
 // real call signatures, so the loss of type safety is acceptable.
 const mockAuth = auth as unknown as jest.Mock
 const mockIsPrivateInstance = isPrivateInstance as unknown as jest.Mock
+const mockGenerateInitialPassword =
+  generateInitialPassword as unknown as jest.Mock
 const mockCheck = checkOperationRateLimit as unknown as jest.Mock
 const mockRecord = recordOperationAttempt as unknown as jest.Mock
 const mockBcryptHash = bcrypt.hash as unknown as jest.Mock
@@ -119,6 +122,9 @@ function setupValidSession(overrides: Partial<SessionUser> = {}) {
   mockIsPrivateInstance.mockReturnValue(true)
   mockAuth.mockResolvedValue(makeSession(overrides))
   mockCheck.mockReturnValue({ isLimited: false, remainingAttempts: 60 })
+  // `jest.resetAllMocks()` in beforeEach wipes the mock's initial impl,
+  // so the literal default needs to be re-established per test.
+  mockGenerateInitialPassword.mockReturnValue('A'.repeat(20))
 }
 
 beforeEach(() => {
@@ -366,8 +372,12 @@ describe('POST /api/admin/whitelist — section G (success + 500, reserved-slot 
     }
     expect(json.user.email).toBe('a@b.co')
     expect(json.user.name).toBe('Alice')
-    expect(typeof json.initialPassword).toBe('string')
-    expect(json.initialPassword.length).toBeGreaterThan(0)
+    // Pin the shared `generateInitialPassword` helper (Issue #177): the
+    // mock returns `'A'.repeat(20)` and that exact value must flow into
+    // both the response and bcrypt.hash so a future refactor that drops
+    // the helper import (or bypasses it) is caught here.
+    expect(json.initialPassword).toBe('A'.repeat(20))
+    expect(mockBcryptHash).toHaveBeenCalledWith('A'.repeat(20), 12)
     expect(mockRecord).toHaveBeenCalledTimes(1)
   })
 

--- a/src/__tests__/private-instance.test.ts
+++ b/src/__tests__/private-instance.test.ts
@@ -123,32 +123,112 @@ describe('Private Instance Mode', () => {
     })
   })
 
-  describe('Initial Password Generation', () => {
-    it('should generate passwords with sufficient entropy', () => {
-      const { randomBytes } = require('crypto')
+  describe('Initial Password Generation (Issue #177)', () => {
+    // The shared helper lives in @/lib/auth, whose top-level evaluates
+    // NextAuth(authConfig) + PrismaAdapter(prisma) and reads env. We
+    // mirror the `loadIsPrivateInstance` pattern below: load the module
+    // inside `jest.isolateModulesAsync` with the heavy dependencies
+    // doMocked, then exercise the helper itself. `crypto` is NOT
+    // mocked — the test runs the real `randomBytes()` so entropy /
+    // charset / uniqueness are measured against the production
+    // implementation. The pre-#177 path was `randomBytes(8).toString(
+    // 'base64').slice(0, 12)` (= 64 bits); the new shared helper emits
+    // 20 base64url chars (= 120 bits).
+    async function loadGenerateInitialPassword(): Promise<() => string> {
+      let generateInitialPassword: () => string = () => ''
 
-      const generateInitialPassword = (): string => {
-        return randomBytes(8).toString('base64').slice(0, 12)
-      }
+      await jest.isolateModulesAsync(async () => {
+        jest.doMock('@/lib/env', () => ({
+          __esModule: true,
+          env: {
+            PRIVATE_INSTANCE: false,
+            ADMIN_EMAIL: undefined,
+            ADMIN_PASSWORD: undefined,
+          },
+        }))
+        jest.doMock('@/lib/prisma', () => ({
+          __esModule: true,
+          prisma: { admin: { findUnique: jest.fn(), create: jest.fn() } },
+        }))
+        jest.doMock('@/lib/rate-limit', () => ({
+          __esModule: true,
+          checkRateLimitAsync: jest.fn(),
+          clearAttemptsAsync: jest.fn(),
+          recordFailedAttemptAsync: jest.fn(),
+        }))
+        jest.doMock('@/lib/auth-jwt', () => ({
+          __esModule: true,
+          jwtCallback: jest.fn(),
+        }))
+        jest.doMock('next-auth', () => ({
+          __esModule: true,
+          default: () => ({
+            handlers: {},
+            signIn: jest.fn(),
+            signOut: jest.fn(),
+            auth: jest.fn(),
+          }),
+        }))
+        jest.doMock('next-auth/providers/credentials', () => ({
+          __esModule: true,
+          default: (config: unknown) => config,
+        }))
+        jest.doMock('@auth/prisma-adapter', () => ({
+          __esModule: true,
+          PrismaAdapter: jest.fn(() => ({})),
+        }))
+        jest.doMock('bcryptjs', () => ({
+          __esModule: true,
+          default: {
+            hash: jest.fn(),
+            hashSync: jest.fn(() => 'hashed-sync-dummy'),
+            compare: jest.fn(),
+          },
+        }))
 
+        const mod = (await import('@/lib/auth')) as {
+          generateInitialPassword: () => string
+        }
+        generateInitialPassword = mod.generateInitialPassword
+      })
+
+      return generateInitialPassword
+    }
+
+    afterEach(() => {
+      jest.resetModules()
+      jest.clearAllMocks()
+      jest.dontMock('@/lib/env')
+      jest.dontMock('@/lib/prisma')
+      jest.dontMock('@/lib/rate-limit')
+      jest.dontMock('@/lib/auth-jwt')
+      jest.dontMock('next-auth')
+      jest.dontMock('next-auth/providers/credentials')
+      jest.dontMock('@auth/prisma-adapter')
+      jest.dontMock('bcryptjs')
+    })
+
+    it('produces a 20-character password', async () => {
+      const generateInitialPassword = await loadGenerateInitialPassword()
+      const password = generateInitialPassword()
+      expect(password.length).toBe(20)
+    })
+
+    it('uses the base64url alphabet only (A-Z, a-z, 0-9, -, _)', async () => {
+      const generateInitialPassword = await loadGenerateInitialPassword()
+      const password = generateInitialPassword()
+      // base64url omits the URL-unsafe `+`, `/`, `=` of standard base64,
+      // so the password is safe to embed in chat / URL channels.
+      expect(password).toMatch(/^[A-Za-z0-9_-]{20}$/)
+    })
+
+    it('generates unique passwords over 100 samples (sufficient entropy)', async () => {
+      const generateInitialPassword = await loadGenerateInitialPassword()
       const passwords = new Set<string>()
       for (let i = 0; i < 100; i++) {
         passwords.add(generateInitialPassword())
       }
-
-      // All 100 passwords should be unique
       expect(passwords.size).toBe(100)
-    })
-
-    it('should generate passwords of correct length', () => {
-      const { randomBytes } = require('crypto')
-
-      const generateInitialPassword = (): string => {
-        return randomBytes(8).toString('base64').slice(0, 12)
-      }
-
-      const password = generateInitialPassword()
-      expect(password.length).toBe(12)
     })
   })
 

--- a/src/app/api/admin/whitelist/[userId]/route.ts
+++ b/src/app/api/admin/whitelist/[userId]/route.ts
@@ -2,19 +2,14 @@
  * Individual Whitelist User API (Issue #4)
  */
 
-import { auth, isPrivateInstance } from '@/lib/auth'
+import { auth, generateInitialPassword, isPrivateInstance } from '@/lib/auth'
 import {
   passwordChangeRequiredResponse,
   requiresTwoFactorResponse,
 } from '@/lib/auth-helpers'
 import { prisma } from '@/lib/prisma'
 import bcrypt from 'bcryptjs'
-import { randomBytes } from 'crypto'
 import { NextResponse } from 'next/server'
-
-function generateInitialPassword(): string {
-  return randomBytes(8).toString('base64').slice(0, 12)
-}
 
 /**
  * Reset password for a whitelist user

--- a/src/app/api/admin/whitelist/route.ts
+++ b/src/app/api/admin/whitelist/route.ts
@@ -20,7 +20,7 @@
  * consumed one attempt.
  */
 
-import { auth, isPrivateInstance } from '@/lib/auth'
+import { auth, generateInitialPassword, isPrivateInstance } from '@/lib/auth'
 import {
   passwordChangeRequiredResponse,
   requiresTwoFactorResponse,
@@ -31,17 +31,8 @@ import {
   recordOperationAttempt,
 } from '@/lib/rate-limit'
 import bcrypt from 'bcryptjs'
-import { randomBytes } from 'crypto'
 import { NextResponse } from 'next/server'
 import { z } from 'zod'
-
-/**
- * Generate a random initial password with sufficient entropy (Issue #48)
- * Uses 16 bytes (128 bits) of random data for cryptographic strength
- */
-function generateInitialPassword(): string {
-  return randomBytes(16).toString('base64url').slice(0, 20)
-}
 
 const MAX_BODY_BYTES = 4 * 1024 // 4 KB
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -12,6 +12,7 @@ import {
 } from '@/lib/rate-limit'
 import { PrismaAdapter } from '@auth/prisma-adapter'
 import bcrypt from 'bcryptjs'
+import { randomBytes } from 'crypto'
 import NextAuth, { type NextAuthConfig } from 'next-auth'
 import Credentials from 'next-auth/providers/credentials'
 
@@ -164,6 +165,25 @@ const authConfig: NextAuthConfig = {
 }
 
 export const { handlers, signIn, signOut, auth } = NextAuth(authConfig)
+
+/**
+ * Generate a random initial password with sufficient entropy.
+ *
+ * Returns 20 base64url characters drawn from `randomBytes(16)`:
+ *   - 16 raw bytes = 128 bits of entropy
+ *   - `.toString('base64url')` = 22 URL-safe characters (no padding)
+ *   - `.slice(0, 20)` = 120 bits of effective entropy
+ *
+ * Shared by `/api/admin/whitelist` POST (create, Issue #48) and PATCH
+ * (reset, Issue #177) so both endpoints emit equally strong passwords.
+ * The pre-Issue-#177 reset path used `randomBytes(8).toString('base64')
+ * .slice(0, 12)` (= 64 bits of entropy), which is brute-forceable in
+ * months on modern HPC. base64url avoids `+`, `/`, `=` so the password
+ * survives chat / URL channels without escaping.
+ */
+export function generateInitialPassword(): string {
+  return randomBytes(16).toString('base64url').slice(0, 20)
+}
 
 /**
  * Check if private instance mode is enabled.


### PR DESCRIPTION
## Summary

- Issue #48 で create endpoint (`/api/admin/whitelist` POST) は既に 120-bit 相当の entropy (`randomBytes(16).toString('base64url').slice(0, 20)`) で実装済み。
- 本 PR で reset endpoint (`/api/admin/whitelist/[userId]` PATCH) の 64-bit (`randomBytes(8).toString('base64').slice(0, 12)`) を `src/lib/auth.ts` の shared `generateInitialPassword()` helper に統一し、 120-bit 化。

## Changes

- `src/lib/auth.ts`: `generateInitialPassword()` を export (新規 helper)
- `src/app/api/admin/whitelist/route.ts`: 共有 helper を使用 (重複削除のみ、 既存挙動は維持)
- `src/app/api/admin/whitelist/[userId]/route.ts`: 共有 helper を使用 (本 PR の本来の fix — 64-bit → 120-bit)
- `src/__tests__/admin-whitelist-validation.test.ts`: auth mock 拡張 + Section G success の固定値 assertion 追加
- `src/__tests__/admin-whitelist-reset.test.ts`: 新規 — PATCH route の helper 統一を regression test (5 gate + 404 + success contract)
- `src/__tests__/private-instance.test.ts`: Initial Password Generation を `jest.isolateModulesAsync` + 共有 helper 経由 test に refactor

## Test plan

- [x] pnpm check-formatting (prettier)
- [x] pnpm check-types (tsc --noEmit)
- [x] pnpm test src/__tests__/admin-whitelist-validation.test.ts src/__tests__/admin-whitelist-reset.test.ts src/__tests__/private-instance.test.ts src/lib/rate-limit.test.ts (77 tests, 4 suites, all green)
- [ ] manual: admin whitelist POST → response.initialPassword 長 20
- [ ] manual: admin whitelist PATCH → response.initialPassword 長 20

Closes #177