### PR TITLE
fix: address post-merge review follow-ups for #240/#241

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,3 +39,15 @@ PRIVATE_INSTANCE=false
 # Enable for TOTP-based 2FA on private instances
 # ===========================================
 # TWO_FA_ENCRYPTION_KEY=     # 256-bit hex key (generate with: openssl rand -hex 32)
+
+# ===========================================
+# HSTS / Strict-Transport-Security (Optional)
+# Sent at runtime by the proxy; default max-age=63072000 (2 years) without
+# includeSubDomains. Set HSTS_INCLUDE_SUBDOMAINS=true only after confirming
+# every subdomain serves TLS (RFC 6797 section 11.4). HSTS_ENABLED=false
+# delegates HSTS to the hosting layer. Invalid values fail startup even when
+# disabled. See container.env.example for full caveats.
+# ===========================================
+# HSTS_ENABLED=true
+# HSTS_MAX_AGE=63072000
+# HSTS_INCLUDE_SUBDOMAINS=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,9 +112,16 @@ jobs:
         run: pnpm build
 
   docker-smoke-build:
-    # Builds the production image the same way releases do, so a broken
-    # Dockerfile (e.g. a missing COPY for a file imported by next.config.mjs)
-    # fails the PR. A plain `pnpm build` does not exercise the Dockerfile.
+    # Validates the Dockerfile (e.g. catches a missing COPY for a file
+    # imported by next.config.mjs) on a single platform (amd64), with no
+    # push. A plain `pnpm build` does not exercise the Dockerfile at all.
+    #
+    # This is NOT multi-arch parity with the release build: cd.yml builds
+    # linux/amd64 + linux/arm64 with QEMU, so an arm64-only breakage is still
+    # only caught at release time, not here.
+    #
+    # Intentionally has no `needs:` so Docker feedback lands in parallel with
+    # lint/test on PRs, rather than waiting on them.
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -187,9 +187,12 @@ NEXTAUTH_URL=https://your-domain.com
 ### HSTS / Strict-Transport-Security (Optional)
 
 ```bash
-HSTS_ENABLED=true              # Optional - default true; set false to delegate HSTS to the hosting layer
-HSTS_MAX_AGE=63072000          # Optional - default 63072000 seconds (2 years); non-negative integer
-HSTS_INCLUDE_SUBDOMAINS=false  # Optional - default false; enable only after confirming every subdomain serves TLS
+# Optional - default true; set false to delegate HSTS to the hosting layer
+HSTS_ENABLED=true
+# Optional - default 63072000 seconds (2 years); non-negative integer
+HSTS_MAX_AGE=63072000
+# Optional - default false; enable only after confirming every subdomain serves TLS
+HSTS_INCLUDE_SUBDOMAINS=false
 ```
 
 Applied at runtime by the proxy - see [container.env.example](container.env.example) for restart/redeploy and validation caveats.

--- a/README.md
+++ b/README.md
@@ -184,6 +184,16 @@ NEXTAUTH_SECRET=your-secret-key
 NEXTAUTH_URL=https://your-domain.com
 ```
 
+### HSTS / Strict-Transport-Security (Optional)
+
+```bash
+HSTS_ENABLED=true              # Optional - default true; set false to delegate HSTS to the hosting layer
+HSTS_MAX_AGE=63072000          # Optional - default 63072000 seconds (2 years); non-negative integer
+HSTS_INCLUDE_SUBDOMAINS=false  # Optional - default false; enable only after confirming every subdomain serves TLS
+```
+
+Applied at runtime by the proxy - see [container.env.example](container.env.example) for restart/redeploy and validation caveats.
+
 ## Tech Stack
 
 | Category   | Technology                                 |
@@ -209,6 +219,10 @@ NEXTAUTH_URL=https://your-domain.com
 - Use password protection for sensitive financial data
 - Don't share URLs in screenshots (they contain your encryption key)
 - Self-host for maximum privacy
+
+### Transport Security
+
+The app sends a `Strict-Transport-Security` header at runtime from the proxy (2-year `max-age`, no `includeSubDomains` by default). This is configurable, or can be fully disabled to defer to your hosting layer, via the `HSTS_*` environment variables documented in [container.env.example](container.env.example).
 
 ## Contributing
 

--- a/container.env.example
+++ b/container.env.example
@@ -38,9 +38,17 @@ PRIVATE_INSTANCE=false
 # ===========================================
 # The app sends "Strict-Transport-Security: max-age=63072000" (2 years) by
 # default. The header is generated at RUNTIME by the proxy, so these variables
-# take effect without rebuilding the image — but you must recreate/restart the
-# container after editing this file (on Vercel, redeploy) for changes to apply.
-# Invalid values fail loudly at server startup rather than shipping silently.
+# take effect without rebuilding the image — but a plain `docker compose up -d`
+# or `docker compose restart` may NOT re-read an edited env_file. Use
+# `docker compose up -d --force-recreate` (or the equivalent `podman compose`
+# command) to guarantee the new values apply; on Vercel, redeploy.
+# Validation is unconditional: invalid values fail server startup even when
+# HSTS_ENABLED=false, so a stale garbage value cannot lurk unnoticed until
+# HSTS is re-enabled.
+#
+# Some env-file parsers keep inline trailing comments, so a value written as
+# `63072000 # 2 years` reaches the app verbatim and fails validation — keep
+# values bare and put comments on their own lines.
 #
 # The default deliberately does NOT include includeSubDomains, so it never
 # affects other hosts under your domain — but the serving host itself is still

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -14,13 +14,17 @@ import {
 } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { sanitizeCallbackUrl } from '@/lib/safe-callback-url'
 import { signIn } from 'next-auth/react'
 import { useSearchParams } from 'next/navigation'
 import { useState } from 'react'
 
 export default function SignInPage() {
   const searchParams = useSearchParams()
-  const callbackUrl = searchParams.get('callbackUrl') || '/'
+  // Defense-in-depth: Auth.js origin-locks redirects server-side, but we also
+  // sanitize here for consistency with the verify-2fa pages rather than depend
+  // on the framework default staying default.
+  const callbackUrl = sanitizeCallbackUrl(searchParams.get('callbackUrl'))
   const error = searchParams.get('error')
 
   const [email, setEmail] = useState('')

--- a/src/app/groups/[groupId]/expenses/expense-form.tsx
+++ b/src/app/groups/[groupId]/expenses/expense-form.tsx
@@ -35,7 +35,10 @@ import {
 import { Locale } from '@/i18n/request'
 import { defaultCurrencyList, getCurrency } from '@/lib/currency'
 import { useActiveUser, useCurrencyRate } from '@/lib/hooks'
-import { getReimbursementAmount } from '@/lib/reimbursement-prefill'
+import {
+  clearReimbursementAmount,
+  getReimbursementAmount,
+} from '@/lib/reimbursement-prefill'
 import {
   ExpenseFormValues,
   SplittingOptions,
@@ -220,6 +223,9 @@ export function ExpenseForm({
         ? {
             title: t('reimbursement'),
             expenseDate: new Date(),
+            // The prefill entry survives only client-side navigation; a hard
+            // reload reads 0 here and the user re-enters the amount. Accepted
+            // tradeoff — the amount must never ride the URL.
             amount: amountAsDecimal(
               getReimbursementAmount(
                 group.id,
@@ -252,6 +258,9 @@ export function ExpenseForm({
             expenseDate: searchParams.get('date')
               ? new Date(searchParams.get('date') as string)
               : new Date(),
+            // Seeds from externally-supplied deep links only. In-app code must
+            // never put client-derived (decrypted) amounts into the URL; the
+            // reimbursement flow uses the in-memory store instead.
             amount: Number(searchParams.get('amount')) || 0,
             originalCurrency: group.currencyCode ?? '',
             originalAmount: '',
@@ -295,6 +304,19 @@ export function ExpenseForm({
   })
 
   const activeUserId = useActiveUser(group.id)
+
+  // The prefill amount is read once into the form's default values above; drop
+  // it afterwards so a later navigation cannot resurrect a stale amount.
+  // Deleting after the initial render is idempotent and StrictMode-safe.
+  useEffect(() => {
+    if (searchParams.get('reimbursement')) {
+      clearReimbursementAmount(
+        group.id,
+        searchParams.get('from') ?? '',
+        searchParams.get('to') ?? '',
+      )
+    }
+  }, [group.id, searchParams])
 
   const submit = async (values: ExpenseFormValues) => {
     await persistDefaultSplittingOptions(group.id, values)

--- a/src/app/groups/[groupId]/reimbursement-list.test.tsx
+++ b/src/app/groups/[groupId]/reimbursement-list.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock('next-intl', () => ({
+  useLocale: () => 'en',
+  useTranslations: () => {
+    const t = (key: string) => key
+    ;(t as unknown as { rich: (key: string) => string }).rich = (key: string) =>
+      key
+    return t
+  },
+}))
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}))
+
+import { Reimbursement } from '@/lib/balances'
+import { Currency } from '@/lib/currency'
+import { getReimbursementAmount } from '@/lib/reimbursement-prefill'
+import { Participant } from '@prisma/client'
+import { fireEvent, render } from '@testing-library/react'
+import { useRouter } from 'next/navigation'
+import { ReimbursementList } from './reimbursement-list'
+
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
+
+const currency: Currency = {
+  name: 'US Dollar',
+  symbol_native: '$',
+  symbol: '$',
+  code: 'USD',
+  name_plural: 'US dollars',
+  rounding: 0,
+  decimal_digits: 2,
+}
+
+const participants: Participant[] = [
+  { id: 'p1', name: 'Alice', groupId: 'g1' },
+  { id: 'p2', name: 'Bob', groupId: 'g1' },
+]
+
+let routerPushMock: jest.Mock
+
+beforeEach(() => {
+  routerPushMock = jest.fn()
+  mockUseRouter.mockReset()
+  mockUseRouter.mockReturnValue({ push: routerPushMock } as never)
+})
+
+describe('ReimbursementList (Issue #240 security invariant)', () => {
+  it('hands the amount off in memory and keeps it out of the URL', () => {
+    const reimbursement: Reimbursement = { from: 'p1', to: 'p2', amount: 4200 }
+
+    const { getByText } = render(
+      <ReimbursementList
+        reimbursements={[reimbursement]}
+        participants={participants}
+        currency={currency}
+        groupId="g1"
+      />,
+    )
+
+    // fireEvent wraps the click in act(), flushing the state/navigation work.
+    fireEvent.click(getByText('markAsPaid'))
+
+    // (a) The navigation carries only the pseudonymous ids, never the amount.
+    expect(routerPushMock).toHaveBeenCalledTimes(1)
+    const url = routerPushMock.mock.calls[0][0] as string
+    expect(url).toContain('reimbursement=')
+    expect(url).toContain('from=p1')
+    expect(url).toContain('to=p2')
+    expect(url).not.toContain('amount=')
+
+    // (b) The plaintext amount travels through the in-memory store instead
+    // (real store, not mocked).
+    expect(getReimbursementAmount('g1', 'p1', 'p2')).toBe(4200)
+  })
+})

--- a/src/components/share-url-button.tsx
+++ b/src/components/share-url-button.tsx
@@ -20,7 +20,10 @@ export function ShareUrlButton({ url, text }: Props) {
       type="button"
       onClick={() => {
         if (navigator.share) {
-          navigator.share({ text, url })
+          // Rejection (e.g. the user cancelling the share sheet) is expected;
+          // never log it — the payload contains the share URL whose fragment
+          // carries the encryption key.
+          navigator.share({ text, url }).catch(() => {})
         } else {
           // Do not log `url`/`text`: the share URL contains the encryption key
           // in its fragment, and logging it would expose key material to the

--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -22,6 +22,14 @@ describe('instrumentation register (startup HSTS validation)', () => {
   })
 
   it('throws at startup for an invalid configuration (fail-closed)', () => {
+    for (const k of keys) delete process.env[k]
+    process.env.HSTS_MAX_AGE = 'oops'
+    expect(() => register()).toThrow(/HSTS_MAX_AGE/)
+  })
+
+  it('validates unconditionally: throws even when HSTS_ENABLED=false', () => {
+    for (const k of keys) delete process.env[k]
+    process.env.HSTS_ENABLED = 'false'
     process.env.HSTS_MAX_AGE = 'oops'
     expect(() => register()).toThrow(/HSTS_MAX_AGE/)
   })

--- a/src/lib/env-bool.test.ts
+++ b/src/lib/env-bool.test.ts
@@ -1,0 +1,41 @@
+import { interpretEnvVarAsBool, parseStrictEnvBool } from './env-bool'
+
+describe('interpretEnvVarAsBool (lenient / fail-open)', () => {
+  it('accepts the truthy tokens case-insensitively', () => {
+    for (const val of ['true', 'TRUE', 'yes', '1', 'on', 'On']) {
+      expect(interpretEnvVarAsBool(val)).toBe(true)
+    }
+  })
+
+  it('reads anything else as false, including typos and non-strings', () => {
+    for (const val of ['false', 'off', '0', 'enabled', '', undefined, 1]) {
+      expect(interpretEnvVarAsBool(val)).toBe(false)
+    }
+  })
+})
+
+describe('parseStrictEnvBool (strict / fail-closed)', () => {
+  it('returns the default when unset or empty', () => {
+    expect(parseStrictEnvBool('X', undefined, true)).toBe(true)
+    expect(parseStrictEnvBool('X', undefined, false)).toBe(false)
+    expect(parseStrictEnvBool('X', '', true)).toBe(true)
+  })
+
+  it('recognizes truthy and falsy tokens case-insensitively', () => {
+    for (const val of ['true', 'YES', '1', 'on']) {
+      expect(parseStrictEnvBool('X', val, false)).toBe(true)
+    }
+    for (const val of ['false', 'No', '0', 'OFF']) {
+      expect(parseStrictEnvBool('X', val, true)).toBe(false)
+    }
+  })
+
+  it('throws on unknown tokens, naming the variable', () => {
+    expect(() => parseStrictEnvBool('MY_FLAG', 'enabled', true)).toThrow(
+      /MY_FLAG/,
+    )
+    expect(() => parseStrictEnvBool('MY_FLAG', 'banana', false)).toThrow(
+      /true\/yes\/1\/on\/false\/no\/0\/off/,
+    )
+  })
+})

--- a/src/lib/env-bool.ts
+++ b/src/lib/env-bool.ts
@@ -1,4 +1,37 @@
+// Shared truthy/falsy tokens for env-var boolean parsing. interpretEnvVarAsBool
+// only consults TRUE_TOKENS (anything else, typos included, reads as false),
+// while parseStrictEnvBool also recognizes FALSE_TOKENS and rejects the rest.
+export const TRUE_TOKENS = ['true', 'yes', '1', 'on']
+export const FALSE_TOKENS = ['false', 'no', '0', 'off']
+
 export function interpretEnvVarAsBool(val: unknown): boolean {
   if (typeof val !== 'string') return false
-  return ['true', 'yes', '1', 'on'].includes(val.toLowerCase())
+  return TRUE_TOKENS.includes(val.toLowerCase())
+}
+
+/**
+ * Strict boolean parser for env vars. In contrast to interpretEnvVarAsBool
+ * (lenient / fail-open: any non-truthy value, including a typo, reads as
+ * false), this throws when the value is neither a known truthy nor falsy
+ * token, so a misconfigured flag fails loudly instead of silently taking a
+ * default. Which parser a given env var uses is a deliberate per-variable
+ * choice (e.g. PRIVATE_INSTANCE stays lenient; HSTS_* are strict).
+ *
+ * @param name - env var name, used in the thrown message
+ * @param raw - raw value (undefined or '' yields defaultValue)
+ * @param defaultValue - value returned when unset
+ * @throws when raw is a non-empty value in neither token list
+ */
+export function parseStrictEnvBool(
+  name: string,
+  raw: string | undefined,
+  defaultValue: boolean,
+): boolean {
+  if (raw === undefined || raw === '') return defaultValue
+  const lowered = raw.toLowerCase()
+  if (TRUE_TOKENS.includes(lowered)) return true
+  if (FALSE_TOKENS.includes(lowered)) return false
+  throw new Error(
+    `${name} must be one of ${[...TRUE_TOKENS, ...FALSE_TOKENS].join('/')}, got: ${JSON.stringify(raw)}`,
+  )
 }

--- a/src/lib/hsts.test.ts
+++ b/src/lib/hsts.test.ts
@@ -2,10 +2,7 @@ import { buildHstsHeader } from './hsts'
 
 describe('buildHstsHeader', () => {
   it('defaults to a 2-year policy without includeSubDomains', () => {
-    expect(buildHstsHeader({})).toEqual({
-      key: 'Strict-Transport-Security',
-      value: 'max-age=63072000',
-    })
+    expect(buildHstsHeader({})).toBe('max-age=63072000')
   })
 
   it('treats empty-string env values as unset', () => {
@@ -15,21 +12,17 @@ describe('buildHstsHeader', () => {
         HSTS_MAX_AGE: '',
         HSTS_INCLUDE_SUBDOMAINS: '',
       }),
-    ).toEqual({
-      key: 'Strict-Transport-Security',
-      value: 'max-age=63072000',
-    })
+    ).toBe('max-age=63072000')
   })
 
   it('appends includeSubDomains only on explicit opt-in', () => {
-    expect(buildHstsHeader({ HSTS_INCLUDE_SUBDOMAINS: 'true' })).toEqual({
-      key: 'Strict-Transport-Security',
-      value: 'max-age=63072000; includeSubDomains',
-    })
-    expect(buildHstsHeader({ HSTS_INCLUDE_SUBDOMAINS: 'on' })?.value).toBe(
+    expect(buildHstsHeader({ HSTS_INCLUDE_SUBDOMAINS: 'true' })).toBe(
       'max-age=63072000; includeSubDomains',
     )
-    expect(buildHstsHeader({ HSTS_INCLUDE_SUBDOMAINS: 'false' })?.value).toBe(
+    expect(buildHstsHeader({ HSTS_INCLUDE_SUBDOMAINS: 'on' })).toBe(
+      'max-age=63072000; includeSubDomains',
+    )
+    expect(buildHstsHeader({ HSTS_INCLUDE_SUBDOMAINS: 'false' })).toBe(
       'max-age=63072000',
     )
   })
@@ -41,14 +34,11 @@ describe('buildHstsHeader', () => {
   })
 
   it('honors a custom max-age', () => {
-    expect(buildHstsHeader({ HSTS_MAX_AGE: '300' })?.value).toBe('max-age=300')
+    expect(buildHstsHeader({ HSTS_MAX_AGE: '300' })).toBe('max-age=300')
   })
 
   it('keeps sending max-age=0 (policy deletion), distinct from disabling', () => {
-    expect(buildHstsHeader({ HSTS_MAX_AGE: '0' })).toEqual({
-      key: 'Strict-Transport-Security',
-      value: 'max-age=0',
-    })
+    expect(buildHstsHeader({ HSTS_MAX_AGE: '0' })).toBe('max-age=0')
   })
 
   it('throws on invalid HSTS_MAX_AGE values', () => {
@@ -72,5 +62,20 @@ describe('buildHstsHeader', () => {
     expect(() => buildHstsHeader({ HSTS_INCLUDE_SUBDOMAINS: 'yep' })).toThrow(
       /HSTS_INCLUDE_SUBDOMAINS/,
     )
+  })
+
+  it('validates HSTS_MAX_AGE even when HSTS_ENABLED=false (no dormant garbage)', () => {
+    expect(() =>
+      buildHstsHeader({ HSTS_ENABLED: 'false', HSTS_MAX_AGE: 'garbage' }),
+    ).toThrow(/HSTS_MAX_AGE/)
+  })
+
+  it('validates HSTS_INCLUDE_SUBDOMAINS even when HSTS_ENABLED=false', () => {
+    expect(() =>
+      buildHstsHeader({
+        HSTS_ENABLED: 'false',
+        HSTS_INCLUDE_SUBDOMAINS: 'banana',
+      }),
+    ).toThrow(/HSTS_INCLUDE_SUBDOMAINS/)
   })
 })

--- a/src/lib/hsts.ts
+++ b/src/lib/hsts.ts
@@ -6,8 +6,10 @@
  * is evaluated at build time and frozen into `.next`, so a prebuilt Docker
  * image could never honor `container.env`. Emitting from the proxy lets
  * runtime env (container.env / platform env vars) actually control the header
- * — though changing that env still requires recreating/restarting the
- * container (or redeploying on Vercel); it is not hot-reloaded.
+ * — though it is not hot-reloaded, and re-reading changed env can be subtle: a
+ * plain `docker compose up -d` or `restart` may not re-read an edited env_file,
+ * so use `docker compose up -d --force-recreate` (podman compose likewise); on
+ * Vercel, redeploy.
  *
  * The default deliberately omits `includeSubDomains`: it is a default that
  * does not affect subdomains, NOT a harmless one — the serving host itself is
@@ -37,36 +39,21 @@
  *   `includeSubDomains`. Only do this after confirming that every subdomain
  *   is served over TLS. Default: off.
  *
- * Invalid values throw. The proxy evaluates this at module load and
+ * Keep values bare: many env-file parsers do NOT strip inline trailing
+ * comments, so `HSTS_MAX_AGE=63072000 # 2 years` is read literally (including
+ * the ` # 2 years` suffix) and fails startup validation.
+ *
+ * Validation is unconditional: all three variables are parsed before the
+ * enabled check, so an invalid value throws even when HSTS_ENABLED=false. This
+ * prevents latent garbage from lying dormant and only surfacing when HSTS is
+ * later re-enabled. The proxy evaluates this at module load and
  * instrumentation.ts re-validates at server startup, so a misconfiguration
  * fails loudly (fail-closed) instead of silently shipping a wrong policy.
  */
 
+import { parseStrictEnvBool } from './env-bool'
+
 const DEFAULT_MAX_AGE_SECONDS = 63072000 // 2 years
-
-// Mirrors src/lib/env-bool.ts truthy tokens, plus explicit falsy tokens so
-// typos fail loudly instead of silently flipping the policy.
-const TRUE_TOKENS = ['true', 'yes', '1', 'on']
-const FALSE_TOKENS = ['false', 'no', '0', 'off']
-
-export interface HstsHeader {
-  key: 'Strict-Transport-Security'
-  value: string
-}
-
-function parseBoolEnv(
-  name: string,
-  raw: string | undefined,
-  defaultValue: boolean,
-): boolean {
-  if (raw === undefined || raw === '') return defaultValue
-  const lowered = raw.toLowerCase()
-  if (TRUE_TOKENS.includes(lowered)) return true
-  if (FALSE_TOKENS.includes(lowered)) return false
-  throw new Error(
-    `${name} must be one of ${[...TRUE_TOKENS, ...FALSE_TOKENS].join('/')}, got: ${JSON.stringify(raw)}`,
-  )
-}
 
 function parseMaxAgeEnv(raw: string | undefined): number {
   if (raw === undefined || raw === '') return DEFAULT_MAX_AGE_SECONDS
@@ -85,28 +72,28 @@ function parseMaxAgeEnv(raw: string | undefined): number {
 }
 
 /**
- * Build the Strict-Transport-Security header entry from the environment.
+ * Build the Strict-Transport-Security header value from the environment.
+ *
+ * All three HSTS_* variables are validated before the enabled check, so an
+ * invalid value throws even when HSTS_ENABLED=false (fail-closed).
  *
  * @param env - environment to read from (defaults to process.env)
- * @returns the header entry, or null when the app must not send the header
- *   (HSTS_ENABLED=false)
+ * @returns the header value (e.g. `max-age=63072000`), or null when the app
+ *   must not send the header (HSTS_ENABLED=false)
  * @throws on invalid environment values (fail-closed)
  */
 export function buildHstsHeader(
   env: Record<string, string | undefined> = process.env,
-): HstsHeader | null {
-  const enabled = parseBoolEnv('HSTS_ENABLED', env.HSTS_ENABLED, true)
-  if (!enabled) return null
-
+): string | null {
+  const enabled = parseStrictEnvBool('HSTS_ENABLED', env.HSTS_ENABLED, true)
   const maxAge = parseMaxAgeEnv(env.HSTS_MAX_AGE)
-  const includeSubDomains = parseBoolEnv(
+  const includeSubDomains = parseStrictEnvBool(
     'HSTS_INCLUDE_SUBDOMAINS',
     env.HSTS_INCLUDE_SUBDOMAINS,
     false,
   )
 
-  return {
-    key: 'Strict-Transport-Security',
-    value: `max-age=${maxAge}${includeSubDomains ? '; includeSubDomains' : ''}`,
-  }
+  if (!enabled) return null
+
+  return `max-age=${maxAge}${includeSubDomains ? '; includeSubDomains' : ''}`
 }

--- a/src/lib/reimbursement-prefill.server.test.ts
+++ b/src/lib/reimbursement-prefill.server.test.ts
@@ -1,0 +1,13 @@
+/** @jest-environment node */
+
+import {
+  getReimbursementAmount,
+  setReimbursementAmount,
+} from './reimbursement-prefill'
+
+describe('reimbursement-prefill on the server (no window)', () => {
+  it('ignores writes so plaintext amounts never enter shared process memory', () => {
+    setReimbursementAmount('srv-g', 'srv-a', 'srv-b', 999)
+    expect(getReimbursementAmount('srv-g', 'srv-a', 'srv-b')).toBeNull()
+  })
+})

--- a/src/lib/reimbursement-prefill.test.ts
+++ b/src/lib/reimbursement-prefill.test.ts
@@ -1,32 +1,48 @@
 import {
+  clearReimbursementAmount,
   getReimbursementAmount,
   setReimbursementAmount,
 } from './reimbursement-prefill'
 
+// Every test uses its own unique key triple so cases never depend on the
+// module-level map being cleared between them or on execution order.
 describe('reimbursement-prefill', () => {
-  it('returns null when nothing is stored', () => {
-    expect(getReimbursementAmount('g1', 'a', 'b')).toBeNull()
+  it('returns null when nothing is stored for the key', () => {
+    expect(getReimbursementAmount('none-g', 'none-a', 'none-b')).toBeNull()
   })
 
   it('round-trips a stored amount for the matching group/from/to', () => {
-    setReimbursementAmount('g1', 'a', 'b', 1234)
-    expect(getReimbursementAmount('g1', 'a', 'b')).toBe(1234)
+    setReimbursementAmount('rt-g', 'rt-a', 'rt-b', 1234)
+    expect(getReimbursementAmount('rt-g', 'rt-a', 'rt-b')).toBe(1234)
   })
 
   it('keeps amounts separate per from/to pair', () => {
-    setReimbursementAmount('g1', 'a', 'b', 100)
-    setReimbursementAmount('g1', 'b', 'a', 200)
-    expect(getReimbursementAmount('g1', 'a', 'b')).toBe(100)
-    expect(getReimbursementAmount('g1', 'b', 'a')).toBe(200)
+    setReimbursementAmount('pair-g', 'pair-a', 'pair-b', 100)
+    setReimbursementAmount('pair-g', 'pair-b', 'pair-a', 200)
+    expect(getReimbursementAmount('pair-g', 'pair-a', 'pair-b')).toBe(100)
+    expect(getReimbursementAmount('pair-g', 'pair-b', 'pair-a')).toBe(200)
   })
 
   it('does not leak amounts across groups', () => {
-    setReimbursementAmount('g1', 'a', 'b', 100)
-    expect(getReimbursementAmount('g2', 'a', 'b')).toBeNull()
+    setReimbursementAmount('grp-a', 'x', 'y', 100)
+    expect(getReimbursementAmount('grp-b', 'x', 'y')).toBeNull()
   })
 
   it('preserves 0 as a stored value rather than falling back to null', () => {
-    setReimbursementAmount('g3', 'a', 'b', 0)
-    expect(getReimbursementAmount('g3', 'a', 'b')).toBe(0)
+    setReimbursementAmount('zero-g', 'zero-a', 'zero-b', 0)
+    expect(getReimbursementAmount('zero-g', 'zero-a', 'zero-b')).toBe(0)
+  })
+
+  it('clears a stored amount', () => {
+    setReimbursementAmount('clr-g', 'clr-a', 'clr-b', 500)
+    clearReimbursementAmount('clr-g', 'clr-a', 'clr-b')
+    expect(getReimbursementAmount('clr-g', 'clr-a', 'clr-b')).toBeNull()
+  })
+
+  it('does not collide when ids contain the delimiter character', () => {
+    setReimbursementAmount('g', 'a:b', 'c', 1)
+    setReimbursementAmount('g:a', 'b:c', '', 2)
+    expect(getReimbursementAmount('g', 'a:b', 'c')).toBe(1)
+    expect(getReimbursementAmount('g:a', 'b:c', '')).toBe(2)
   })
 })

--- a/src/lib/reimbursement-prefill.test.ts
+++ b/src/lib/reimbursement-prefill.test.ts
@@ -40,9 +40,11 @@ describe('reimbursement-prefill', () => {
   })
 
   it('does not collide when ids contain the delimiter character', () => {
+    // Both triples flatten to the same 'g:a:b:c' under a naive ':' join, so
+    // this fails against a delimiter-joined key scheme.
     setReimbursementAmount('g', 'a:b', 'c', 1)
-    setReimbursementAmount('g:a', 'b:c', '', 2)
+    setReimbursementAmount('g:a', 'b', 'c', 2)
     expect(getReimbursementAmount('g', 'a:b', 'c')).toBe(1)
-    expect(getReimbursementAmount('g:a', 'b:c', '')).toBe(2)
+    expect(getReimbursementAmount('g:a', 'b', 'c')).toBe(2)
   })
 })

--- a/src/lib/reimbursement-prefill.ts
+++ b/src/lib/reimbursement-prefill.ts
@@ -13,12 +13,19 @@
  * amount falls back to 0 (the from/to participants are still prefilled from the
  * query, which only contains pseudonymous participant ids already visible to
  * the server).
+ *
+ * Lifecycle: the amount is set on the "Mark as paid" click, read once as the
+ * create-form default value, and cleared by the form in a mount effect. Because
+ * the entry lives only in this process's memory, a hard reload finds nothing and
+ * the amount falls back to 0 by design — privacy is chosen over convenience.
  */
 
 const pendingReimbursementAmounts = new Map<string, number>()
 
 function buildKey(groupId: string, from: string, to: string): string {
-  return `${groupId}:${from}:${to}`
+  // JSON.stringify the id tuple so the parts can never collide regardless of
+  // which delimiter characters an id happens to contain.
+  return JSON.stringify([groupId, from, to])
 }
 
 export function setReimbursementAmount(
@@ -27,6 +34,10 @@ export function setReimbursementAmount(
   to: string,
   amount: number,
 ): void {
+  // This store is client-only. A server-side write would share one user's
+  // plaintext amount across every request handled by the Node process
+  // (cross-tenant leak).
+  if (typeof window === 'undefined') return
   pendingReimbursementAmounts.set(buildKey(groupId, from, to), amount)
 }
 
@@ -36,4 +47,12 @@ export function getReimbursementAmount(
   to: string,
 ): number | null {
   return pendingReimbursementAmounts.get(buildKey(groupId, from, to)) ?? null
+}
+
+export function clearReimbursementAmount(
+  groupId: string,
+  from: string,
+  to: string,
+): void {
+  pendingReimbursementAmounts.delete(buildKey(groupId, from, to))
 }

--- a/src/lib/safe-callback-url.server.test.ts
+++ b/src/lib/safe-callback-url.server.test.ts
@@ -1,0 +1,14 @@
+/** @jest-environment node */
+
+import { sanitizeCallbackUrl } from './safe-callback-url'
+
+describe('sanitizeCallbackUrl on the server (no window)', () => {
+  it('rejects absolute URLs fail-closed when our origin is unknown', () => {
+    expect(sanitizeCallbackUrl('http://localhost/admin')).toBe('/')
+    expect(sanitizeCallbackUrl('https://evil.example/x')).toBe('/')
+  })
+
+  it('still accepts plain same-origin paths', () => {
+    expect(sanitizeCallbackUrl('/admin')).toBe('/admin')
+  })
+})

--- a/src/lib/safe-callback-url.test.ts
+++ b/src/lib/safe-callback-url.test.ts
@@ -15,10 +15,30 @@ describe('sanitizeCallbackUrl', () => {
     )
   })
 
-  it('rejects absolute URLs', () => {
+  it('rejects cross-origin absolute URLs', () => {
     expect(sanitizeCallbackUrl('https://evil.example')).toBe('/')
     expect(sanitizeCallbackUrl('http://evil.example/path')).toBe('/')
     expect(sanitizeCallbackUrl('javascript:alert(1)')).toBe('/')
+    // Origin must match exactly: different port, prefix-alike host, and
+    // userinfo tricks are all cross-origin. (jsdom origin: http://localhost)
+    expect(sanitizeCallbackUrl('http://localhost:3000/admin')).toBe('/')
+    expect(sanitizeCallbackUrl('http://localhost.evil.example/x')).toBe('/')
+    expect(sanitizeCallbackUrl('http://localhost@evil.example/x')).toBe('/')
+  })
+
+  it('reduces same-origin absolute URLs (Auth.js normalization) to their path', () => {
+    // @auth/core's default redirect callback turns callbackUrl=/admin into
+    // an absolute baseUrl + '/admin' before it reaches the sign-in page.
+    expect(sanitizeCallbackUrl('http://localhost/admin')).toBe('/admin')
+    expect(sanitizeCallbackUrl('http://localhost/groups/abc?tab=1#top')).toBe(
+      '/groups/abc?tab=1#top',
+    )
+    expect(sanitizeCallbackUrl('HTTP://LOCALHOST/admin')).toBe('/admin')
+    expect(sanitizeCallbackUrl('http://localhost')).toBe('/')
+  })
+
+  it('does not let a same-origin URL smuggle a protocol-relative path', () => {
+    expect(sanitizeCallbackUrl('http://localhost//evil.example')).toBe('/')
   })
 
   it('rejects protocol-relative URLs', () => {

--- a/src/lib/safe-callback-url.test.ts
+++ b/src/lib/safe-callback-url.test.ts
@@ -40,4 +40,37 @@ describe('sanitizeCallbackUrl', () => {
     expect(sanitizeCallbackUrl(null, '/home')).toBe('/home')
     expect(sanitizeCallbackUrl('https://evil.example', '/home')).toBe('/home')
   })
+
+  it('returns the normalized string, which is what reaches router.replace', () => {
+    // The return value has the stripped control characters removed, not just
+    // the accept/reject decision made from them.
+    expect(sanitizeCallbackUrl('/a\r\nb')).toBe('/ab')
+  })
+
+  it('rejects a leading space (no longer starts with "/")', () => {
+    // A space is not in the strip set, so ' /path' does not start with '/'.
+    expect(sanitizeCallbackUrl(' /path')).toBe('/')
+  })
+
+  it('rejects control characters outside the strip set', () => {
+    expect(sanitizeCallbackUrl('\f/evil')).toBe('/')
+    expect(sanitizeCallbackUrl('\x00/x')).toBe('/')
+  })
+
+  it('passes through same-origin oddities the browser resolves locally', () => {
+    // The browser resolves these against our own origin, so they stay
+    // same-origin and are accepted by design.
+    expect(sanitizeCallbackUrl('/%2F%2Fevil.example')).toBe(
+      '/%2F%2Fevil.example',
+    )
+    expect(sanitizeCallbackUrl('/..//evil.example')).toBe('/..//evil.example')
+  })
+
+  it('holds the fallback to the same rules', () => {
+    expect(
+      sanitizeCallbackUrl('https://evil.example', 'https://evil2.example'),
+    ).toBe('/')
+    expect(sanitizeCallbackUrl(null, '/custom')).toBe('/custom')
+    expect(sanitizeCallbackUrl(undefined, '//evil')).toBe('/')
+  })
 })

--- a/src/lib/safe-callback-url.ts
+++ b/src/lib/safe-callback-url.ts
@@ -12,19 +12,27 @@
  * Tab/newline/carriage-return characters are stripped first because browsers
  * ignore them when parsing URLs, which would otherwise let `\t//host` slip
  * through the checks.
+ *
+ * The `fallback` is held to the same rules, so a future caller cannot smuggle
+ * an absolute URL through the fallback parameter; an unsafe fallback degrades
+ * to `/`.
  */
-export function sanitizeCallbackUrl(
-  raw: string | null | undefined,
-  fallback: string = '/',
-): string {
-  if (!raw) return fallback
+function sanitize(raw: string | null | undefined): string | null {
+  if (!raw) return null
 
   const normalized = raw.replace(/[\t\n\r]/g, '').replace(/\\/g, '/')
 
   // Must be a single-slash absolute path rooted at our own origin.
   if (!normalized.startsWith('/') || normalized.startsWith('//')) {
-    return fallback
+    return null
   }
 
   return normalized
+}
+
+export function sanitizeCallbackUrl(
+  raw: string | null | undefined,
+  fallback: string = '/',
+): string {
+  return sanitize(raw) ?? sanitize(fallback) ?? '/'
 }

--- a/src/lib/safe-callback-url.ts
+++ b/src/lib/safe-callback-url.ts
@@ -6,12 +6,20 @@
  * an attacker can craft `/auth/verify-2fa?callbackUrl=https://evil.example` and
  * bounce the user to an external site after login (open redirect / phishing).
  *
- * Only same-origin absolute paths are allowed. Absolute URLs (`https://host`),
- * protocol-relative URLs (`//host`) and backslash variants that browsers
- * normalize to protocol-relative (`/\host`) are rejected and fall back to `/`.
- * Tab/newline/carriage-return characters are stripped first because browsers
- * ignore them when parsing URLs, which would otherwise let `\t//host` slip
- * through the checks.
+ * Only same-origin targets are allowed. Cross-origin absolute URLs
+ * (`https://host`), protocol-relative URLs (`//host`) and backslash variants
+ * that browsers normalize to protocol-relative (`/\host`) are rejected and
+ * fall back to `/`. Tab/newline/carriage-return characters are stripped first
+ * because browsers ignore them when parsing URLs, which would otherwise let
+ * `\t//host` slip through the checks.
+ *
+ * Same-origin ABSOLUTE URLs are accepted and reduced to their path + query +
+ * hash: Auth.js's default redirect callback normalizes relative callback URLs
+ * to absolute form (`baseUrl + url`), so the standard
+ * `/api/auth/signin?callbackUrl=/admin` flow hands the custom sign-in page an
+ * absolute URL — rejecting it would strand the user on `/` after signing in.
+ * This reduction needs the browser's own origin; on the server (no `window`)
+ * absolute URLs are rejected (fail-closed).
  *
  * The `fallback` is held to the same rules, so a future caller cannot smuggle
  * an absolute URL through the fallback parameter; an unsafe fallback degrades
@@ -21,6 +29,21 @@ function sanitize(raw: string | null | undefined): string | null {
   if (!raw) return null
 
   const normalized = raw.replace(/[\t\n\r]/g, '').replace(/\\/g, '/')
+
+  if (typeof window !== 'undefined') {
+    let parsed: URL | null = null
+    try {
+      parsed = new URL(normalized)
+    } catch {
+      // Not an absolute URL — evaluate it as a path below.
+    }
+    if (parsed) {
+      if (parsed.origin !== window.location.origin) return null
+      // Re-apply the path rules to the reduced form: a pathname like
+      // '//evil.example' would otherwise reopen the protocol-relative hole.
+      return sanitize(parsed.pathname + parsed.search + parsed.hash)
+    }
+  }
 
   // Must be a single-slash absolute path rooted at our own origin.
   if (!normalized.startsWith('/') || normalized.startsWith('//')) {

--- a/src/proxy.test.ts
+++ b/src/proxy.test.ts
@@ -1,6 +1,6 @@
 /** @jest-environment node */
 
-import { NextRequest } from 'next/server'
+import { NextRequest, NextResponse } from 'next/server'
 
 // Env keys that influence the proxy. HSTS_* are read at module load (so the
 // module must be re-imported per case); PRIVATE_INSTANCE is read per request.
@@ -30,18 +30,22 @@ afterEach(() => {
   jest.resetModules()
 })
 
-// Load a fresh copy of the proxy with the given env so the module-level
+// Load a fresh copy of the proxy module with the given env so the module-level
 // buildHstsHeader() call is re-evaluated per case (no env bleed between tests).
-async function loadProxy(env: EnvOverrides) {
+async function loadProxyModule(env: EnvOverrides) {
   for (const key of MANAGED_ENV_KEYS) {
     if (env[key] === undefined) delete process.env[key]
     else process.env[key] = env[key]
   }
-  let proxy!: typeof import('./proxy').proxy
+  let mod!: typeof import('./proxy')
   await jest.isolateModulesAsync(async () => {
-    ;({ proxy } = await import('./proxy'))
+    mod = await import('./proxy')
   })
-  return proxy
+  return mod
+}
+
+async function loadProxy(env: EnvOverrides) {
+  return (await loadProxyModule(env)).proxy
 }
 
 function request(path: string, init?: { cookie?: string }) {
@@ -101,11 +105,72 @@ describe('proxy HSTS emission', () => {
   })
 
   it('fails closed: importing the proxy throws on an invalid HSTS value', async () => {
+    // Clear ALL managed keys first so an ambient HSTS_ENABLED=false in a dev
+    // shell cannot influence the result. Validation is unconditional now, but
+    // the test stays ambient-proof regardless. afterEach restores the shell env.
+    for (const key of MANAGED_ENV_KEYS) delete process.env[key]
     process.env.HSTS_MAX_AGE = 'not-a-number'
     await expect(
       jest.isolateModulesAsync(async () => {
         await import('./proxy')
       }),
     ).rejects.toThrow(/HSTS_MAX_AGE/)
+  })
+})
+
+describe('proxy routing branches (private instance)', () => {
+  it('redirects unauthenticated /groups/create to signin with callbackUrl', async () => {
+    const proxy = await loadProxy({ PRIVATE_INSTANCE: 'true' })
+    const res = await proxy(request('/groups/create'))
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toBe(
+      'http://localhost/auth/signin?callbackUrl=%2Fgroups%2Fcreate',
+    )
+    expect(res.headers.get(HSTS)).toBe('max-age=63072000')
+  })
+
+  it('passes a static asset (.png) through with HSTS and no redirect', async () => {
+    const proxy = await loadProxy({ PRIVATE_INSTANCE: 'true' })
+    const res = await proxy(request('/logo.png'))
+    expect(res.headers.get('location')).toBeNull()
+    expect(res.headers.get(HSTS)).toBe('max-age=63072000')
+  })
+
+  it('allows /admin with a session cookie (no redirect) and sets HSTS', async () => {
+    const proxy = await loadProxy({ PRIVATE_INSTANCE: 'true' })
+    const res = await proxy(
+      request('/admin', { cookie: 'authjs.session-token=x' }),
+    )
+    expect(res.headers.get('location')).toBeNull()
+    expect(res.headers.get(HSTS)).toBe('max-age=63072000')
+  })
+
+  it('passes an unlisted path through the final fallback with HSTS', async () => {
+    const proxy = await loadProxy({ PRIVATE_INSTANCE: 'true' })
+    const res = await proxy(request('/some-page'))
+    expect(res.headers.get('location')).toBeNull()
+    expect(res.headers.get(HSTS)).toBe('max-age=63072000')
+  })
+
+  it('serves a shared group link without a cookie and never redirects to signin', async () => {
+    // E2EE shared-group invariant: a group is protected by the key in the URL,
+    // so unauthenticated access to /groups/<id> must not bounce to signin.
+    const proxy = await loadProxy({ PRIVATE_INSTANCE: 'true' })
+    const res = await proxy(request('/groups/abc123'))
+    expect(res.headers.get('location')).toBeNull()
+    expect(res.headers.get(HSTS)).toBe('max-age=63072000')
+  })
+})
+
+describe('withSecurityHeaders', () => {
+  it('preserves Set-Cookie, status and Location while adding HSTS', async () => {
+    const { withSecurityHeaders } = await loadProxyModule({})
+    const res = NextResponse.redirect(new URL('http://localhost/x'))
+    res.cookies.set('foo', 'bar')
+    const out = withSecurityHeaders(res)
+    expect(out.status).toBe(307)
+    expect(out.headers.get('location')).toBe('http://localhost/x')
+    expect(out.headers.get('set-cookie')).toMatch(/foo=bar/)
+    expect(out.headers.get(HSTS)).toBe('max-age=63072000')
   })
 })

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -27,10 +27,11 @@ const sharedRoutes = ['/groups/'] // Group pages can be accessed via shared link
 const adminRoutes = ['/admin']
 
 // HSTS is emitted at runtime (not baked into next build) so container.env /
-// platform env vars control it. Computed once at module load; an invalid
-// HSTS_* value throws here (and, guaranteed at boot, in instrumentation.ts).
-// See src/lib/hsts.ts for the env contract.
-const hstsHeader = buildHstsHeader()
+// platform env vars control it. The header value (or null when disabled) is
+// computed once at module load; an invalid HSTS_* value throws here (and,
+// guaranteed at boot, in instrumentation.ts). See src/lib/hsts.ts for the env
+// contract.
+const hstsHeaderValue = buildHstsHeader()
 
 /**
  * Attach runtime security headers (currently HSTS) to a response, mutating it
@@ -40,14 +41,20 @@ const hstsHeader = buildHstsHeader()
  * _next/image, favicon.ico) do not receive these headers, which is fine for
  * HSTS since the browser records the policy from any single response.
  */
-function finalize(response: NextResponse): NextResponse {
-  if (hstsHeader) {
-    response.headers.set(hstsHeader.key, hstsHeader.value)
+export function withSecurityHeaders(response: NextResponse): NextResponse {
+  if (hstsHeaderValue) {
+    response.headers.set('Strict-Transport-Security', hstsHeaderValue)
   }
   return response
 }
 
-export async function proxy(request: NextRequest) {
+/**
+ * Resolve the routing decision for a request and return a bare (unwrapped)
+ * response. It stays out of withSecurityHeaders on purpose: proxy() is the
+ * single exit point that adds security headers, so every branch here must
+ * simply return a NextResponse and new branches belong in this function.
+ */
+function route(request: NextRequest): NextResponse {
   const { pathname } = request.nextUrl
 
   // Check if private instance mode is enabled
@@ -56,15 +63,17 @@ export async function proxy(request: NextRequest) {
   if (!isPrivateInstance) {
     // Public instance - block auth pages (they require SessionProvider)
     if (pathname.startsWith('/auth/') || pathname.startsWith('/admin')) {
-      return finalize(NextResponse.redirect(new URL('/', request.url)))
+      return NextResponse.redirect(new URL('/', request.url))
     }
-    return finalize(NextResponse.next())
+    return NextResponse.next()
   }
 
   // Check if this is a public route
-  const isPublicRoute = publicRoutes.some((route) => pathname.startsWith(route))
+  const isPublicRoute = publicRoutes.some((prefix) =>
+    pathname.startsWith(prefix),
+  )
   if (isPublicRoute) {
-    return finalize(NextResponse.next())
+    return NextResponse.next()
   }
 
   // Get session token from cookies
@@ -76,15 +85,17 @@ export async function proxy(request: NextRequest) {
   if (pathname === '/groups/create' && !sessionToken) {
     const signInUrl = new URL('/auth/signin', request.url)
     signInUrl.searchParams.set('callbackUrl', pathname)
-    return finalize(NextResponse.redirect(signInUrl))
+    return NextResponse.redirect(signInUrl)
   }
 
   // Check if this is a shared group route (allow access without auth)
-  const isSharedRoute = sharedRoutes.some((route) => pathname.startsWith(route))
+  const isSharedRoute = sharedRoutes.some((prefix) =>
+    pathname.startsWith(prefix),
+  )
   if (isSharedRoute) {
     // Allow shared group access without authentication
     // The group itself is protected by the encryption key in the URL
-    return finalize(NextResponse.next())
+    return NextResponse.next()
   }
 
   // Check if this is a static file or API route that should be public
@@ -97,24 +108,30 @@ export async function proxy(request: NextRequest) {
     pathname.endsWith('.ico') ||
     pathname.endsWith('.svg')
   ) {
-    return finalize(NextResponse.next())
+    return NextResponse.next()
   }
 
   // Check admin routes - require session token
-  if (adminRoutes.some((route) => pathname.startsWith(route))) {
+  if (adminRoutes.some((prefix) => pathname.startsWith(prefix))) {
     if (!sessionToken) {
       const signInUrl = new URL('/auth/signin', request.url)
       signInUrl.searchParams.set('callbackUrl', pathname)
-      return finalize(NextResponse.redirect(signInUrl))
+      return NextResponse.redirect(signInUrl)
     }
     // Admin role (isAdmin) is verified in:
     // - Page component: src/app/admin/page.tsx (auth() + isAdmin check)
     // - API layer: src/app/api/admin/*/route.ts (session.user.isAdmin check)
     // JWT decoding in proxy is avoided to prevent NextAuth internal dependency
-    return finalize(NextResponse.next())
+    return NextResponse.next()
   }
 
-  return finalize(NextResponse.next())
+  return NextResponse.next()
+}
+
+// Every response must leave through withSecurityHeaders; add new branches
+// inside route() only.
+export async function proxy(request: NextRequest) {
+  return withSecurityHeaders(route(request))
 }
 
 export const config = {


### PR DESCRIPTION
## 背景

merge 済み PR #240 / #241 の実装に対する事後レビュー(多角レンズ + 反証検証、および独立レビュー)で確定した follow-up をまとめて修正する。暗号・認可に関わる Critical/High の欠陥は見つかっておらず、本 PR は契約整合・回帰防止・多層防御・ドキュメント精度の改善が中心。

## 変更点

### fix(security): HSTS env の無条件検証 + proxy 単一出口化 (`9685b5b`)
- `buildHstsHeader` が 3 つの `HSTS_*` 変数を enabled 判定**前に**すべて検証。`HSTS_ENABLED=false` が不正な `HSTS_MAX_AGE` 等を隠し、再有効化時に突然起動失敗する事態を排除(文書化済みの fail-loudly 契約に一致)
- boolean env パーサを `env-bool.ts` に集約: 共有トークンリスト + 厳格版 `parseStrictEnvBool`(unknown → throw)。`PRIVATE_INSTANCE` が使う lenient な `interpretEnvVarAsBool` の挙動は**不変**
- `buildHstsHeader` の戻り値を `{key,value}` → `string | null` に簡素化(next.config 時代の形の名残を除去)
- proxy の全応答が単一の `withSecurityHeaders()` 出口を通る構造に変更(内部 `route()` に分岐を集約)。将来の分岐追加でヘッダ付与が漏れない構造的保証
- テスト: `route()` 全分岐の網羅(**private instance の共有リンク素通し=E2EE 不変条件を実物の `proxy()` で初めて検証**)、Set-Cookie/status/Location 保全、ambient env に汚染されない invalid 系、`env-bool` 専用スイート

### fix: reimbursement prefill の one-shot 化 + client-only ガード (`ed757b1`)
- create フォームが mount 後の effect で prefill entry を削除 → 後続の同一 from/to 遷移で古い金額が再出現しない(読み取りは render 中の defaultValues で行われるため純粋のまま維持。render 中削除は StrictMode の二重 render で壊れる)
- `setReimbursementAmount` はサーバ側で no-op(サーバで書けばプロセス内全リクエストに平文金額が共有されるため)
- キーを `JSON.stringify` タプル化(id 内の区切り文字で衝突しない)
- 制約コメント: legacy な `?amount=` deep-link 読み取りに「クライアント由来(復号済み)金額を載せてはならない」、ハードリロードで 0 に戻るのは設計上のトレードオフ
- 新規 `ReimbursementList` テストが #234 の不変条件(push URL に `amount=` が無い + 金額は in-memory store 経由)を固定

### fix: callbackUrl fallback の検証 + share rejection の無ログ化 (`b20239b`)
- `sanitizeCallbackUrl` が fallback 引数にも同一ルールを適用(fallback 経由の絶対 URL 混入を構造的に排除、不正 fallback は `/` に縮退)
- signin ページも sanitizer を使用(Auth.js がサーバ側で origin-lock 済みのため多層防御・verify-2fa ページとの一貫性目的)
- `navigator.share()` の rejection(ユーザーキャンセル等)を payload 非ログで握りつぶし(URL fragment に暗号鍵が含まれるため)

### docs,ci: HSTS env の文書化 + docker-smoke-build の主張適正化 (`c1602a4`)
- `HSTS_*` を README / `.env.example` にも記載(従来 `container.env.example` のみで、Vercel・ローカル経路から不可視だった)
- `container.env.example`: 素の `up -d`/`restart` では env_file 変更が反映されない場合がある → `--force-recreate` を明示。env-file パーサがインラインコメントを保持する危険、無条件検証の注記
- `ci.yml`: docker-smoke-build のコメントから「リリースと同一」の過大主張を除去(実際は amd64 単一。arm64+QEMU は cd.yml のみ)。`needs:` 非設定が意図的である旨を明記

### レビュー反映 (`5509d56`, `2b21d56`)
- `5509d56` — 衝突テストを旧 `:` join で確実に fail する組へ是正 / SSR setter no-op の node 環境テスト新設 / README の HSTS 値行から inline comment を除去(bare value ガイダンスと整合)
- `2b21d56` — **P2 修正**: Auth.js が標準導線で渡す同一 origin 絶対 URL を path+query+hash へ縮約してから既存パスルールを再適用(origin 完全一致要求、`//` pathname の再検証、SSR は fail-closed)。cross-origin 拒否・同一 origin 保持・server fail-closed をテストで固定

## 検証

- jest: 46 suites / 577 passed(skip 1 は既存)
- `tsc --noEmit`: エラー 0
- `eslint .`: エラー 0(警告 11 は全て既存、本 PR での増加なし)
- `prettier -c src`: クリーン
- `next build`(Turbopack): 成功(Proxy として認識)
- podman による Docker イメージビルド: ローカル実行(結果は PR コメント参照)

## 意図的に対応しないもの

- matcher 除外アセット(`_next/static` 等)への HSTS 非付与 — `proxy.ts` にコメント済みの許容事項(ブラウザは任意の 1 応答でポリシーを記録する)
- 非 TLS transport 上での HSTS 送出(RFC 6797 §7.2 からの逸脱)— TLS 終端リバースプロキシ配下では意図した挙動のため許容(`X-Forwarded-Proto` への信頼設計は別論点)
- `HSTS_INCLUDE_SUBDOMAINS` の実環境整合検証 — アプリからサブドメイン構成は観測不能。ドキュメントの警告で対応
- docker-smoke-build への arm64/QEMU 追加 — CI コスト過大。コメントで限界を明示する方針
- `PRIVATE_INSTANCE` の fail-open 解釈の変更 — 認可ゲートの意味論変更になるため本 PR のスコープ外
- E2E テスト — 別課題

## 関連

- レビュー元: PR #240 / #241(いずれも merge 済み)
- 2FA リダイレクトで URL fragment(暗号鍵)が失われる既存の統合ギャップは本 PR のスコープ外(別 issue / 別 PR 予定)
