### PR TITLE
fix(security): harden private-instance auth gates and admin transitions

### DIFF
--- a/src/__tests__/admin-whitelist-reset.test.ts
+++ b/src/__tests__/admin-whitelist-reset.test.ts
@@ -36,9 +36,20 @@ jest.mock('bcryptjs', () => ({
   },
 }))
 
+// The PATCH route now applies the per-admin operation rate limit, so mock the
+// limiter (mirrors admin-whitelist-validation.test.ts). This also avoids
+// loading the real module, whose module-level cleanup setInterval would keep
+// the Jest worker's event loop alive.
+jest.mock('@/lib/rate-limit', () => ({
+  __esModule: true,
+  checkOperationRateLimit: jest.fn(() => ({ isLimited: false })),
+  recordOperationAttempt: jest.fn(),
+}))
+
 import { PATCH } from '@/app/api/admin/whitelist/[userId]/route'
 import { auth, generateInitialPassword, isPrivateInstance } from '@/lib/auth'
 import { prisma } from '@/lib/prisma'
+import { checkOperationRateLimit } from '@/lib/rate-limit'
 import bcrypt from 'bcryptjs'
 
 // MockedFunction<typeof X> chokes on NextAuth's overloaded `auth` and on
@@ -52,6 +63,7 @@ const mockBcryptHash = bcrypt.hash as unknown as jest.Mock
 const mockWhitelistFindUnique = prisma.whitelistUser
   .findUnique as unknown as jest.Mock
 const mockWhitelistUpdate = prisma.whitelistUser.update as unknown as jest.Mock
+const mockCheckRateLimit = checkOperationRateLimit as unknown as jest.Mock
 
 type SessionUser = {
   id: string
@@ -100,6 +112,8 @@ function setupValidSession(overrides: Partial<SessionUser> = {}) {
   // `jest.resetAllMocks()` in beforeEach wipes the mock's initial impl,
   // so re-establish the fixed return value per test for stability.
   mockGenerateInitialPassword.mockReturnValue('A'.repeat(20))
+  // Not rate-limited by default so the route reaches the DB work.
+  mockCheckRateLimit.mockReturnValue({ isLimited: false })
 }
 
 beforeEach(() => {
@@ -195,11 +209,14 @@ describe('PATCH /api/admin/whitelist/[userId] — success contract', () => {
     // The latter ensures the user is forced through the change-password
     // flow on next login — a regression here would let a reset user log
     // in indefinitely without changing the admin-issued password.
+    // 5. `passwordChangedAt` is stamped so the reset invalidates the
+    // target's pre-existing JWTs via the iat acceptance check (Issue #135).
     expect(mockWhitelistUpdate).toHaveBeenCalledWith({
       where: { id: TARGET_USER_ID },
       data: {
         password: HASHED_PWD,
         mustChangePassword: true,
+        passwordChangedAt: expect.any(Date),
       },
     })
     expect(mockGenerateInitialPassword).toHaveBeenCalledTimes(1)

--- a/src/__tests__/admin-whitelist-reset.test.ts
+++ b/src/__tests__/admin-whitelist-reset.test.ts
@@ -37,9 +37,8 @@ jest.mock('bcryptjs', () => ({
 }))
 
 // The PATCH route now applies the per-admin operation rate limit, so mock the
-// limiter (mirrors admin-whitelist-validation.test.ts). This also avoids
-// loading the real module, whose module-level cleanup setInterval would keep
-// the Jest worker's event loop alive.
+// limiter (mirrors admin-whitelist-validation.test.ts) to keep these tests
+// isolated from the real limiter's shared in-memory state.
 jest.mock('@/lib/rate-limit', () => ({
   __esModule: true,
   checkOperationRateLimit: jest.fn(() => ({ isLimited: false })),

--- a/src/app/admin/page.test.tsx
+++ b/src/app/admin/page.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Server-side gate tests for the admin dashboard (auth-gate hardening).
+ *
+ * The client TwoFactorGuard / PasswordChangeGuard only run after hydration,
+ * so AdminPage must enforce the 2FA / password-change gates server-side
+ * BEFORE any Prisma query, or the initial payload would leak serialized
+ * admin / whitelist emails. `redirect()` throws NEXT_REDIRECT in Next.js;
+ * the mock below reproduces that so we can assert the queries never run.
+ */
+
+jest.mock('@/lib/auth', () => ({
+  auth: jest.fn(),
+  isPrivateInstance: jest.fn(() => true),
+}))
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    group: { count: jest.fn() },
+    admin: {
+      count: jest.fn(),
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+    },
+    whitelistUser: {
+      count: jest.fn(),
+      findMany: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('next/navigation', () => ({
+  redirect: jest.fn((url: string) => {
+    throw new Error(`NEXT_REDIRECT:${url}`)
+  }),
+}))
+
+jest.mock('./admin-dashboard', () => ({
+  AdminDashboard: () => null,
+}))
+
+import { auth } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import { redirect } from 'next/navigation'
+import AdminPage from './page'
+
+const mockedAuth = auth as jest.MockedFunction<typeof auth>
+const mockedRedirect = redirect as jest.MockedFunction<typeof redirect>
+const mockedPrisma = prisma as unknown as {
+  group: { count: jest.Mock }
+  admin: { count: jest.Mock; findMany: jest.Mock; findUnique: jest.Mock }
+  whitelistUser: { count: jest.Mock; findMany: jest.Mock }
+}
+
+function makeSession({
+  isAdmin = true,
+  requiresTwoFactor = false,
+  mustChangePassword = false,
+}: {
+  isAdmin?: boolean
+  requiresTwoFactor?: boolean
+  mustChangePassword?: boolean
+} = {}) {
+  return {
+    user: {
+      id: 'a1',
+      email: 'admin@example.com',
+      isAdmin,
+      mustChangePassword,
+      twoFactorEnabled: true,
+      requiresTwoFactor,
+    },
+    expires: '2099-01-01T00:00:00.000Z',
+  } as never
+}
+
+function expectNoDataQueried() {
+  expect(mockedPrisma.group.count).not.toHaveBeenCalled()
+  expect(mockedPrisma.admin.count).not.toHaveBeenCalled()
+  expect(mockedPrisma.whitelistUser.count).not.toHaveBeenCalled()
+  expect(mockedPrisma.admin.findMany).not.toHaveBeenCalled()
+  expect(mockedPrisma.whitelistUser.findMany).not.toHaveBeenCalled()
+  expect(mockedPrisma.admin.findUnique).not.toHaveBeenCalled()
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('AdminPage server-side auth gates', () => {
+  it('redirects to 2FA (before password change) and queries nothing when both are pending', async () => {
+    mockedAuth.mockResolvedValue(
+      makeSession({ requiresTwoFactor: true, mustChangePassword: true }),
+    )
+
+    await expect(AdminPage()).rejects.toThrow(
+      'NEXT_REDIRECT:/auth/verify-2fa?callbackUrl=/admin',
+    )
+    expect(mockedRedirect).toHaveBeenCalledWith(
+      '/auth/verify-2fa?callbackUrl=/admin',
+    )
+    expectNoDataQueried()
+  })
+
+  it('redirects to change-password when only a password change is pending', async () => {
+    mockedAuth.mockResolvedValue(makeSession({ mustChangePassword: true }))
+
+    await expect(AdminPage()).rejects.toThrow(
+      'NEXT_REDIRECT:/auth/change-password',
+    )
+    expect(mockedRedirect).toHaveBeenCalledWith('/auth/change-password')
+    expectNoDataQueried()
+  })
+
+  it('queries the dashboard data only after both gates pass', async () => {
+    mockedAuth.mockResolvedValue(makeSession())
+    mockedPrisma.group.count.mockResolvedValue(0)
+    mockedPrisma.admin.count.mockResolvedValue(0)
+    mockedPrisma.whitelistUser.count.mockResolvedValue(0)
+    mockedPrisma.admin.findMany.mockResolvedValue([])
+    mockedPrisma.admin.findUnique.mockResolvedValue({ twoFactorEnabled: true })
+    mockedPrisma.whitelistUser.findMany.mockResolvedValue([])
+
+    await AdminPage()
+
+    expect(mockedRedirect).not.toHaveBeenCalled()
+    expect(mockedPrisma.admin.findMany).toHaveBeenCalled()
+    expect(mockedPrisma.whitelistUser.findMany).toHaveBeenCalled()
+  })
+})

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -24,6 +24,20 @@ export default async function AdminPage() {
     redirect('/')
   }
 
+  // Enforce the 2FA / password-change gates server-side before any data is
+  // queried or serialized. The client TwoFactorGuard / PasswordChangeGuard
+  // only run after hydration, so without this an admin who has not cleared
+  // 2FA (or must change their password) would receive the serialized admin
+  // and whitelist emails in the initial payload. `redirect()` throws
+  // (NEXT_REDIRECT), short-circuiting before the Prisma queries below. 2FA is
+  // checked first to match the REST/tRPC ordering.
+  if (session.user.requiresTwoFactor) {
+    redirect('/auth/verify-2fa?callbackUrl=/admin')
+  }
+  if (session.user.mustChangePassword) {
+    redirect('/auth/change-password')
+  }
+
   // Get stats
   const [groupCount, adminCount, whitelistCount] = await Promise.all([
     prisma.group.count({ where: { deletedAt: null } }),

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -24,13 +24,14 @@ export default async function AdminPage() {
     redirect('/')
   }
 
-  // Enforce the 2FA / password-change gates server-side before any data is
-  // queried or serialized. The client TwoFactorGuard / PasswordChangeGuard
-  // only run after hydration, so without this an admin who has not cleared
-  // 2FA (or must change their password) would receive the serialized admin
-  // and whitelist emails in the initial payload. `redirect()` throws
-  // (NEXT_REDIRECT), short-circuiting before the Prisma queries below. 2FA is
-  // checked first to match the REST/tRPC ordering.
+  // Enforce the 2FA / password-change gates server-side before any dashboard
+  // data is queried or serialized. (`auth()` above already reads the session's
+  // security fields; this gate runs before the dashboard/stat/identity queries
+  // below.) The client TwoFactorGuard / PasswordChangeGuard only run after
+  // hydration, so without this an admin who has not cleared 2FA (or must change
+  // their password) would receive the serialized admin and whitelist emails in
+  // the initial payload. `redirect()` throws (NEXT_REDIRECT), short-circuiting
+  // before those queries. 2FA is checked first to match the REST/tRPC ordering.
   if (session.user.requiresTwoFactor) {
     redirect('/auth/verify-2fa?callbackUrl=/admin')
   }

--- a/src/app/api/admin/whitelist/[userId]/route.test.ts
+++ b/src/app/api/admin/whitelist/[userId]/route.test.ts
@@ -123,13 +123,36 @@ describe('PATCH /api/admin/whitelist/[userId] — password reset', () => {
       '2026-07-14T12:00:00.000Z',
     )
     // Success consumes exactly one slot, keyed by admin id with the reset
-    // prefix.
+    // prefix — CHECK and RECORD use the same key/limit/window.
     expect(mockedRecord).toHaveBeenCalledTimes(1)
     expect(mockedCheck).toHaveBeenCalledWith(
       'admin-whitelist-reset:a1',
       60,
       60 * 60 * 1000,
     )
+    expect(mockedRecord).toHaveBeenCalledWith(
+      'admin-whitelist-reset:a1',
+      60,
+      60 * 60 * 1000,
+    )
+    // The slot is reserved BEFORE any DB await, so a concurrent burst cannot
+    // all pass CHECK at a low count.
+    expect(mockedRecord.mock.invocationCallOrder[0]).toBeLessThan(
+      mockedPrisma.whitelistUser.findUnique.mock.invocationCallOrder[0],
+    )
+  })
+
+  it('consumes exactly one slot when the DB work throws (caught 500)', async () => {
+    mockedAuth.mockResolvedValue(makeSession())
+    mockedPrisma.whitelistUser.findUnique.mockResolvedValue({ id: 'w1' })
+    mockedPrisma.whitelistUser.update.mockRejectedValue(new Error('db down'))
+
+    const res = await PATCH(patchRequest(), params)
+
+    // The reservation already happened before the throwing update, so the
+    // caught 500 has consumed one slot.
+    expect(res.status).toBe(500)
+    expect(mockedRecord).toHaveBeenCalledTimes(1)
   })
 
   it('returns 429 with Retry-After and does not consume when rate limited', async () => {
@@ -204,5 +227,16 @@ describe('DELETE /api/admin/whitelist/[userId]', () => {
     expect(res.headers.get('Retry-After')).toBe('3600')
     expect(mockedRecord).not.toHaveBeenCalled()
     expect(mockedPrisma.whitelistUser.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('consumes a slot on 404 (user not found)', async () => {
+    mockedAuth.mockResolvedValue(makeSession())
+    mockedPrisma.whitelistUser.findUnique.mockResolvedValue(null)
+
+    const res = await DELETE(deleteRequest(), params)
+
+    expect(res.status).toBe(404)
+    expect(mockedRecord).toHaveBeenCalledTimes(1)
+    expect(mockedPrisma.whitelistUser.delete).not.toHaveBeenCalled()
   })
 })

--- a/src/app/api/admin/whitelist/[userId]/route.test.ts
+++ b/src/app/api/admin/whitelist/[userId]/route.test.ts
@@ -1,0 +1,208 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Route-level tests for the individual whitelist user API (auth-gate
+ * hardening).
+ *
+ * Covers:
+ *   - PATCH password reset stamps `passwordChangedAt` (invalidates prior
+ *     JWTs via the iat check, Issue #135) alongside password +
+ *     mustChangePassword.
+ *   - Per-admin operation rate limit on PATCH and DELETE: gate failures and
+ *     the 429 do NOT consume a slot; 404 and success each consume exactly
+ *     once; the key is prefixed per operation and keyed by the admin id.
+ */
+
+jest.mock('@/lib/auth', () => ({
+  auth: jest.fn(),
+  isPrivateInstance: jest.fn(() => true),
+  generateInitialPassword: jest.fn(() => 'INITIAL-PW'),
+}))
+
+jest.mock('@/lib/prisma', () => ({
+  prisma: {
+    whitelistUser: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+  },
+}))
+
+jest.mock('@/lib/rate-limit', () => ({
+  checkOperationRateLimit: jest.fn(() => ({ isLimited: false })),
+  recordOperationAttempt: jest.fn(),
+}))
+
+jest.mock('bcryptjs', () => ({
+  hash: jest.fn(() => Promise.resolve('hashed')),
+}))
+
+import { auth } from '@/lib/auth'
+import { prisma } from '@/lib/prisma'
+import {
+  checkOperationRateLimit,
+  recordOperationAttempt,
+} from '@/lib/rate-limit'
+import { DELETE, PATCH } from './route'
+
+const mockedAuth = auth as jest.MockedFunction<typeof auth>
+const mockedCheck = checkOperationRateLimit as jest.MockedFunction<
+  typeof checkOperationRateLimit
+>
+const mockedRecord = recordOperationAttempt as jest.MockedFunction<
+  typeof recordOperationAttempt
+>
+const mockedPrisma = prisma as unknown as {
+  whitelistUser: {
+    findUnique: jest.Mock
+    update: jest.Mock
+    delete: jest.Mock
+  }
+}
+
+function makeSession({
+  isAdmin = true,
+  id = 'a1',
+  requiresTwoFactor = false,
+  mustChangePassword = false,
+} = {}) {
+  return {
+    user: {
+      id,
+      email: 'admin@example.com',
+      isAdmin,
+      mustChangePassword,
+      twoFactorEnabled: true,
+      requiresTwoFactor,
+    },
+    expires: '2099-01-01T00:00:00.000Z',
+  } as never
+}
+
+function patchRequest() {
+  return new Request('http://localhost/api/admin/whitelist/w1', {
+    method: 'PATCH',
+  })
+}
+
+function deleteRequest() {
+  return new Request('http://localhost/api/admin/whitelist/w1', {
+    method: 'DELETE',
+  })
+}
+
+const params = { params: Promise.resolve({ userId: 'w1' }) }
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockedCheck.mockReturnValue({ isLimited: false })
+})
+
+afterEach(() => {
+  jest.useRealTimers()
+})
+
+describe('PATCH /api/admin/whitelist/[userId] — password reset', () => {
+  it('stamps passwordChangedAt alongside password + mustChangePassword', async () => {
+    jest.useFakeTimers().setSystemTime(new Date('2026-07-14T12:00:00.000Z'))
+    mockedAuth.mockResolvedValue(makeSession())
+    mockedPrisma.whitelistUser.findUnique.mockResolvedValue({ id: 'w1' })
+    mockedPrisma.whitelistUser.update.mockResolvedValue({ id: 'w1' })
+
+    const res = await PATCH(patchRequest(), params)
+
+    expect(res.status).toBe(200)
+    const data = mockedPrisma.whitelistUser.update.mock.calls[0][0].data
+    expect(data.password).toBe('hashed')
+    expect(data.mustChangePassword).toBe(true)
+    expect(data.passwordChangedAt).toBeInstanceOf(Date)
+    expect(data.passwordChangedAt.toISOString()).toBe(
+      '2026-07-14T12:00:00.000Z',
+    )
+    // Success consumes exactly one slot, keyed by admin id with the reset
+    // prefix.
+    expect(mockedRecord).toHaveBeenCalledTimes(1)
+    expect(mockedCheck).toHaveBeenCalledWith(
+      'admin-whitelist-reset:a1',
+      60,
+      60 * 60 * 1000,
+    )
+  })
+
+  it('returns 429 with Retry-After and does not consume when rate limited', async () => {
+    mockedAuth.mockResolvedValue(makeSession())
+    mockedCheck.mockReturnValue({ isLimited: true, retryAfter: 3600 })
+
+    const res = await PATCH(patchRequest(), params)
+
+    expect(res.status).toBe(429)
+    expect(res.headers.get('Retry-After')).toBe('3600')
+    expect(mockedRecord).not.toHaveBeenCalled()
+    expect(mockedPrisma.whitelistUser.findUnique).not.toHaveBeenCalled()
+  })
+
+  it('consumes a slot on 404 (user not found)', async () => {
+    mockedAuth.mockResolvedValue(makeSession())
+    mockedPrisma.whitelistUser.findUnique.mockResolvedValue(null)
+
+    const res = await PATCH(patchRequest(), params)
+
+    expect(res.status).toBe(404)
+    expect(mockedRecord).toHaveBeenCalledTimes(1)
+    expect(mockedPrisma.whitelistUser.update).not.toHaveBeenCalled()
+  })
+
+  it('does not consume when the admin/id gate fails', async () => {
+    // Session with an admin flag but no `id` — the gate must 401 before the
+    // limiter so a `...undefined` shared bucket is never keyed.
+    mockedAuth.mockResolvedValue({
+      user: {
+        email: 'admin@example.com',
+        isAdmin: true,
+        mustChangePassword: false,
+        twoFactorEnabled: true,
+        requiresTwoFactor: false,
+      },
+      expires: '2099-01-01T00:00:00.000Z',
+    } as never)
+
+    const res = await PATCH(patchRequest(), params)
+
+    expect(res.status).toBe(401)
+    expect(mockedCheck).not.toHaveBeenCalled()
+    expect(mockedRecord).not.toHaveBeenCalled()
+  })
+})
+
+describe('DELETE /api/admin/whitelist/[userId]', () => {
+  it('consumes one slot on success, keyed with the delete prefix', async () => {
+    mockedAuth.mockResolvedValue(makeSession())
+    mockedPrisma.whitelistUser.findUnique.mockResolvedValue({ id: 'w1' })
+    mockedPrisma.whitelistUser.delete.mockResolvedValue({ id: 'w1' })
+
+    const res = await DELETE(deleteRequest(), params)
+
+    expect(res.status).toBe(200)
+    expect(mockedRecord).toHaveBeenCalledTimes(1)
+    expect(mockedCheck).toHaveBeenCalledWith(
+      'admin-whitelist-delete:a1',
+      60,
+      60 * 60 * 1000,
+    )
+  })
+
+  it('returns 429 with Retry-After and does not consume when rate limited', async () => {
+    mockedAuth.mockResolvedValue(makeSession())
+    mockedCheck.mockReturnValue({ isLimited: true, retryAfter: 3600 })
+
+    const res = await DELETE(deleteRequest(), params)
+
+    expect(res.status).toBe(429)
+    expect(res.headers.get('Retry-After')).toBe('3600')
+    expect(mockedRecord).not.toHaveBeenCalled()
+    expect(mockedPrisma.whitelistUser.findUnique).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/admin/whitelist/[userId]/route.ts
+++ b/src/app/api/admin/whitelist/[userId]/route.ts
@@ -8,12 +8,13 @@
  * guarantee on multi-instance / Vercel deployments.
  *
  * Rate-limit policy (mirrors POST): the pre-auth gates (private-instance,
- * session/admin+id, 2FA, password-change) and the CHECK itself never touch
- * the limiter, so a third party cannot be locked out by failed requests.
- * Once CHECK passes the slot is reserved synchronously — before any await —
- * so a concurrent burst cannot all observe `count<MAX` and bypass the cap.
- * Every subsequent outcome (404 not-found, success, internal 500) has
- * therefore already consumed one attempt.
+ * session/admin+id, 2FA, password-change) and the CHECK itself do not consume
+ * an attempt (CHECK reads the counter but reserves nothing), so a third party
+ * cannot be locked out by failed requests. Once CHECK passes the slot is
+ * reserved synchronously — before the DB/bcrypt work below — so a concurrent
+ * burst cannot all observe `count<MAX` and bypass the cap. Every outcome after
+ * that reservation (404 not-found, success, internal 500 from the DB/bcrypt
+ * work) has therefore already consumed one attempt.
  */
 
 import { auth, generateInitialPassword, isPrivateInstance } from '@/lib/auth'
@@ -67,8 +68,9 @@ export async function PATCH(
   const pwChangeResp = passwordChangeRequiredResponse(session)
   if (pwChangeResp) return pwChangeResp
 
-  // 5. Rate-limit CHECK keyed by the admin subject. Gates 1-4 do not touch
-  //    the limiter so a third party cannot be locked out via failed requests.
+  // 5. Rate-limit CHECK keyed by the admin subject. Gates 1-4 and this CHECK
+  //    do not consume an attempt, so a third party cannot be locked out via
+  //    failed requests.
   const rateLimitKey = `${RESET_RATE_LIMIT_PREFIX}${session.user.id}`
   const limit = checkOperationRateLimit(
     rateLimitKey,
@@ -111,9 +113,13 @@ export async function PATCH(
 
     // Update user with new password. `passwordChangedAt` is bumped so
     // pre-existing JWTs are rejected by the iat acceptance check (Issue #135).
-    // This is not a race-free revocation guarantee: iat is second-granular
-    // while passwordChangedAt is millisecond, so a same-second concurrent
-    // login can retain a residual valid token.
+    // This is NOT a race-free revocation and it cuts both ways:
+    //  - iat is second-granular while passwordChangedAt is millisecond, so a
+    //    legitimate token minted in the same wall-clock second as the reset
+    //    (iat <= passwordChangedAt) is also rejected — a rare transient logout.
+    //  - a login whose authorize() started before this write (TOCTOU) can
+    //    still mint a token that survives, since its iat may land after
+    //    passwordChangedAt.
     await prisma.whitelistUser.update({
       where: { id: userId },
       data: {
@@ -160,8 +166,9 @@ export async function DELETE(
   const pwChangeResp = passwordChangeRequiredResponse(session)
   if (pwChangeResp) return pwChangeResp
 
-  // 5. Rate-limit CHECK keyed by the admin subject. Gates 1-4 do not touch
-  //    the limiter so a third party cannot be locked out via failed requests.
+  // 5. Rate-limit CHECK keyed by the admin subject. Gates 1-4 and this CHECK
+  //    do not consume an attempt, so a third party cannot be locked out via
+  //    failed requests.
   const rateLimitKey = `${DELETE_RATE_LIMIT_PREFIX}${session.user.id}`
   const limit = checkOperationRateLimit(
     rateLimitKey,

--- a/src/app/api/admin/whitelist/[userId]/route.ts
+++ b/src/app/api/admin/whitelist/[userId]/route.ts
@@ -1,5 +1,19 @@
 /**
  * Individual Whitelist User API (Issue #4)
+ *
+ * PATCH (password reset) and DELETE each carry a per-admin operation rate
+ * limit (60/h) keyed by the JWT subject (`session.user.id`), mirroring the
+ * POST route in `../route.ts`. The limiter is the process-local in-memory
+ * limiter from Issue #78: best-effort only, NOT a cross-instance 60/h
+ * guarantee on multi-instance / Vercel deployments.
+ *
+ * Rate-limit policy (mirrors POST): the pre-auth gates (private-instance,
+ * session/admin+id, 2FA, password-change) and the CHECK itself never touch
+ * the limiter, so a third party cannot be locked out by failed requests.
+ * Once CHECK passes the slot is reserved synchronously — before any await —
+ * so a concurrent burst cannot all observe `count<MAX` and bypass the cap.
+ * Every subsequent outcome (404 not-found, success, internal 500) has
+ * therefore already consumed one attempt.
  */
 
 import { auth, generateInitialPassword, isPrivateInstance } from '@/lib/auth'
@@ -8,8 +22,20 @@ import {
   requiresTwoFactorResponse,
 } from '@/lib/auth-helpers'
 import { prisma } from '@/lib/prisma'
+import {
+  checkOperationRateLimit,
+  recordOperationAttempt,
+} from '@/lib/rate-limit'
 import bcrypt from 'bcryptjs'
 import { NextResponse } from 'next/server'
+
+const RATE_LIMIT_MAX = 60
+const RATE_LIMIT_WINDOW_MS = 60 * 60 * 1000 // 1 hour
+// Distinct, non-colliding prefixes so reset and delete keep independent
+// per-admin budgets. The full key is `${PREFIX}${session.user.id}` — keyed
+// by the authenticated admin subject, not by the target userId.
+const RESET_RATE_LIMIT_PREFIX = 'admin-whitelist-reset:'
+const DELETE_RATE_LIMIT_PREFIX = 'admin-whitelist-delete:'
 
 /**
  * Reset password for a whitelist user
@@ -18,28 +44,57 @@ export async function PATCH(
   request: Request,
   { params }: { params: Promise<{ userId: string }> },
 ) {
+  // 1. Private-instance gate.
+  if (!isPrivateInstance()) {
+    return NextResponse.json(
+      { error: 'Private instance mode is not enabled' },
+      { status: 400 },
+    )
+  }
+
+  // 2. Session + admin gate. Requiring `id` avoids a `...undefined` shared
+  //    rate-limit bucket.
+  const session = await auth()
+  if (!session?.user?.isAdmin || !session.user.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // 3. 2FA gate (mirrors tRPC publicProcedure / adminProcedure ordering).
+  const twoFaResp = requiresTwoFactorResponse(session)
+  if (twoFaResp) return twoFaResp
+
+  // 4. Password-change gate.
+  const pwChangeResp = passwordChangeRequiredResponse(session)
+  if (pwChangeResp) return pwChangeResp
+
+  // 5. Rate-limit CHECK keyed by the admin subject. Gates 1-4 do not touch
+  //    the limiter so a third party cannot be locked out via failed requests.
+  const rateLimitKey = `${RESET_RATE_LIMIT_PREFIX}${session.user.id}`
+  const limit = checkOperationRateLimit(
+    rateLimitKey,
+    RATE_LIMIT_MAX,
+    RATE_LIMIT_WINDOW_MS,
+  )
+  if (limit.isLimited) {
+    return NextResponse.json(
+      { error: 'Too many requests', retryAfter: limit.retryAfter },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(
+            limit.retryAfter || RATE_LIMIT_WINDOW_MS / 1000,
+          ),
+        },
+      },
+    )
+  }
+
+  // Reserve the limiter slot synchronously, before any await, so a concurrent
+  // burst cannot all pass CHECK at low counts and bypass the cap.
+  recordOperationAttempt(rateLimitKey, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS)
+
   try {
     const { userId } = await params
-
-    // Check if private instance mode is enabled
-    if (!isPrivateInstance()) {
-      return NextResponse.json(
-        { error: 'Private instance mode is not enabled' },
-        { status: 400 },
-      )
-    }
-
-    // Check authentication
-    const session = await auth()
-    if (!session?.user?.isAdmin) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
-    const twoFaResp = requiresTwoFactorResponse(session)
-    if (twoFaResp) return twoFaResp
-
-    const pwChangeResp = passwordChangeRequiredResponse(session)
-    if (pwChangeResp) return pwChangeResp
 
     // Check if user exists
     const user = await prisma.whitelistUser.findUnique({
@@ -54,12 +109,17 @@ export async function PATCH(
     const initialPassword = generateInitialPassword()
     const hashedPassword = await bcrypt.hash(initialPassword, 12)
 
-    // Update user with new password
+    // Update user with new password. `passwordChangedAt` is bumped so
+    // pre-existing JWTs are rejected by the iat acceptance check (Issue #135).
+    // This is not a race-free revocation guarantee: iat is second-granular
+    // while passwordChangedAt is millisecond, so a same-second concurrent
+    // login can retain a residual valid token.
     await prisma.whitelistUser.update({
       where: { id: userId },
       data: {
         password: hashedPassword,
         mustChangePassword: true,
+        passwordChangedAt: new Date(),
       },
     })
 
@@ -77,28 +137,57 @@ export async function DELETE(
   request: Request,
   { params }: { params: Promise<{ userId: string }> },
 ) {
+  // 1. Private-instance gate.
+  if (!isPrivateInstance()) {
+    return NextResponse.json(
+      { error: 'Private instance mode is not enabled' },
+      { status: 400 },
+    )
+  }
+
+  // 2. Session + admin gate. Requiring `id` avoids a `...undefined` shared
+  //    rate-limit bucket.
+  const session = await auth()
+  if (!session?.user?.isAdmin || !session.user.id) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+
+  // 3. 2FA gate (mirrors tRPC publicProcedure / adminProcedure ordering).
+  const twoFaResp = requiresTwoFactorResponse(session)
+  if (twoFaResp) return twoFaResp
+
+  // 4. Password-change gate.
+  const pwChangeResp = passwordChangeRequiredResponse(session)
+  if (pwChangeResp) return pwChangeResp
+
+  // 5. Rate-limit CHECK keyed by the admin subject. Gates 1-4 do not touch
+  //    the limiter so a third party cannot be locked out via failed requests.
+  const rateLimitKey = `${DELETE_RATE_LIMIT_PREFIX}${session.user.id}`
+  const limit = checkOperationRateLimit(
+    rateLimitKey,
+    RATE_LIMIT_MAX,
+    RATE_LIMIT_WINDOW_MS,
+  )
+  if (limit.isLimited) {
+    return NextResponse.json(
+      { error: 'Too many requests', retryAfter: limit.retryAfter },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': String(
+            limit.retryAfter || RATE_LIMIT_WINDOW_MS / 1000,
+          ),
+        },
+      },
+    )
+  }
+
+  // Reserve the limiter slot synchronously, before any await, so a concurrent
+  // burst cannot all pass CHECK at low counts and bypass the cap.
+  recordOperationAttempt(rateLimitKey, RATE_LIMIT_MAX, RATE_LIMIT_WINDOW_MS)
+
   try {
     const { userId } = await params
-
-    // Check if private instance mode is enabled
-    if (!isPrivateInstance()) {
-      return NextResponse.json(
-        { error: 'Private instance mode is not enabled' },
-        { status: 400 },
-      )
-    }
-
-    // Check authentication
-    const session = await auth()
-    if (!session?.user?.isAdmin) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
-    }
-
-    const twoFaResp = requiresTwoFactorResponse(session)
-    if (twoFaResp) return twoFaResp
-
-    const pwChangeResp = passwordChangeRequiredResponse(session)
-    if (pwChangeResp) return pwChangeResp
 
     // Check if user exists
     const user = await prisma.whitelistUser.findUnique({

--- a/src/app/api/admin/whitelist/[userId]/route.ts
+++ b/src/app/api/admin/whitelist/[userId]/route.ts
@@ -112,14 +112,17 @@ export async function PATCH(
     const hashedPassword = await bcrypt.hash(initialPassword, 12)
 
     // Update user with new password. `passwordChangedAt` is bumped so
-    // pre-existing JWTs are rejected by the iat acceptance check (Issue #135).
-    // This is NOT a race-free revocation and it cuts both ways:
+    // pre-existing JWTs are rejected by the iat acceptance check (Issue #135):
+    // a token is rejected when `tokenIatSeconds * 1000 < passwordChangedAt`
+    // (strict; an exact match is accepted — see isTokenIatAcceptable). This is
+    // NOT a race-free revocation and it cuts both ways:
     //  - iat is second-granular while passwordChangedAt is millisecond, so a
-    //    legitimate token minted in the same wall-clock second as the reset
-    //    (iat <= passwordChangedAt) is also rejected — a rare transient logout.
+    //    legitimate token minted later in the same wall-clock second as the
+    //    reset (its iat floors below passwordChangedAt's millisecond value) is
+    //    also rejected — a rare transient logout.
     //  - a login whose authorize() started before this write (TOCTOU) can
-    //    still mint a token that survives, since its iat may land after
-    //    passwordChangedAt.
+    //    still mint a token that survives, if its iat floors to a second at or
+    //    after passwordChangedAt.
     await prisma.whitelistUser.update({
       where: { id: userId },
       data: {

--- a/src/app/auth/verify-2fa/page.test.tsx
+++ b/src/app/auth/verify-2fa/page.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Auto-submit loop regression test for the 2FA verification page (auth-gate
+ * hardening).
+ *
+ * A fetch rejection (offline) previously left the token intact while
+ * `isLoading` flipped back to false, which re-triggered the auto-submit
+ * effect in an infinite loop. A ref records the last attempted token so the
+ * effect only fires for a not-yet-attempted token; manual submit bypasses
+ * the gate; editing the token re-enables auto-submit.
+ */
+
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+}))
+
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  useSearchParams: jest.fn(),
+}))
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode
+    href: string
+  }) => <a href={href}>{children}</a>,
+}))
+
+import Verify2FAPage from '@/app/auth/verify-2fa/page'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useSession } from 'next-auth/react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { StrictMode } from 'react'
+
+const mockedUseSession = useSession as jest.MockedFunction<typeof useSession>
+const mockedUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
+const mockedUseSearchParams = useSearchParams as jest.MockedFunction<
+  typeof useSearchParams
+>
+
+function setup2FASession() {
+  mockedUseRouter.mockReturnValue({ replace: jest.fn() } as never)
+  mockedUseSearchParams.mockReturnValue({ get: () => null } as never)
+  mockedUseSession.mockReturnValue({
+    data: {
+      user: { email: 'user@example.com', requiresTwoFactor: true },
+    },
+    status: 'authenticated',
+    update: jest.fn(() => Promise.resolve()),
+  } as never)
+}
+
+function rejectingFetch() {
+  const fetchMock = jest.fn(() => Promise.reject(new Error('offline')))
+  global.fetch = fetchMock as unknown as typeof fetch
+  return fetchMock
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  setup2FASession()
+})
+
+describe('Verify2FAPage auto-submit gating', () => {
+  it('auto-submits once, does not resubmit after a rejected fetch, then a manual click submits once more', async () => {
+    const fetchMock = rejectingFetch()
+    render(<Verify2FAPage />)
+
+    const input = screen.getByLabelText('verify.codeLabel') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '123456' } })
+
+    // Auto-submit fires exactly once.
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    // After the rejection, the input is retained and the button re-enables,
+    // but the effect does NOT auto-resubmit the same token.
+    const button = screen.getByRole('button', {
+      name: 'verify.submit',
+    }) as HTMLButtonElement
+    await waitFor(() => expect(button.disabled).toBe(false))
+    expect(input.value).toBe('123456')
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // A manual click submits exactly once more.
+    fireEvent.click(button)
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+  })
+
+  it('re-enables auto-submit after the user re-enters the same 6 digits', async () => {
+    const fetchMock = rejectingFetch()
+    render(<Verify2FAPage />)
+
+    const input = screen.getByLabelText('verify.codeLabel') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '123456' } })
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(input.disabled).toBe(false))
+
+    // Editing clears the ref; re-entering the same code retries.
+    fireEvent.change(input, { target: { value: '12345' } })
+    fireEvent.change(input, { target: { value: '123456' } })
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+  })
+
+  it('does not double-submit under StrictMode', async () => {
+    // A never-settling fetch keeps isLoading true so any StrictMode effect
+    // double-invoke would show up as a second call.
+    const fetchMock = jest.fn(() => new Promise<Response>(() => {}))
+    global.fetch = fetchMock as unknown as typeof fetch
+
+    render(
+      <StrictMode>
+        <Verify2FAPage />
+      </StrictMode>,
+    )
+
+    const input = screen.getByLabelText('verify.codeLabel') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '123456' } })
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/app/auth/verify-2fa/page.tsx
+++ b/src/app/auth/verify-2fa/page.tsx
@@ -25,7 +25,7 @@ import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 
 export default function Verify2FAPage() {
   const t = useTranslations('TwoFactorAuth')
@@ -38,6 +38,11 @@ export default function Verify2FAPage() {
   const [token, setToken] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+
+  // Last token handed to a submit attempt. Gates the auto-submit effect so a
+  // fetch rejection (e.g. offline) does not re-fire the same token in a loop
+  // once `isLoading` clears. Cleared on user edit so a re-typed code retries.
+  const lastAttemptedTokenRef = useRef<string | null>(null)
 
   // Redirect if user doesn't require 2FA verification
   useEffect(() => {
@@ -52,6 +57,9 @@ export default function Verify2FAPage() {
   // Handle token input - only allow digits and max 6 characters
   const handleTokenChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value.replace(/\D/g, '').slice(0, 6)
+    // User is editing: re-enable auto-submit so re-entering the same 6 digits
+    // retries.
+    lastAttemptedTokenRef.current = null
     setToken(value)
   }
 
@@ -66,6 +74,13 @@ export default function Verify2FAPage() {
         setError(t('verify.errors.invalidLength'))
         return
       }
+
+      // Record the attempted token synchronously before the request. The
+      // auto-submit effect will not re-fire while the ref still equals the
+      // current token, so a fetch rejection cannot loop. Setting it here (in
+      // both auto and manual paths) also makes a StrictMode double-invoke of
+      // the effect a no-op on the second call. Not cleared in catch/finally.
+      lastAttemptedTokenRef.current = token
 
       setIsLoading(true)
       setError(null)
@@ -104,9 +119,16 @@ export default function Verify2FAPage() {
     [token, session?.user?.email, t, update, router, callbackUrl],
   )
 
-  // Auto-submit when 6 digits are entered
+  // Auto-submit when 6 digits are entered. Gated on the ref so it fires only
+  // for a token that has not already been attempted (prevents the offline
+  // re-submit loop and StrictMode double-submit). Manual submit calls
+  // handleSubmit directly and bypasses this gate.
   useEffect(() => {
-    if (token.length === 6 && !isLoading) {
+    if (
+      token.length === 6 &&
+      !isLoading &&
+      lastAttemptedTokenRef.current !== token
+    ) {
       handleSubmit()
     }
   }, [token, isLoading, handleSubmit])

--- a/src/components/auth-guards-precedence.test.tsx
+++ b/src/components/auth-guards-precedence.test.tsx
@@ -101,6 +101,8 @@ describe('PasswordChangeGuard / TwoFactorGuard precedence', () => {
 
     // StrictMode may replay the effect, so the same-target push can repeat,
     // but the 2FA-first invariant must hold: change-password is never pushed.
+    // Assert a push actually happened so the checks below aren't vacuous.
+    expect(push).toHaveBeenCalled()
     expect(push).not.toHaveBeenCalledWith('/auth/change-password')
     for (const call of push.mock.calls) {
       expect(String(call[0])).toContain('/auth/verify-2fa')

--- a/src/components/auth-guards-precedence.test.tsx
+++ b/src/components/auth-guards-precedence.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Precedence test for the two auth guards mounted together in the root
+ * layout (auth-gate hardening). When a session has both requiresTwoFactor
+ * and mustChangePassword set, PasswordChangeGuard must defer to
+ * TwoFactorGuard so exactly one navigation happens (to 2FA) rather than
+ * both guards pushing simultaneously.
+ */
+
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  usePathname: jest.fn(),
+}))
+
+import { PasswordChangeGuard } from '@/components/password-change-guard'
+import { TwoFactorGuard } from '@/components/two-factor-guard'
+import { render } from '@testing-library/react'
+import { useSession } from 'next-auth/react'
+import { usePathname, useRouter } from 'next/navigation'
+
+const mockedUseSession = useSession as jest.MockedFunction<typeof useSession>
+const mockedUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
+const mockedUsePathname = usePathname as jest.MockedFunction<typeof usePathname>
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('PasswordChangeGuard / TwoFactorGuard precedence', () => {
+  it('pushes only to 2FA when both requiresTwoFactor and mustChangePassword are set', () => {
+    const push = jest.fn()
+    mockedUseRouter.mockReturnValue({ push } as never)
+    mockedUsePathname.mockReturnValue('/dashboard')
+    mockedUseSession.mockReturnValue({
+      data: {
+        user: { requiresTwoFactor: true, mustChangePassword: true },
+      },
+      status: 'authenticated',
+    } as never)
+
+    // Mount order mirrors layout.tsx: PasswordChangeGuard outside,
+    // TwoFactorGuard inside.
+    render(
+      <PasswordChangeGuard enabled>
+        <TwoFactorGuard enabled>
+          <div>content</div>
+        </TwoFactorGuard>
+      </PasswordChangeGuard>,
+    )
+
+    expect(push).toHaveBeenCalledTimes(1)
+    expect(push).toHaveBeenCalledWith(
+      expect.stringContaining('/auth/verify-2fa'),
+    )
+    expect(push).not.toHaveBeenCalledWith('/auth/change-password')
+  })
+})

--- a/src/components/auth-guards-precedence.test.tsx
+++ b/src/components/auth-guards-precedence.test.tsx
@@ -24,10 +24,39 @@ import { TwoFactorGuard } from '@/components/two-factor-guard'
 import { render } from '@testing-library/react'
 import { useSession } from 'next-auth/react'
 import { usePathname, useRouter } from 'next/navigation'
+import { StrictMode } from 'react'
 
 const mockedUseSession = useSession as jest.MockedFunction<typeof useSession>
 const mockedUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
 const mockedUsePathname = usePathname as jest.MockedFunction<typeof usePathname>
+
+function setup(user: {
+  requiresTwoFactor?: boolean
+  mustChangePassword?: boolean
+}) {
+  const push = jest.fn()
+  mockedUseRouter.mockReturnValue({ push } as never)
+  mockedUsePathname.mockReturnValue('/dashboard')
+  mockedUseSession.mockReturnValue({
+    data: { user },
+    status: 'authenticated',
+  } as never)
+  return push
+}
+
+// Mount order mirrors layout.tsx: PasswordChangeGuard outside, TwoFactorGuard
+// inside. Both guards mount together and run their redirect effects.
+function renderGuards(wrapper: (node: React.ReactNode) => React.ReactElement) {
+  render(
+    wrapper(
+      <PasswordChangeGuard enabled>
+        <TwoFactorGuard enabled>
+          <div>content</div>
+        </TwoFactorGuard>
+      </PasswordChangeGuard>,
+    ),
+  )
+}
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -35,30 +64,46 @@ beforeEach(() => {
 
 describe('PasswordChangeGuard / TwoFactorGuard precedence', () => {
   it('pushes only to 2FA when both requiresTwoFactor and mustChangePassword are set', () => {
-    const push = jest.fn()
-    mockedUseRouter.mockReturnValue({ push } as never)
-    mockedUsePathname.mockReturnValue('/dashboard')
-    mockedUseSession.mockReturnValue({
-      data: {
-        user: { requiresTwoFactor: true, mustChangePassword: true },
-      },
-      status: 'authenticated',
-    } as never)
-
-    // Mount order mirrors layout.tsx: PasswordChangeGuard outside,
-    // TwoFactorGuard inside.
-    render(
-      <PasswordChangeGuard enabled>
-        <TwoFactorGuard enabled>
-          <div>content</div>
-        </TwoFactorGuard>
-      </PasswordChangeGuard>,
-    )
+    const push = setup({ requiresTwoFactor: true, mustChangePassword: true })
+    renderGuards((node) => <>{node}</>)
 
     expect(push).toHaveBeenCalledTimes(1)
     expect(push).toHaveBeenCalledWith(
       expect.stringContaining('/auth/verify-2fa'),
     )
     expect(push).not.toHaveBeenCalledWith('/auth/change-password')
+  })
+
+  it('pushes only to 2FA when requiresTwoFactor alone is set', () => {
+    const push = setup({ requiresTwoFactor: true, mustChangePassword: false })
+    renderGuards((node) => <>{node}</>)
+
+    expect(push).toHaveBeenCalledTimes(1)
+    expect(push).toHaveBeenCalledWith(
+      expect.stringContaining('/auth/verify-2fa'),
+    )
+  })
+
+  it('pushes only to change-password when mustChangePassword alone is set', () => {
+    const push = setup({ requiresTwoFactor: false, mustChangePassword: true })
+    renderGuards((node) => <>{node}</>)
+
+    expect(push).toHaveBeenCalledTimes(1)
+    expect(push).toHaveBeenCalledWith('/auth/change-password')
+    expect(push).not.toHaveBeenCalledWith(
+      expect.stringContaining('/auth/verify-2fa'),
+    )
+  })
+
+  it('never mixes both targets under StrictMode effect replay (both flags set)', () => {
+    const push = setup({ requiresTwoFactor: true, mustChangePassword: true })
+    renderGuards((node) => <StrictMode>{node}</StrictMode>)
+
+    // StrictMode may replay the effect, so the same-target push can repeat,
+    // but the 2FA-first invariant must hold: change-password is never pushed.
+    expect(push).not.toHaveBeenCalledWith('/auth/change-password')
+    for (const call of push.mock.calls) {
+      expect(String(call[0])).toContain('/auth/verify-2fa')
+    }
   })
 })

--- a/src/components/password-change-guard.tsx
+++ b/src/components/password-change-guard.tsx
@@ -15,7 +15,13 @@ interface PasswordChangeGuardProps {
 }
 
 // Routes that don't require password change check
-const excludedRoutes = ['/auth/signin', '/auth/error', '/auth/change-password']
+const excludedRoutes = [
+  '/auth/signin',
+  '/auth/error',
+  '/auth/change-password',
+  '/auth/verify-2fa',
+  '/auth/verify-2fa/backup',
+]
 
 export function PasswordChangeGuard({
   children,
@@ -41,6 +47,9 @@ function PasswordChangeGuardContent({
   useEffect(() => {
     if (status !== 'authenticated') return
     if (excludedRoutes.some((route) => pathname.startsWith(route))) return
+    // 2FA takes precedence; defer to TwoFactorGuard so both guards mounting
+    // together (layout.tsx) do not push simultaneously and race.
+    if (session?.user?.requiresTwoFactor) return
 
     if (session?.user?.mustChangePassword) {
       router.push('/auth/change-password')

--- a/src/components/share-url-button.test.tsx
+++ b/src/components/share-url-button.test.tsx
@@ -45,7 +45,8 @@ afterEach(() => {
 
 describe('ShareUrlButton', () => {
   it('stays usable when `share` exists but `canShare` does not (compat regression)', () => {
-    setNavigatorShare(jest.fn())
+    const shareMock = jest.fn(() => Promise.resolve())
+    setNavigatorShare(shareMock)
     // `canShare` is intentionally left unset, as in WebViews that shipped
     // `share` years before `canShare`.
 
@@ -54,7 +55,14 @@ describe('ShareUrlButton', () => {
       utils = render(<ShareUrlButton url={KEYED_URL} text="t" />)
     }).not.toThrow()
 
-    expect(utils.queryByRole('button')).not.toBeNull()
+    const button = utils.queryByRole('button')
+    expect(button).not.toBeNull()
+
+    // "Usable" means the click actually invokes the Web Share API, not just
+    // that a button renders.
+    fireEvent.click(button as HTMLElement)
+    expect(shareMock).toHaveBeenCalledTimes(1)
+    expect(shareMock).toHaveBeenCalledWith({ url: KEYED_URL, text: 't' })
   })
 
   it('never logs the url/text (key material), even when the share sheet is dismissed', async () => {

--- a/src/components/share-url-button.test.tsx
+++ b/src/components/share-url-button.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render } from '@testing-library/react'
+import { ShareUrlButton } from './share-url-button'
+
+const KEYED_URL = 'https://host/groups/g#SECRETKEY'
+
+function setNavigatorShare(value: unknown) {
+  Object.defineProperty(navigator, 'share', {
+    value,
+    configurable: true,
+    writable: true,
+  })
+}
+
+function setNavigatorCanShare(value: unknown) {
+  Object.defineProperty(navigator, 'canShare', {
+    value,
+    configurable: true,
+    writable: true,
+  })
+}
+
+// Flattens a console-spy argument to a comparable string, regardless of
+// whether it was logged as a string, an Error, or a plain object.
+function serializeArg(arg: unknown): string {
+  if (typeof arg === 'string') return arg
+  if (arg instanceof Error) return `${arg.message} ${arg.stack ?? ''}`
+  try {
+    return JSON.stringify(arg)
+  } catch {
+    return String(arg)
+  }
+}
+
+afterEach(() => {
+  // jsdom has neither `share` nor `canShare` by default; restore that
+  // absence so a mutation from one case never leaks into the next.
+  Reflect.deleteProperty(navigator, 'share')
+  Reflect.deleteProperty(navigator, 'canShare')
+  jest.restoreAllMocks()
+})
+
+describe('ShareUrlButton', () => {
+  it('stays usable when `share` exists but `canShare` does not (compat regression)', () => {
+    setNavigatorShare(jest.fn())
+    // `canShare` is intentionally left unset, as in WebViews that shipped
+    // `share` years before `canShare`.
+
+    let utils!: ReturnType<typeof render>
+    expect(() => {
+      utils = render(<ShareUrlButton url={KEYED_URL} text="t" />)
+    }).not.toThrow()
+
+    expect(utils.queryByRole('button')).not.toBeNull()
+  })
+
+  it('never logs the url/text (key material), even when the share sheet is dismissed', async () => {
+    const secretUrl = 'https://host/groups/g#top-secret-encryption-key'
+    const secretText = 'Join my very secret group on Spliit'
+
+    setNavigatorShare(
+      jest
+        .fn()
+        .mockImplementation(() => Promise.reject(new Error('share cancelled'))),
+    )
+    setNavigatorCanShare(jest.fn().mockReturnValue(true))
+
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {})
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {})
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
+    const { getByRole } = render(
+      <ShareUrlButton url={secretUrl} text={secretText} />,
+    )
+    fireEvent.click(getByRole('button'))
+
+    // Flush the microtask queue so the rejected `.catch()` handler runs.
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    for (const spy of [logSpy, warnSpy, errorSpy]) {
+      for (const call of spy.mock.calls) {
+        for (const arg of call) {
+          const serialized = serializeArg(arg)
+          expect(serialized).not.toContain(secretUrl)
+          expect(serialized).not.toContain(secretText)
+        }
+      }
+    }
+  })
+
+  it('renders nothing when the Web Share API is unsupported', () => {
+    // Both `share` and `canShare` are left unset (jsdom default).
+    const { queryByRole, container } = render(
+      <ShareUrlButton url={KEYED_URL} text="t" />,
+    )
+
+    expect(queryByRole('button')).toBeNull()
+    expect(container.firstChild).toBeNull()
+  })
+})

--- a/src/components/share-url-button.tsx
+++ b/src/components/share-url-button.tsx
@@ -19,17 +19,11 @@ export function ShareUrlButton({ url, text }: Props) {
       variant="secondary"
       type="button"
       onClick={() => {
-        if (navigator.share) {
-          // Rejection (e.g. the user cancelling the share sheet) is expected;
-          // never log it — the payload contains the share URL whose fragment
-          // carries the encryption key.
-          navigator.share({ text, url }).catch(() => {})
-        } else {
-          // Do not log `url`/`text`: the share URL contains the encryption key
-          // in its fragment, and logging it would expose key material to the
-          // console (DevTools, extensions, screen shares).
-          console.warn('Web Share API is not available')
-        }
+        if (typeof navigator.share !== 'function') return
+        // Rejection (e.g. the user cancelling the share sheet) is expected;
+        // never log it — the payload contains the share URL whose fragment
+        // carries the encryption key.
+        navigator.share({ text, url }).catch(() => {})
       }}
     >
       <Share className="w-4 h-4" />
@@ -41,8 +35,13 @@ function useCanShare(url: string, text: string) {
   const [canShare, setCanShare] = useState<boolean | null>(null)
 
   useEffect(() => {
+    // `navigator.share` shipped years before `navigator.canShare`; keep the
+    // button usable when the runtime has the former but not the latter
+    // instead of calling `canShare` and throwing.
     setCanShare(
-      navigator.share !== undefined && navigator.canShare({ url, text }),
+      typeof navigator.share === 'function' &&
+        (typeof navigator.canShare !== 'function' ||
+          navigator.canShare({ url, text })),
     )
   }, [text, url])
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -63,6 +63,10 @@ class MemoryStorage implements RateLimitStorage {
     this.cleanupInterval = setInterval(() => {
       this.cleanup()
     }, CLEANUP_INTERVAL_MS)
+    // Don't keep the Node event loop alive solely for periodic cleanup: the
+    // running server is held open by its listener, while a short-lived process
+    // (e.g. a Jest worker that imports this module) must still be able to exit.
+    this.cleanupInterval.unref?.()
   }
 
   async get(key: string): Promise<AttemptRecord | null> {
@@ -540,7 +544,7 @@ const operationAttempts = new Map<string, AttemptRecord>()
 
 // Cleanup old operation attempts periodically
 if (typeof window === 'undefined') {
-  setInterval(
+  const operationCleanupInterval = setInterval(
     () => {
       const now = Date.now()
       const keysToDelete: string[] = []
@@ -555,6 +559,9 @@ if (typeof window === 'undefined') {
     },
     5 * 60 * 1000,
   ) // Every 5 minutes
+  // Don't keep the Node event loop alive solely for this timer, so short-lived
+  // processes (e.g. Jest workers importing this module) can exit cleanly.
+  operationCleanupInterval.unref?.()
 }
 
 /**


### PR DESCRIPTION
## 背景

現 main(#242 merge 後)への再監査(ultracode workflow 33 agents + Codex 独立レビュー + セッション裏取り)で確定した **private-instance 認証導線の欠陥**を修正する。スコープ「セキュリティ最優先で順次」の PR-1(認証ゲート堅牢化)。schema 変更なし。

## 修正内容

### finding 1(High)— admin ページのサーバ側 2FA/パスワードゲート
`admin/page.tsx` は `isAdmin` のみ検証し、全 admin・whitelist の email/名前/2FA 状態を RSC で serialize していた。クライアント guard は hydration 後にしか動かないため、TOTP 未入力の攻撃者が `curl --cookie` で `/admin` から PII を取得できた。`isAdmin` チェック直後・全 Prisma クエリ前に、REST/tRPC と同じ順序(**2FA→パスワード変更**)で `redirect()`(NEXT_REDIRECT throw で短絡)を追加。

### finding 2(High)— guard 相互リダイレクトループ
`PasswordChangeGuard` と `TwoFactorGuard` は `layout.tsx` で同時 mount され、両フラグ true 時に双方が同時 `router.push` → 二重 navigation・change-password 瞬間表示・history 汚染・ループ(2FA 有効 whitelist ユーザーのパスワードリセット後にアカウントロックアウト)。**2FA 優先の非対称修正**: `PasswordChangeGuard` の effect に `if (requiresTwoFactor) return`(TwoFactorGuard に委譲)を追加し、`/auth/verify-2fa`・`/auth/verify-2fa/backup` を excludedRoutes に追加。`TwoFactorGuard` は現状維持。

### finding 5(Medium)— admin リセットの `passwordChangedAt`
PATCH リセットが `passwordChangedAt` を設定せず、#135 の「盗まれた token は継続不可」が admin リセット経路で無効化されていた。bcrypt 完了後に timestamp 生成し同一 update に含める。※iat は秒・`passwordChangedAt` はミリ秒精度で、拒否条件は `tokenIatSeconds * 1000 < passwordChangedAt`(厳密 `<`、等値は許可)。両刃のため race-free な完全失効ではない: (a) reset と同一秒後半に発行された正当な token は iat が秒に floor され拒否され得る(一過的ログアウト)、(b) reset 書き込み前に authorize() が進行していた login(TOCTOU)は iat が passwordChangedAt 以降の秒に floor されれば生き残り得る。

### finding 8(Medium)— verify-2fa auto-submit のオフライン無限再送
fetch reject 時に token を保持したまま isLoading 反転で auto-submit effect が再発火しループ。`lastAttemptedTokenRef` を導入し auto-submit effect のみをゲート(手動 submit は常に許可、fetch 前に ref を同期記録、token 編集で clear)。StrictMode 二重呼び出しも単一送信。

### finding 10(Low)— PATCH/DELETE のレート制限
POST のみ per-admin レート制限(60/h)を持ち、同一 bcrypt を回す PATCH と DELETE は無制限だった。POST と同一契約をミラー: `!isAdmin || !session.user.id` で 401(`...undefined` bucket 回避)、operation 別 prefix(`admin-whitelist-reset:` / `admin-whitelist-delete:`)、admin ID key、gate 後 check → **await 前に同期 record**、gate 失敗・429 は非消費、404/500/成功は各 1 回消費、Retry-After 付与。limiter は process-local(best-effort)。

### finding 12 + 13(Low)— share-url-button
`navigator.share` はあるが `navigator.canShare` が無い WebView で `canShare` 呼び出しが TypeError → サブツリー白画面。検出を `typeof navigator.canShare !== 'function' || navigator.canShare(...)` に変更しボタンを維持、到達不能な else 分岐を除去、onClick で `navigator.share` を再確認。

## テスト
- admin ページ: redirect mock を throw させ、両フラグ true で verify-2fa が選ばれ**全 Prisma クエリ未呼び出し**を固定
- guard: 実 layout 順で両フラグ true → verify-2fa への push が**ちょうど 1 回**、change-password への push なし
- PATCH/DELETE: `passwordChangedAt`(fake timer で Date)+ レート制限消費契約(gate/429 非消費、404/成功は 1 回、Retry-After)
- verify-2fa: reject 後に自動再送なし・手動 retry で +1・同一 6 桁再入力で再試行・StrictMode 単一
- share-url: share あり canShare なしで例外なくボタン表示 + reject 時に URL を console 出力しない

## 統合監査で捕捉・修正した回帰(subagent の個別検証では見逃されていた)
- 既存 `admin-whitelist-reset.test.ts` が PATCH の新 update shape で失敗 → `passwordChangedAt: expect.any(Date)` を追加
- 同テストが rate-limit 実モジュール(module-level cleanup `setInterval`、当時 `.unref()` なし)を読み込み、**jest が open handle でハング**(CI の `pnpm test` を停止させる)。Codex レビューを受け**根本修正**: `rate-limit.ts` の両 cleanup timer(`MemoryStorage.startCleanup` + module-level operation sweep)に `.unref()` を適用(稼働サーバは listener で生存するため無影響、短命プロセス/Jest worker のみ exit 可能に)。テストの mock は分離目的で維持

## Codex レビュー反映
Codex 3 パス(APPROVE / 非 blocking nit のみ)を反映: 両 timer の `.unref()`、コメント正確化(admin ゲートは `auth()` の後・データ取得の前 / rate-limit CHECK は attempt を消費しない / passwordChangedAt の厳密 `<` 比較と両刃の race)、テスト強化(guard の 2FA-only・pw-only・StrictMode 非空虚化、route の caught-500・DELETE 404・reserve 前後順・record 引数、share-url の click assert)。rate-limit の 1ms 境界 retryAfter 欠陥は #238 にコメント記録し defer。

## 検証
- jest: 51 suites / 598 passed(1 skip、**ハングなし・forceExit 不要 = unref 修正確認**)
- `tsc --noEmit`: 0 エラー / `eslint .`: 0 エラー(warning 11 は既存)/ `prettier -c src`: クリーン
- `next build`(Turbopack): 成功(worktree の hardlink node_modules は Turbopack 解決に難があるため、実 node_modules 環境で確認)

## 関連
- 再監査元の親: #214。本 PR は「セキュリティ最優先で順次」の PR-1
- 後続予定(別 PR): 2FA fragment 喪失、アカウント単位 2FA timestamp のセッション束縛(schema)、private-mode 共有リンク・backup code 並行消費・auto-delete race、refactor/hygiene
