### PR TITLE
fix(security): keep reimbursement amount out of URL query (closes #234)

### DIFF
--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -35,6 +35,7 @@ import {
 import { Locale } from '@/i18n/request'
 import { defaultCurrencyList, getCurrency } from '@/lib/currency'
 import { useActiveUser, useCurrencyRate } from '@/lib/hooks'
+import { getReimbursementAmount } from '@/lib/reimbursement-prefill'
 import {
   ExpenseFormValues,
   SplittingOptions,
@@ -220,7 +221,11 @@ export function ExpenseForm({
             title: t('reimbursement'),
             expenseDate: new Date(),
             amount: amountAsDecimal(
-              Number(searchParams.get('amount')) || 0,
+              getReimbursementAmount(
+                group.id,
+                searchParams.get('from') ?? '',
+                searchParams.get('to') ?? '',
+              ) ?? 0,
               groupCurrency,
             ),
             originalCurrency: group.currencyCode,

--- a/src/app/groups/[groupId]/reimbursement-list.tsx
+++ b/src/app/groups/[groupId]/reimbursement-list.tsx
@@ -1,10 +1,13 @@
+'use client'
+
 import { Button } from '@/components/ui/button'
 import { Reimbursement } from '@/lib/balances'
 import { Currency } from '@/lib/currency'
+import { setReimbursementAmount } from '@/lib/reimbursement-prefill'
 import { formatCurrency } from '@/lib/utils'
 import { Participant } from '@prisma/client'
 import { useLocale, useTranslations } from 'next-intl'
-import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 
 type Props = {
   reimbursements: Reimbursement[]
@@ -21,11 +24,28 @@ export function ReimbursementList({
 }: Props) {
   const locale = useLocale()
   const t = useTranslations('Balances.Reimbursements')
+  const router = useRouter()
   if (reimbursements.length === 0) {
     return <p className="text-sm pb-6">{t('noImbursements')}</p>
   }
 
   const getParticipant = (id: string) => participants.find((p) => p.id === id)
+
+  // The amount is derived from decrypted balances (plaintext). Keep it out of
+  // the URL query so it is never sent to the server; pass it via an in-memory
+  // store instead (see reimbursement-prefill.ts).
+  const handleMarkAsPaid = (reimbursement: Reimbursement) => {
+    setReimbursementAmount(
+      groupId,
+      reimbursement.from,
+      reimbursement.to,
+      reimbursement.amount,
+    )
+    router.push(
+      `/groups/${groupId}/expenses/create?reimbursement=yes&from=${reimbursement.from}&to=${reimbursement.to}`,
+    )
+  }
+
   return (
     <div className="text-sm">
       {reimbursements.map((reimbursement, index) => (
@@ -38,12 +58,13 @@ export function ReimbursementList({
                 strong: (chunks) => <strong>{chunks}</strong>,
               })}
             </div>
-            <Button variant="link" asChild className="-mx-4 -my-3">
-              <Link
-                href={`/groups/${groupId}/expenses/create?reimbursement=yes&from=${reimbursement.from}&to=${reimbursement.to}&amount=${reimbursement.amount}`}
-              >
-                {t('markAsPaid')}
-              </Link>
+            <Button
+              variant="link"
+              type="button"
+              className="-mx-4 -my-3"
+              onClick={() => handleMarkAsPaid(reimbursement)}
+            >
+              {t('markAsPaid')}
             </Button>
           </div>
           <div>{formatCurrency(currency, reimbursement.amount, locale)}</div>

--- a/src/lib/reimbursement-prefill.test.ts
+++ b/src/lib/reimbursement-prefill.test.ts
@@ -1,0 +1,32 @@
+import {
+  getReimbursementAmount,
+  setReimbursementAmount,
+} from './reimbursement-prefill'
+
+describe('reimbursement-prefill', () => {
+  it('returns null when nothing is stored', () => {
+    expect(getReimbursementAmount('g1', 'a', 'b')).toBeNull()
+  })
+
+  it('round-trips a stored amount for the matching group/from/to', () => {
+    setReimbursementAmount('g1', 'a', 'b', 1234)
+    expect(getReimbursementAmount('g1', 'a', 'b')).toBe(1234)
+  })
+
+  it('keeps amounts separate per from/to pair', () => {
+    setReimbursementAmount('g1', 'a', 'b', 100)
+    setReimbursementAmount('g1', 'b', 'a', 200)
+    expect(getReimbursementAmount('g1', 'a', 'b')).toBe(100)
+    expect(getReimbursementAmount('g1', 'b', 'a')).toBe(200)
+  })
+
+  it('does not leak amounts across groups', () => {
+    setReimbursementAmount('g1', 'a', 'b', 100)
+    expect(getReimbursementAmount('g2', 'a', 'b')).toBeNull()
+  })
+
+  it('preserves 0 as a stored value rather than falling back to null', () => {
+    setReimbursementAmount('g3', 'a', 'b', 0)
+    expect(getReimbursementAmount('g3', 'a', 'b')).toBe(0)
+  })
+})

--- a/src/lib/reimbursement-prefill.ts
+++ b/src/lib/reimbursement-prefill.ts
@@ -1,0 +1,39 @@
+/**
+ * In-memory store for the reimbursement "Mark as paid" prefill amount.
+ *
+ * The suggested reimbursement amount is derived on the client from decrypted
+ * balances and is therefore plaintext financial data. It must never be placed
+ * in the URL query string: navigating to the (server-rendered) create-expense
+ * route would transmit the query to the server via the RSC fetch (or a full
+ * reload), leaking the amount into server/proxy access logs and breaking the
+ * E2EE invariant that the server never receives plaintext.
+ *
+ * We keep it in a module-level map instead. It survives client-side navigation
+ * but is never sent to the server. On a full reload the entry is absent and the
+ * amount falls back to 0 (the from/to participants are still prefilled from the
+ * query, which only contains pseudonymous participant ids already visible to
+ * the server).
+ */
+
+const pendingReimbursementAmounts = new Map<string, number>()
+
+function buildKey(groupId: string, from: string, to: string): string {
+  return `${groupId}:${from}:${to}`
+}
+
+export function setReimbursementAmount(
+  groupId: string,
+  from: string,
+  to: string,
+  amount: number,
+): void {
+  pendingReimbursementAmounts.set(buildKey(groupId, from, to), amount)
+}
+
+export function getReimbursementAmount(
+  groupId: string,
+  from: string,
+  to: string,
+): number | null {
+  return pendingReimbursementAmounts.get(buildKey(groupId, from, to)) ?? null
+}


### PR DESCRIPTION
## 目的

Closes #234 (High / E2EE 不変条件違反)

「Mark as paid」精算リンクが、復号済み残高から算出した**精算額(平文の金融データ)**を create-expense の URL クエリ文字列に埋め込んでいた。遷移先 `create/page.tsx` はサーバコンポーネントであり、App Router のクライアント遷移では RSC ペイロード取得リクエスト(およびフルリロード時の文書リクエスト)の URL にクエリ全体が付与されサーバへ到達する。結果として平文の金額がリバースプロキシ / CDN / アプリのアクセスログに記録され、「サーバは平文の機微データを受信・保存・処理・ログ出力しない」という E2EE 中核不変条件に違反していた。

## 変更内容

- `src/lib/reimbursement-prefill.ts`(新規): 精算額を保持するクライアント専用のモジュール内メモリストア。クライアント遷移では保持されるがサーバへは送信されない。
- `src/app/groups/[groupId]/reimbursement-list.tsx`: `<Link>`(クエリに `amount` を含む)を、ストアへ保存してから `router.push` するボタンに変更。URL から `amount` を除去。`<Link>` の prefetch も無くなり、遷移前に create ルートを取得する経路も消える。
- `src/app/groups/[groupId]/expenses/expense-form.tsx`: 精算プリフィルの金額をクエリではなくストアから読む(`from`/`to` は擬名参加者 ID で元々サーバ可視のためクエリ残置)。フルリロード時はストア未設定で金額 0 フォールバック、`from`/`to` プリフィルは維持。
- `src/lib/reimbursement-prefill.test.ts`(新規): ストアの round-trip / group・from/to 分離 / 0 値保持のユニットテスト。

URL フラグメント(`#`)は暗号鍵が占有しているため amount の格納先には使えない点に留意して、メモリストア方式を採用した。

## 設計上の注意 / 残存事項

- `expense-form.tsx:245-256` の汎用プリフィル分岐(`title`/`amount`/`date`/`categoryId` をクエリから読む)は今回の対象外。現状これらを平文金額付きで生成する経路は精算リンクのみで、それを本 PR で解消している。将来この汎用分岐を使う機能を追加する場合は同様の配慮が必要。
- `from`/`to`(参加者 ID)はクエリに残置。精算登録後にはサーバも同じ支払い関係を保持するため本 PR の実害面ではないが、`from`/`to` の組は「現在誰が誰へ支払うべきか」という派生メタデータになり得る点は脅威モデル次第であり、「新たな漏洩は一切ない」と断定はしない(削除された平文 `amount` が本 PR の主眼)。

## Follow-up(非 blocking)

- メモリストア(`reimbursement-prefill.ts`)の cleanup / TTL 設計。現状 non-consuming で `(groupId, from, to)` ごとに小さな数値が残るが、履歴再訪で古い金額が出る挙動は変更前の amount 付き URL でも同様。
- `ReimbursementList` → `router.push` → `ExpenseForm` を通す統合テストの追加。

## 検証

- `prettier -c`(変更ファイル): pass
- `tsc --noEmit`(全体): pass
- `jest`: `reimbursement-prefill`(新規 5)、`balances-and-reimbursements` / `create-expense-form` / `edit-expense-form`(14): 全 pass
- `eslint`(変更ファイル): 0 errors(既存の hook 依存 warning のみ、本変更外)

## 関連

- 親トラッキング: #214
