### PR TITLE
fix(e2ee): preserve URL fragment (encryption key) across the 2FA redirect

### DIFF
--- a/src/__tests__/rate-limit-callers.test.ts
+++ b/src/__tests__/rate-limit-callers.test.ts
@@ -135,7 +135,12 @@ describe('rate-limit async callers (Issue #167)', () => {
     const { POST } = await import('@/app/api/2fa/verify/route')
     const request = new Request('http://localhost/api/2fa/verify', {
       method: 'POST',
-      body: JSON.stringify({ email: 'user@example.com', token: '123456' }),
+      body: JSON.stringify({
+        email: 'user@example.com',
+        token: '123456',
+        subjectId: 'u1',
+        subjectIsAdmin: false,
+      }),
     })
     const res = await POST(request)
 

--- a/src/__tests__/two-factor-verify-pre-auth.test.ts
+++ b/src/__tests__/two-factor-verify-pre-auth.test.ts
@@ -104,10 +104,21 @@ function makeSession({
 }
 
 function makeRequest(body: unknown): Request {
+  // The route requires the body subject ({subjectId, subjectIsAdmin}) to
+  // match the session subject; default to the default session's subject so
+  // tests only override what they exercise.
+  const payload =
+    typeof body === 'string'
+      ? body
+      : JSON.stringify({
+          subjectId: 'u1',
+          subjectIsAdmin: false,
+          ...(body as Record<string, unknown>),
+        })
   return new Request('http://localhost/api/2fa/verify', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: typeof body === 'string' ? body : JSON.stringify(body),
+    body: payload,
   })
 }
 
@@ -205,7 +216,57 @@ describe('POST /api/2fa/verify — subject binding (Issue #174)', () => {
     expectZeroSideEffects()
   })
 
-  it('7: returns 400 Already verified when requiresTwoFactor is false', async () => {
+  it('6b: returns 401 when the body subject id does not match the session (no side effects)', async () => {
+    // Same email can exist on both the Admin and WhitelistUser tables: an
+    // outcome must never be attributable to a subject the session does not
+    // prove.
+    mockedAuth.mockResolvedValue(makeSession({ email: 'u@example.com' }))
+    const { POST } = await import('@/app/api/2fa/verify/route')
+    const res = await POST(
+      makeRequest({
+        email: 'u@example.com',
+        token: '123456',
+        subjectId: 'someone-else',
+      }),
+    )
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: 'Invalid request' })
+    expect(mockedCheckRateLimitAsync).not.toHaveBeenCalled()
+    expectZeroSideEffects()
+  })
+
+  it('6c: returns 401 when the body subject role does not match the session', async () => {
+    mockedAuth.mockResolvedValue(makeSession({ email: 'u@example.com' }))
+    const { POST } = await import('@/app/api/2fa/verify/route')
+    const res = await POST(
+      makeRequest({
+        email: 'u@example.com',
+        token: '123456',
+        subjectIsAdmin: true,
+      }),
+    )
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: 'Invalid request' })
+    expect(mockedCheckRateLimitAsync).not.toHaveBeenCalled()
+    expectZeroSideEffects()
+  })
+
+  it('6d: returns 400 when the body subject fields are missing or mistyped', async () => {
+    const { POST } = await import('@/app/api/2fa/verify/route')
+    const res = await POST(
+      makeRequest({
+        email: 'u@example.com',
+        token: '123456',
+        subjectId: 42,
+      }),
+    )
+    expect(res.status).toBe(400)
+    expect(await res.json()).toEqual({ error: 'Invalid request' })
+    expect(mockedAuth).not.toHaveBeenCalled()
+    expectZeroSideEffects()
+  })
+
+  it('7: returns 400 Already verified (machine-readable code) when requiresTwoFactor is false', async () => {
     mockedAuth.mockResolvedValue(
       makeSession({ email: 'u@example.com', requiresTwoFactor: false }),
     )
@@ -214,7 +275,12 @@ describe('POST /api/2fa/verify — subject binding (Issue #174)', () => {
       makeRequest({ email: 'u@example.com', token: '123456' }),
     )
     expect(res.status).toBe(400)
-    expect(await res.json()).toEqual({ error: 'Already verified' })
+    // The code lets the client treat this as the success it is; subject
+    // match is guaranteed because the check above (6b/6c) runs first.
+    expect(await res.json()).toEqual({
+      error: 'Already verified',
+      code: 'ALREADY_VERIFIED',
+    })
     expect(mockedCheckRateLimitAsync).not.toHaveBeenCalled()
     expectZeroSideEffects()
   })
@@ -261,7 +327,12 @@ describe('POST /api/2fa/verify — subject binding (Issue #174)', () => {
     mockedVerifyTOTP.mockReturnValue(true)
     const { POST } = await import('@/app/api/2fa/verify/route')
     const res = await POST(
-      makeRequest({ email: 'admin@example.com', token: '123456' }),
+      makeRequest({
+        email: 'admin@example.com',
+        token: '123456',
+        subjectId: 'a1',
+        subjectIsAdmin: true,
+      }),
     )
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({

--- a/src/__tests__/two-factor-verify-pre-auth.test.ts
+++ b/src/__tests__/two-factor-verify-pre-auth.test.ts
@@ -278,14 +278,12 @@ describe('POST /api/2fa/verify — subject binding (Issue #174)', () => {
         twoFactorBackupCodes: true,
       },
     })
-    expect(mockedPrisma.admin.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: 'a1' },
-        data: expect.objectContaining({
-          lastTwoFactorVerifiedAt: expect.any(Date),
-        }),
-      }),
-    )
+    // TOTP path: exactly one write, timestamp only (no backup-code field).
+    expect(mockedPrisma.admin.update).toHaveBeenCalledTimes(1)
+    expect(mockedPrisma.admin.update).toHaveBeenCalledWith({
+      where: { id: 'a1' },
+      data: { lastTwoFactorVerifiedAt: expect.any(Date) },
+    })
     expect(mockedPrisma.whitelistUser.findUnique).not.toHaveBeenCalled()
     expect(mockedPrisma.whitelistUser.update).not.toHaveBeenCalled()
     expect(mockedClearAttemptsAsync).toHaveBeenCalledWith('2fa-verify:a1')
@@ -323,20 +321,18 @@ describe('POST /api/2fa/verify — subject binding (Issue #174)', () => {
         twoFactorBackupCodes: true,
       },
     })
-    // Two updates: backup-codes splice then lastTwoFactorVerifiedAt.
-    expect(mockedPrisma.whitelistUser.update).toHaveBeenCalledTimes(2)
+    // Single write: backup-code consumption and the verification timestamp
+    // must commit together — a partial commit would burn the code without
+    // granting the 5-minute session-refresh window the client needs to
+    // complete the sign-in.
+    expect(mockedPrisma.whitelistUser.update).toHaveBeenCalledTimes(1)
     expect(mockedPrisma.whitelistUser.update).toHaveBeenCalledWith({
       where: { id: 'u1' },
-      data: { twoFactorBackupCodes: 'enc-codes' },
+      data: {
+        twoFactorBackupCodes: 'enc-codes',
+        lastTwoFactorVerifiedAt: expect.any(Date),
+      },
     })
-    expect(mockedPrisma.whitelistUser.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: 'u1' },
-        data: expect.objectContaining({
-          lastTwoFactorVerifiedAt: expect.any(Date),
-        }),
-      }),
-    )
     expect(mockedPrisma.admin.findUnique).not.toHaveBeenCalled()
     expect(mockedPrisma.admin.update).not.toHaveBeenCalled()
     expect(mockedClearAttemptsAsync).toHaveBeenCalledWith('2fa-verify:u1')

--- a/src/__tests__/two-factor-verify-pre-auth.test.ts
+++ b/src/__tests__/two-factor-verify-pre-auth.test.ts
@@ -22,10 +22,12 @@ jest.mock('@/lib/prisma', () => ({
     admin: {
       findUnique: jest.fn(),
       update: jest.fn(),
+      updateMany: jest.fn(),
     },
     whitelistUser: {
       findUnique: jest.fn(),
       update: jest.fn(),
+      updateMany: jest.fn(),
     },
   },
 }))
@@ -75,8 +77,12 @@ const mockedTimingSafeCompare = timingSafeCompare as jest.MockedFunction<
   typeof timingSafeCompare
 >
 const mockedPrisma = prisma as unknown as {
-  admin: { findUnique: jest.Mock; update: jest.Mock }
-  whitelistUser: { findUnique: jest.Mock; update: jest.Mock }
+  admin: { findUnique: jest.Mock; update: jest.Mock; updateMany: jest.Mock }
+  whitelistUser: {
+    findUnique: jest.Mock
+    update: jest.Mock
+    updateMany: jest.Mock
+  }
 }
 
 function makeSession({
@@ -125,8 +131,10 @@ function makeRequest(body: unknown): Request {
 function expectZeroSideEffects() {
   expect(mockedPrisma.admin.findUnique).not.toHaveBeenCalled()
   expect(mockedPrisma.admin.update).not.toHaveBeenCalled()
+  expect(mockedPrisma.admin.updateMany).not.toHaveBeenCalled()
   expect(mockedPrisma.whitelistUser.findUnique).not.toHaveBeenCalled()
   expect(mockedPrisma.whitelistUser.update).not.toHaveBeenCalled()
+  expect(mockedPrisma.whitelistUser.updateMany).not.toHaveBeenCalled()
   expect(mockedRecordFailedAttemptAsync).not.toHaveBeenCalled()
   expect(mockedClearAttemptsAsync).not.toHaveBeenCalled()
 }
@@ -347,6 +355,7 @@ describe('POST /api/2fa/verify — subject binding (Issue #174)', () => {
         twoFactorEnabled: true,
         twoFactorSecret: true,
         twoFactorBackupCodes: true,
+        lastTwoFactorVerifiedAt: true,
       },
     })
     // TOTP path: exactly one write, timestamp only (no backup-code field).
@@ -370,9 +379,11 @@ describe('POST /api/2fa/verify — subject binding (Issue #174)', () => {
       twoFactorEnabled: true,
       twoFactorSecret: 'enc-secret',
       twoFactorBackupCodes: 'enc-codes',
+      lastTwoFactorVerifiedAt: null,
     })
     // First timingSafeCompare returns true → codeIndex=0 → consume.
     mockedTimingSafeCompare.mockImplementationOnce(() => true)
+    mockedPrisma.whitelistUser.updateMany.mockResolvedValue({ count: 1 })
     const { POST } = await import('@/app/api/2fa/verify/route')
     const res = await POST(
       makeRequest({ email: 'user@example.com', token: 'ABCD1234' }),
@@ -390,22 +401,24 @@ describe('POST /api/2fa/verify — subject binding (Issue #174)', () => {
         twoFactorEnabled: true,
         twoFactorSecret: true,
         twoFactorBackupCodes: true,
+        lastTwoFactorVerifiedAt: true,
       },
     })
-    // Single write: backup-code consumption and the verification timestamp
-    // must commit together — a partial commit would burn the code without
-    // granting the 5-minute session-refresh window the client needs to
-    // complete the sign-in.
-    expect(mockedPrisma.whitelistUser.update).toHaveBeenCalledTimes(1)
-    expect(mockedPrisma.whitelistUser.update).toHaveBeenCalledWith({
-      where: { id: 'u1' },
+    // Single CAS write: the WHERE pins the exact blob this attempt decoded,
+    // and code consumption + verification timestamp commit together — a
+    // partial commit would burn the code without granting the 5-minute
+    // session-refresh window the client needs to complete the sign-in.
+    expect(mockedPrisma.whitelistUser.updateMany).toHaveBeenCalledTimes(1)
+    expect(mockedPrisma.whitelistUser.updateMany).toHaveBeenCalledWith({
+      where: { id: 'u1', twoFactorBackupCodes: 'enc-codes' },
       data: {
         twoFactorBackupCodes: 'enc-codes',
         lastTwoFactorVerifiedAt: expect.any(Date),
       },
     })
+    expect(mockedPrisma.whitelistUser.update).not.toHaveBeenCalled()
     expect(mockedPrisma.admin.findUnique).not.toHaveBeenCalled()
-    expect(mockedPrisma.admin.update).not.toHaveBeenCalled()
+    expect(mockedPrisma.admin.updateMany).not.toHaveBeenCalled()
     expect(mockedClearAttemptsAsync).toHaveBeenCalledWith('2fa-verify:u1')
     expect(mockedRecordFailedAttemptAsync).not.toHaveBeenCalled()
   })
@@ -431,5 +444,213 @@ describe('POST /api/2fa/verify — subject binding (Issue #174)', () => {
     expect(mockedPrisma.whitelistUser.update).not.toHaveBeenCalled()
     expect(mockedPrisma.admin.update).not.toHaveBeenCalled()
     expect(mockedClearAttemptsAsync).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/2fa/verify — backup-code CAS (concurrent consumption)', () => {
+  const FRESH = () => new Date()
+  const STALE = () => new Date(Date.now() - 10 * 60 * 1000)
+
+  function setupWhitelistUser(overrides: Record<string, unknown> = {}) {
+    mockedAuth.mockResolvedValue(makeSession())
+    mockedPrisma.whitelistUser.findUnique.mockResolvedValueOnce({
+      id: 'u1',
+      twoFactorEnabled: true,
+      twoFactorSecret: 'enc-secret',
+      twoFactorBackupCodes: 'enc-codes',
+      lastTwoFactorVerifiedAt: null,
+      ...overrides,
+    })
+    mockedTimingSafeCompare.mockImplementation(
+      (a: string, b: string) => a === b,
+    )
+  }
+
+  async function callVerify(token = 'ABCD1234') {
+    const { POST } = await import('@/app/api/2fa/verify/route')
+    return POST(makeRequest({ email: 'user@example.com', token }))
+  }
+
+  it('retries once on a CAS conflict and the final blob drops BOTH concurrently consumed codes', async () => {
+    setupWhitelistUser()
+    const { decryptBackupCodes, encryptBackupCodes } = jest.requireMock(
+      '@/lib/two-factor',
+    ) as { decryptBackupCodes: jest.Mock; encryptBackupCodes: jest.Mock }
+    // First read: our code + one other; a concurrent request consumes the
+    // other and rewrites the blob to 'enc-codes-2' between our read and our
+    // update.
+    decryptBackupCodes.mockImplementation((blob: string) =>
+      blob === 'enc-codes' ? ['ABCD1234', 'OTHR9999'] : ['ABCD1234'],
+    )
+    encryptBackupCodes.mockImplementation(
+      (codes: string[]) => `enc(${codes.join('|')})`,
+    )
+    mockedPrisma.whitelistUser.updateMany
+      .mockResolvedValueOnce({ count: 0 })
+      .mockResolvedValueOnce({ count: 1 })
+    mockedPrisma.whitelistUser.findUnique.mockResolvedValueOnce({
+      twoFactorBackupCodes: 'enc-codes-2',
+      lastTwoFactorVerifiedAt: null,
+    })
+
+    const res = await callVerify()
+
+    expect(res.status).toBe(200)
+    expect(mockedPrisma.whitelistUser.updateMany).toHaveBeenCalledTimes(2)
+    // Each attempt's WHERE pins the exact blob that attempt decoded.
+    expect(mockedPrisma.whitelistUser.updateMany).toHaveBeenNthCalledWith(1, {
+      where: { id: 'u1', twoFactorBackupCodes: 'enc-codes' },
+      data: {
+        twoFactorBackupCodes: 'enc(OTHR9999)',
+        lastTwoFactorVerifiedAt: expect.any(Date),
+      },
+    })
+    // The retry re-decoded the FRESH blob, so the final array is missing
+    // both the concurrently consumed code and ours.
+    expect(mockedPrisma.whitelistUser.updateMany).toHaveBeenNthCalledWith(2, {
+      where: { id: 'u1', twoFactorBackupCodes: 'enc-codes-2' },
+      data: {
+        twoFactorBackupCodes: 'enc()',
+        lastTwoFactorVerifiedAt: expect.any(Date),
+      },
+    })
+    expect(mockedClearAttemptsAsync).toHaveBeenCalledWith('2fa-verify:u1')
+    expect(mockedRecordFailedAttemptAsync).not.toHaveBeenCalled()
+    decryptBackupCodes.mockImplementation(() => ['CODE1', 'CODE2'])
+    encryptBackupCodes.mockImplementation(() => 'enc-codes')
+  })
+
+  it('stops after exactly two CAS attempts and returns 503 with no rate-limit side effects', async () => {
+    setupWhitelistUser()
+    const { decryptBackupCodes } = jest.requireMock('@/lib/two-factor') as {
+      decryptBackupCodes: jest.Mock
+    }
+    decryptBackupCodes.mockImplementation((blob: string) =>
+      blob === 'enc-codes' ? ['ABCD1234', 'X1'] : ['ABCD1234', 'X2'],
+    )
+    mockedPrisma.whitelistUser.updateMany.mockResolvedValue({ count: 0 })
+    mockedPrisma.whitelistUser.findUnique.mockResolvedValueOnce({
+      twoFactorBackupCodes: 'enc-codes-2',
+      lastTwoFactorVerifiedAt: null,
+    })
+
+    const res = await callVerify()
+
+    expect(res.status).toBe(503)
+    expect(mockedPrisma.whitelistUser.updateMany).toHaveBeenCalledTimes(2)
+    // Nothing was proven invalid and nothing succeeded: neither record nor
+    // clear may touch the rate limit.
+    expect(mockedRecordFailedAttemptAsync).not.toHaveBeenCalled()
+    expect(mockedClearAttemptsAsync).not.toHaveBeenCalled()
+    decryptBackupCodes.mockImplementation(() => ['CODE1', 'CODE2'])
+  })
+
+  it('answers RETRY_SYNC when the code vanished after a conflict and the verification is fresh', async () => {
+    setupWhitelistUser()
+    const { decryptBackupCodes } = jest.requireMock('@/lib/two-factor') as {
+      decryptBackupCodes: jest.Mock
+    }
+    // Present on our first read, gone from the fresh row: a concurrent
+    // request (ours, response lost) consumed it and stamped the timestamp.
+    decryptBackupCodes.mockImplementation((blob: string) =>
+      blob === 'enc-codes' ? ['ABCD1234'] : [],
+    )
+    mockedPrisma.whitelistUser.updateMany.mockResolvedValueOnce({ count: 0 })
+    mockedPrisma.whitelistUser.findUnique.mockResolvedValueOnce({
+      twoFactorBackupCodes: 'enc-codes-2',
+      lastTwoFactorVerifiedAt: FRESH(),
+    })
+
+    const res = await callVerify()
+
+    expect(res.status).toBe(409)
+    expect(await res.json()).toEqual({
+      error: 'Verification already recorded',
+      code: 'RETRY_SYNC',
+    })
+    expect(mockedPrisma.whitelistUser.updateMany).toHaveBeenCalledTimes(1)
+    expect(mockedRecordFailedAttemptAsync).not.toHaveBeenCalled()
+    expect(mockedClearAttemptsAsync).not.toHaveBeenCalled()
+    decryptBackupCodes.mockImplementation(() => ['CODE1', 'CODE2'])
+  })
+
+  it('answers RETRY_SYNC when the code is absent from the first read but the verification is fresh', async () => {
+    // e.g. a reload dropped the client's recovery state and the user
+    // re-submits the code their earlier (lost-response) attempt consumed.
+    setupWhitelistUser({ lastTwoFactorVerifiedAt: FRESH() })
+
+    const res = await callVerify('WXYZ9876')
+
+    expect(res.status).toBe(409)
+    expect(await res.json()).toEqual({
+      error: 'Verification already recorded',
+      code: 'RETRY_SYNC',
+    })
+    expect(mockedPrisma.whitelistUser.updateMany).not.toHaveBeenCalled()
+    expect(mockedRecordFailedAttemptAsync).not.toHaveBeenCalled()
+    expect(mockedClearAttemptsAsync).not.toHaveBeenCalled()
+  })
+
+  it('returns a plain 401 (+ failed attempt) only when the code is absent AND no recent verification exists', async () => {
+    setupWhitelistUser({ lastTwoFactorVerifiedAt: STALE() })
+
+    const res = await callVerify('WXYZ9876')
+
+    expect(res.status).toBe(401)
+    expect(await res.json()).toEqual({ error: 'Invalid token' })
+    expect(mockedPrisma.whitelistUser.updateMany).not.toHaveBeenCalled()
+    expect(mockedRecordFailedAttemptAsync).toHaveBeenCalledWith('2fa-verify:u1')
+    expect(mockedClearAttemptsAsync).not.toHaveBeenCalled()
+  })
+
+  it('runs the same CAS retry for Admin (both tables verified)', async () => {
+    mockedAuth.mockResolvedValue(
+      makeSession({ id: 'a1', email: 'admin@example.com', isAdmin: true }),
+    )
+    mockedPrisma.admin.findUnique.mockResolvedValueOnce({
+      id: 'a1',
+      twoFactorEnabled: true,
+      twoFactorSecret: 'enc-secret',
+      twoFactorBackupCodes: 'enc-codes',
+      lastTwoFactorVerifiedAt: null,
+    })
+    mockedTimingSafeCompare.mockImplementation(
+      (a: string, b: string) => a === b,
+    )
+    const { decryptBackupCodes } = jest.requireMock('@/lib/two-factor') as {
+      decryptBackupCodes: jest.Mock
+    }
+    decryptBackupCodes.mockImplementation((blob: string) =>
+      blob === 'enc-codes' ? ['ABCD1234', 'Y1'] : ['ABCD1234'],
+    )
+    mockedPrisma.admin.updateMany
+      .mockResolvedValueOnce({ count: 0 })
+      .mockResolvedValueOnce({ count: 1 })
+    mockedPrisma.admin.findUnique.mockResolvedValueOnce({
+      twoFactorBackupCodes: 'enc-codes-2',
+      lastTwoFactorVerifiedAt: null,
+    })
+
+    const { POST } = await import('@/app/api/2fa/verify/route')
+    const res = await POST(
+      makeRequest({
+        email: 'admin@example.com',
+        token: 'ABCD1234',
+        subjectId: 'a1',
+        subjectIsAdmin: true,
+      }),
+    )
+
+    expect(res.status).toBe(200)
+    expect(mockedPrisma.admin.updateMany).toHaveBeenCalledTimes(2)
+    expect(mockedPrisma.admin.updateMany).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        where: { id: 'a1', twoFactorBackupCodes: 'enc-codes-2' },
+      }),
+    )
+    expect(mockedPrisma.whitelistUser.updateMany).not.toHaveBeenCalled()
+    expect(mockedClearAttemptsAsync).toHaveBeenCalledWith('2fa-verify:a1')
+    decryptBackupCodes.mockImplementation(() => ['CODE1', 'CODE2'])
   })
 })

--- a/src/app/api/2fa/verify/route.ts
+++ b/src/app/api/2fa/verify/route.ts
@@ -66,7 +66,14 @@ export async function POST(request: Request) {
     //    for a security endpoint.
     const email = (body as { email?: unknown }).email
     const token = (body as { token?: unknown }).token
-    if (typeof email !== 'string' || typeof token !== 'string') {
+    const subjectId = (body as { subjectId?: unknown }).subjectId
+    const subjectIsAdmin = (body as { subjectIsAdmin?: unknown }).subjectIsAdmin
+    if (
+      typeof email !== 'string' ||
+      typeof token !== 'string' ||
+      typeof subjectId !== 'string' ||
+      typeof subjectIsAdmin !== 'boolean'
+    ) {
       return NextResponse.json({ error: 'Invalid request' }, { status: 400 })
     }
 
@@ -77,15 +84,31 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Invalid request' }, { status: 401 })
     }
 
-    // 5. `body.email` must match the session subject (client tamper check).
-    if (session.user.email !== email) {
+    // 5. `body.email` AND the body subject ({id, isAdmin}) must match the
+    //    session subject. The subject check is what lets the client trust
+    //    the attribution of any non-4xx outcome (and of ALREADY_VERIFIED
+    //    below): emails are not unique across the Admin and WhitelistUser
+    //    tables, so if the session cookie has meanwhile switched to a
+    //    same-email different subject, this request must fail with no side
+    //    effects instead of verifying (or reporting on) the wrong account.
+    if (
+      session.user.email !== email ||
+      session.user.id !== subjectId ||
+      session.user.isAdmin !== subjectIsAdmin
+    ) {
       return NextResponse.json({ error: 'Invalid request' }, { status: 401 })
     }
 
     // 6. Session must still require 2FA — if `requiresTwoFactor` is false
-    //    the user has already completed verification for this login.
+    //    the user has already completed verification for this login. The
+    //    machine-readable code lets the client treat this as the success it
+    //    is (subject match is already guaranteed by step 5) instead of a
+    //    rejection that would discard its recovery state.
     if (!session.user.requiresTwoFactor) {
-      return NextResponse.json({ error: 'Already verified' }, { status: 400 })
+      return NextResponse.json(
+        { error: 'Already verified', code: 'ALREADY_VERIFIED' },
+        { status: 400 },
+      )
     }
 
     // 7. Token format — normalize then validate shape.

--- a/src/app/api/2fa/verify/route.ts
+++ b/src/app/api/2fa/verify/route.ts
@@ -186,18 +186,25 @@ export async function POST(request: Request) {
         verified = true
         usedBackupCode = true
 
-        // 11a. Consume the used backup code (DB side effect #1).
+        // 11a. Consume the used backup code AND record the verification
+        //      timestamp (Issue #123) in a single write: a partial commit
+        //      (code consumed but timestamp missing) would burn the code
+        //      without granting the 5-minute session-refresh window the
+        //      client needs to complete the sign-in.
         backupCodes.splice(codeIndex, 1)
-        const encryptedBackupCodes = encryptBackupCodes(backupCodes)
+        const backupCodeUpdate = {
+          twoFactorBackupCodes: encryptBackupCodes(backupCodes),
+          lastTwoFactorVerifiedAt: new Date(),
+        }
         if (isAdmin) {
           await prisma.admin.update({
             where: { id: user.id },
-            data: { twoFactorBackupCodes: encryptedBackupCodes },
+            data: backupCodeUpdate,
           })
         } else {
           await prisma.whitelistUser.update({
             where: { id: user.id },
-            data: { twoFactorBackupCodes: encryptedBackupCodes },
+            data: backupCodeUpdate,
           })
         }
       }
@@ -209,20 +216,24 @@ export async function POST(request: Request) {
       return NextResponse.json({ error: 'Invalid token' }, { status: 401 })
     }
 
-    // 11b. Record server-side 2FA verification timestamp (Issue #123). The
-    //      JWT callback clears `requiresTwoFactor` when this is within the
-    //      5-minute freshness window.
-    const now = new Date()
-    if (isAdmin) {
-      await prisma.admin.update({
-        where: { id: user.id },
-        data: { lastTwoFactorVerifiedAt: now },
-      })
-    } else {
-      await prisma.whitelistUser.update({
-        where: { id: user.id },
-        data: { lastTwoFactorVerifiedAt: now },
-      })
+    // 11b. Record server-side 2FA verification timestamp (Issue #123) for
+    //      the TOTP path — the backup path wrote it atomically together with
+    //      the code consumption in 11a. The JWT callback clears
+    //      `requiresTwoFactor` when this is within the 5-minute freshness
+    //      window.
+    if (!usedBackupCode) {
+      const now = new Date()
+      if (isAdmin) {
+        await prisma.admin.update({
+          where: { id: user.id },
+          data: { lastTwoFactorVerifiedAt: now },
+        })
+      } else {
+        await prisma.whitelistUser.update({
+          where: { id: user.id },
+          data: { lastTwoFactorVerifiedAt: now },
+        })
+      }
     }
 
     // 11c. Clear rate-limit attempts only AFTER DB side effects have

--- a/src/app/api/2fa/verify/route.ts
+++ b/src/app/api/2fa/verify/route.ts
@@ -38,6 +38,12 @@ import { NextResponse } from 'next/server'
 // Backup code format: 8 alphanumeric characters (uppercase)
 const BACKUP_CODE_REGEX = /^[A-Z0-9]{8}$/
 
+// Matches the jwt callback's freshness window (src/lib/auth-jwt.ts): a
+// server-recorded verification within this window lets the client clear
+// `requiresTwoFactor` via a session update, so a lost/ambiguous response can
+// be recovered with RETRY_SYNC instead of burning another code.
+const TWO_FACTOR_FRESHNESS_WINDOW_MS = 5 * 60 * 1000
+
 // Rate-limit key prefix for 2FA verification (separate from login attempts).
 // The full key is `${RATE_LIMIT_PREFIX}${session.user.id}` — keyed by the
 // JWT subject id, NOT the request body email. This prevents an attacker
@@ -150,6 +156,7 @@ export async function POST(request: Request) {
             twoFactorEnabled: true,
             twoFactorSecret: true,
             twoFactorBackupCodes: true,
+            lastTwoFactorVerifiedAt: true,
           },
         })
       : await prisma.whitelistUser.findUnique({
@@ -159,6 +166,7 @@ export async function POST(request: Request) {
             twoFactorEnabled: true,
             twoFactorSecret: true,
             twoFactorBackupCodes: true,
+            lastTwoFactorVerifiedAt: true,
           },
         })
 
@@ -187,49 +195,117 @@ export async function POST(request: Request) {
       }
       verified = verifyTOTP(decryptedSecret, normalizedToken)
     } else if (isBackupCode && user.twoFactorBackupCodes) {
-      let backupCodes: string[]
-      try {
-        backupCodes = decryptBackupCodes(user.twoFactorBackupCodes)
-      } catch {
-        return NextResponse.json(
-          { error: 'Failed to decrypt backup codes' },
-          { status: 500 },
+      // 11a. Consume the backup code with optimistic concurrency (CAS on the
+      //      encrypted blob): the codes array is a read-modify-write, and two
+      //      concurrent verifications would otherwise lose updates or
+      //      resurrect consumed codes. Each attempt's WHERE pins the exact
+      //      blob it decoded; only `count === 1` is a successful consumption.
+      //      The code removal and the verification timestamp (Issue #123)
+      //      stay in a single write: a partial commit would burn the code
+      //      without granting the 5-minute session-refresh window the client
+      //      needs to complete the sign-in.
+      const isRecentlyVerified = (at: Date | null | undefined): boolean =>
+        at != null && Date.now() - at.getTime() < TWO_FACTOR_FRESHNESS_WINDOW_MS
+      // A missing code with a fresh server-side verification is (almost
+      // certainly) this user's own earlier attempt whose response was lost —
+      // e.g. a rejected fetch, a proxy 5xx, or a reload that dropped the
+      // client's recovery state. Answer with a machine-readable RETRY_SYNC
+      // (no rate-limit side effects in either direction) so the client
+      // finishes via the session sync instead of burning attempts. Guessing
+      // is not helped: every unknown code gets the identical response while
+      // the window is open, and a real, unconsumed code is still required
+      // once it closes.
+      const retrySyncResponse = () =>
+        NextResponse.json(
+          { error: 'Verification already recorded', code: 'RETRY_SYNC' },
+          { status: 409 },
         )
-      }
 
-      let codeIndex = -1
-      for (let i = 0; i < backupCodes.length; i++) {
-        if (timingSafeCompare(backupCodes[i], normalizedToken)) {
-          codeIndex = i
+      let currentBlob: string = user.twoFactorBackupCodes
+      let currentLastVerifiedAt: Date | null = user.lastTwoFactorVerifiedAt
+
+      for (let attempt = 1; ; attempt++) {
+        let backupCodes: string[]
+        try {
+          backupCodes = decryptBackupCodes(currentBlob)
+        } catch {
+          return NextResponse.json(
+            { error: 'Failed to decrypt backup codes' },
+            { status: 500 },
+          )
+        }
+
+        let codeIndex = -1
+        for (let i = 0; i < backupCodes.length; i++) {
+          if (timingSafeCompare(backupCodes[i], normalizedToken)) {
+            codeIndex = i
+            break
+          }
+        }
+
+        if (codeIndex === -1) {
+          if (isRecentlyVerified(currentLastVerifiedAt)) {
+            return retrySyncResponse()
+          }
+          // Definitely invalid: absent from the freshest read with no recent
+          // verification — fall through to the normal 401 (+ failed-attempt
+          // recording) below.
           break
         }
-      }
 
-      if (codeIndex !== -1) {
-        verified = true
-        usedBackupCode = true
-
-        // 11a. Consume the used backup code AND record the verification
-        //      timestamp (Issue #123) in a single write: a partial commit
-        //      (code consumed but timestamp missing) would burn the code
-        //      without granting the 5-minute session-refresh window the
-        //      client needs to complete the sign-in.
         backupCodes.splice(codeIndex, 1)
         const backupCodeUpdate = {
           twoFactorBackupCodes: encryptBackupCodes(backupCodes),
           lastTwoFactorVerifiedAt: new Date(),
         }
-        if (isAdmin) {
-          await prisma.admin.update({
-            where: { id: user.id },
-            data: backupCodeUpdate,
-          })
-        } else {
-          await prisma.whitelistUser.update({
-            where: { id: user.id },
-            data: backupCodeUpdate,
-          })
+        const { count } = isAdmin
+          ? await prisma.admin.updateMany({
+              where: { id: user.id, twoFactorBackupCodes: currentBlob },
+              data: backupCodeUpdate,
+            })
+          : await prisma.whitelistUser.updateMany({
+              where: { id: user.id, twoFactorBackupCodes: currentBlob },
+              data: backupCodeUpdate,
+            })
+        if (count === 1) {
+          verified = true
+          usedBackupCode = true
+          break
         }
+
+        // CAS conflict: a concurrent write landed between our read and our
+        // update. Retry exactly once against the freshest row; a second
+        // conflict returns 503 (no rate-limit side effects — nothing was
+        // proven invalid) and the client recovers via update-first.
+        if (attempt >= 2) {
+          return NextResponse.json(
+            { error: 'Concurrent verification conflict' },
+            { status: 503 },
+          )
+        }
+        const fresh = isAdmin
+          ? await prisma.admin.findUnique({
+              where: { id: user.id },
+              select: {
+                twoFactorBackupCodes: true,
+                lastTwoFactorVerifiedAt: true,
+              },
+            })
+          : await prisma.whitelistUser.findUnique({
+              where: { id: user.id },
+              select: {
+                twoFactorBackupCodes: true,
+                lastTwoFactorVerifiedAt: true,
+              },
+            })
+        if (!fresh?.twoFactorBackupCodes) {
+          if (isRecentlyVerified(fresh?.lastTwoFactorVerifiedAt)) {
+            return retrySyncResponse()
+          }
+          break
+        }
+        currentBlob = fresh.twoFactorBackupCodes
+        currentLastVerifiedAt = fresh.lastTwoFactorVerifiedAt
       }
     }
 

--- a/src/app/auth/verify-2fa/backup/page.test.tsx
+++ b/src/app/auth/verify-2fa/backup/page.test.tsx
@@ -3,9 +3,11 @@
  */
 
 /**
- * Fragment restoration test for the backup-code verification page: after a
- * successful backup-code check it must re-attach the URL fragment (E2EE key)
- * parked by TwoFactorGuard, exactly like the TOTP page.
+ * Tests for the backup-code verification page: fragment restoration, the
+ * lease-gated redirect-away effect, and the update-first recovery path —
+ * mirroring the TOTP page. Recovery matters most here: a backup code is
+ * consumed server-side before the response, so it must never be re-sent
+ * once its outcome is unknown or committed.
  */
 
 jest.mock('next-auth/react', () => ({
@@ -34,6 +36,13 @@ jest.mock('next/link', () => ({
 
 import BackupCodePage from '@/app/auth/verify-2fa/backup/page'
 import { setPendingFragment, takePendingFragment } from '@/lib/pending-fragment'
+import {
+  invalidateTwoFactorFlow,
+  markVerifyIdle,
+  markVerifyServerVerified,
+  releaseTwoFactorLease,
+  tryAcquireTwoFactorLease,
+} from '@/lib/two-factor-verify-flow'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useSession } from 'next-auth/react'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -44,42 +53,74 @@ const mockedUseSearchParams = useSearchParams as jest.MockedFunction<
   typeof useSearchParams
 >
 
+const SUBJECT = { id: 'u1', isAdmin: false }
+
+type UpdateBehavior = 'success' | 'staleTrue' | 'null'
+
 function setup2FASession(
   callbackUrl: string | null = null,
-  { updateSucceeds = true } = {},
+  {
+    updateBehavior = 'success',
+    requiresTwoFactor = true,
+  }: { updateBehavior?: UpdateBehavior; requiresTwoFactor?: boolean } = {},
 ) {
   const replace = jest.fn()
   mockedUseRouter.mockReturnValue({ replace } as never)
   mockedUseSearchParams.mockReturnValue({
     get: (key: string) => (key === 'callbackUrl' ? callbackUrl : null),
   } as never)
-  // Stateful mock mirroring production: update() makes the refreshed session
-  // come back with requiresTwoFactor=false, which re-fires the redirect-away
-  // effect (the race gated by the navigation ref).
-  let requiresTwoFactor = true
+  // Stateful mock mirroring production: a successful update() makes the
+  // refreshed session come back with requiresTwoFactor=false, re-firing the
+  // redirect-away effect (the race gated by the flow lease).
+  let currentRequiresTwoFactor = requiresTwoFactor
   const update = jest.fn(() => {
-    if (!updateSucceeds) return Promise.resolve(null)
-    requiresTwoFactor = false
-    return Promise.resolve({ user: { email: 'user@example.com' } })
+    if (updateBehavior === 'null') return Promise.resolve(null)
+    if (updateBehavior === 'staleTrue') {
+      return Promise.resolve({
+        user: { id: 'u1', isAdmin: false, requiresTwoFactor: true },
+      })
+    }
+    currentRequiresTwoFactor = false
+    return Promise.resolve({
+      user: { id: 'u1', isAdmin: false, requiresTwoFactor: false },
+    })
   })
   mockedUseSession.mockImplementation(
     () =>
       ({
         data: {
-          user: { email: 'user@example.com', requiresTwoFactor },
+          user: {
+            id: 'u1',
+            email: 'user@example.com',
+            isAdmin: false,
+            requiresTwoFactor: currentRequiresTwoFactor,
+          },
         },
         status: 'authenticated',
         update,
       }) as never,
   )
-  return replace
+  return { replace, update }
 }
 
 function succeedingFetch() {
   const fetchMock = jest.fn(() =>
     Promise.resolve({
       ok: true,
+      status: 200,
       json: () => Promise.resolve({}),
+    } as Response),
+  )
+  global.fetch = fetchMock as unknown as typeof fetch
+  return fetchMock
+}
+
+function statusFetch(status: number, body: unknown = {}) {
+  const fetchMock = jest.fn(() =>
+    Promise.resolve({
+      ok: false,
+      status,
+      json: () => Promise.resolve(body),
     } as Response),
   )
   global.fetch = fetchMock as unknown as typeof fetch
@@ -93,14 +134,22 @@ function submitCode(code: string) {
   fireEvent.click(screen.getByRole('button', { name: 'backup.submit' }))
 }
 
+function resetFlowState() {
+  invalidateTwoFactorFlow()
+  const lease = tryAcquireTwoFactorLease()
+  markVerifyIdle(lease)
+  releaseTwoFactorLease(lease)
+}
+
 beforeEach(() => {
   jest.clearAllMocks()
+  resetFlowState()
 })
 
 // Unique callback paths per test: the pending-fragment store is module-level.
 describe('BackupCodePage fragment restoration', () => {
   it('re-attaches the parked fragment (E2EE key) to the callback URL after success', async () => {
-    const replace = setup2FASession('/groups/bk')
+    const { replace } = setup2FASession('/groups/bk')
     succeedingFetch()
     setPendingFragment('/groups/bk', 'KEYbk')
 
@@ -121,7 +170,7 @@ describe('BackupCodePage fragment restoration', () => {
   })
 
   it('navigates to the plain callback URL when no fragment is pending', async () => {
-    const replace = setup2FASession('/groups/bk-plain')
+    const { replace } = setup2FASession('/groups/bk-plain')
     succeedingFetch()
 
     render(<BackupCodePage />)
@@ -137,12 +186,12 @@ describe('BackupCodePage fragment restoration', () => {
     expect(replace).not.toHaveBeenCalledWith('/')
   })
 
-  it('does not navigate or consume the fragment when the session update fails', async () => {
-    const replace = setup2FASession('/groups/bk-upfail', {
-      updateSucceeds: false,
+  it('does not navigate or consume the fragment when update() returns null', async () => {
+    const { replace } = setup2FASession('/groups/bk-upnull', {
+      updateBehavior: 'null',
     })
     succeedingFetch()
-    setPendingFragment('/groups/bk-upfail', 'KEYbkupfail')
+    setPendingFragment('/groups/bk-upnull', 'KEYbkupnull')
 
     render(<BackupCodePage />)
     submitCode('ABCD1234')
@@ -152,6 +201,123 @@ describe('BackupCodePage fragment restoration', () => {
     )
     expect(replace).not.toHaveBeenCalled()
     // The parked fragment must survive for the retry.
-    expect(takePendingFragment('/groups/bk-upfail')).toBe('KEYbkupfail')
+    expect(takePendingFragment('/groups/bk-upnull')).toBe('KEYbkupnull')
+  })
+
+  it('treats a truthy session with requiresTwoFactor still true as a failure', async () => {
+    const { replace } = setup2FASession('/groups/bk-stale', {
+      updateBehavior: 'staleTrue',
+    })
+    succeedingFetch()
+    setPendingFragment('/groups/bk-stale', 'KEYbkstale')
+
+    render(<BackupCodePage />)
+    submitCode('ABCD1234')
+
+    await waitFor(() =>
+      expect(screen.getByText('backup.errors.networkError')).toBeTruthy(),
+    )
+    expect(replace).not.toHaveBeenCalled()
+    expect(takePendingFragment('/groups/bk-stale')).toBe('KEYbkstale')
+  })
+
+  it('recovers from a post-commit 5xx via update() without re-sending the consumed code', async () => {
+    const { replace, update } = setup2FASession('/groups/bk-5xx')
+    const fetchMock = statusFetch(500, {})
+    setPendingFragment('/groups/bk-5xx', 'KEYbk5xx')
+
+    render(<BackupCodePage />)
+    submitCode('ABCD1234')
+
+    await waitFor(() =>
+      expect(screen.getByText('backup.errors.verificationFailed')).toBeTruthy(),
+    )
+    expect(replace).not.toHaveBeenCalled()
+
+    // The code was consumed server-side before the 5xx: the retry must sync
+    // the session instead of burning a resend on the consumed code.
+    fireEvent.click(screen.getByRole('button', { name: 'backup.submit' }))
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith('/groups/bk-5xx#KEYbk5xx'),
+    )
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(replace).not.toHaveBeenCalledWith('/')
+  })
+
+  it('completes on a 2xx even when the response body fails to parse', async () => {
+    const { replace, update } = setup2FASession('/groups/bk-parse')
+    const fetchMock = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.reject(new Error('bad body')),
+      } as unknown as Response),
+    )
+    global.fetch = fetchMock as unknown as typeof fetch
+    setPendingFragment('/groups/bk-parse', 'KEYbkparse')
+
+    render(<BackupCodePage />)
+    submitCode('ABCD1234')
+
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith('/groups/bk-parse#KEYbkparse'),
+    )
+    expect(update).toHaveBeenCalledTimes(1)
+  })
+
+  it('releases the lease when the code fails length validation', async () => {
+    setup2FASession('/groups/bk-len')
+    succeedingFetch()
+
+    render(<BackupCodePage />)
+    submitCode('ABC')
+
+    await waitFor(() =>
+      expect(screen.getByText('backup.errors.invalidLength')).toBeTruthy(),
+    )
+    const lease = tryAcquireTwoFactorLease()
+    expect(lease).not.toBeNull()
+    releaseTwoFactorLease(lease)
+  })
+})
+
+describe('BackupCodePage redirect-away behavior', () => {
+  it('bounces a direct visit that does not require 2FA to / exactly once', async () => {
+    const { replace } = setup2FASession(null, { requiresTwoFactor: false })
+
+    render(<BackupCodePage />)
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith('/'))
+    expect(replace).toHaveBeenCalledTimes(1)
+  })
+
+  it('completes a recovered verification with the callback + fragment instead of bouncing to /', async () => {
+    const lease = tryAcquireTwoFactorLease()
+    markVerifyServerVerified(lease, SUBJECT)
+    releaseTwoFactorLease(lease)
+    setPendingFragment('/groups/bk-rc', 'KEYbkrc')
+    const { replace } = setup2FASession('/groups/bk-rc', {
+      requiresTwoFactor: false,
+    })
+
+    render(<BackupCodePage />)
+
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith('/groups/bk-rc#KEYbkrc'),
+    )
+    expect(replace).toHaveBeenCalledTimes(1)
+    expect(replace).not.toHaveBeenCalledWith('/')
+  })
+
+  it('normalizes a callback pointing back into the verify flow to /', async () => {
+    const { replace } = setup2FASession('/auth/verify-2fa/backup')
+    succeedingFetch()
+
+    render(<BackupCodePage />)
+    submitCode('ABCD1234')
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith('/'))
+    expect(replace).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/app/auth/verify-2fa/backup/page.test.tsx
+++ b/src/app/auth/verify-2fa/backup/page.test.tsx
@@ -1,0 +1,111 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Fragment restoration test for the backup-code verification page: after a
+ * successful backup-code check it must re-attach the URL fragment (E2EE key)
+ * parked by TwoFactorGuard, exactly like the TOTP page.
+ */
+
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+}))
+
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  useSearchParams: jest.fn(),
+}))
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode
+    href: string
+  }) => <a href={href}>{children}</a>,
+}))
+
+import BackupCodePage from '@/app/auth/verify-2fa/backup/page'
+import { setPendingFragment } from '@/lib/pending-fragment'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useSession } from 'next-auth/react'
+import { useRouter, useSearchParams } from 'next/navigation'
+
+const mockedUseSession = useSession as jest.MockedFunction<typeof useSession>
+const mockedUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
+const mockedUseSearchParams = useSearchParams as jest.MockedFunction<
+  typeof useSearchParams
+>
+
+function setup2FASession(callbackUrl: string | null = null) {
+  const replace = jest.fn()
+  mockedUseRouter.mockReturnValue({ replace } as never)
+  mockedUseSearchParams.mockReturnValue({
+    get: (key: string) => (key === 'callbackUrl' ? callbackUrl : null),
+  } as never)
+  mockedUseSession.mockReturnValue({
+    data: {
+      user: { email: 'user@example.com', requiresTwoFactor: true },
+    },
+    status: 'authenticated',
+    update: jest.fn(() => Promise.resolve()),
+  } as never)
+  return replace
+}
+
+function succeedingFetch() {
+  const fetchMock = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({}),
+    } as Response),
+  )
+  global.fetch = fetchMock as unknown as typeof fetch
+  return fetchMock
+}
+
+function submitCode(code: string) {
+  fireEvent.change(screen.getByLabelText('backup.codeLabel'), {
+    target: { value: code },
+  })
+  fireEvent.click(screen.getByRole('button', { name: 'backup.submit' }))
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+// Unique callback paths per test: the pending-fragment store is module-level.
+describe('BackupCodePage fragment restoration', () => {
+  it('re-attaches the parked fragment (E2EE key) to the callback URL after success', async () => {
+    const replace = setup2FASession('/groups/bk')
+    succeedingFetch()
+    setPendingFragment('/groups/bk', 'KEYbk')
+
+    render(<BackupCodePage />)
+    submitCode('ABCD1234')
+
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith('/groups/bk#KEYbk'),
+    )
+  })
+
+  it('navigates to the plain callback URL when no fragment is pending', async () => {
+    const replace = setup2FASession('/groups/bk-plain')
+    succeedingFetch()
+
+    render(<BackupCodePage />)
+    submitCode('ABCD1234')
+
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith('/groups/bk-plain'),
+    )
+  })
+})

--- a/src/app/auth/verify-2fa/backup/page.test.tsx
+++ b/src/app/auth/verify-2fa/backup/page.test.tsx
@@ -355,8 +355,12 @@ describe('BackupCodePage recovery gating', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 
-  it('never sends another backup code while a rejected dispatch may still be running', async () => {
-    const { update } = setup2FASession('/groups/bk-uns', {
+  it('allows manually re-sending the SAME code once update() confirms the session still pending', async () => {
+    // With server-side CAS serializing concurrent consumption and RETRY_SYNC
+    // answering for a committed-but-lost response, a manual resend of the
+    // only remaining code must be possible — otherwise a user whose last
+    // code got an ambiguous response would be stuck.
+    const { update } = setup2FASession('/groups/bk-same', {
       updateBehavior: 'staleTrue',
     })
     const fetchMock = rejectingFetch()
@@ -371,9 +375,30 @@ describe('BackupCodePage recovery gating', () => {
       ).toBe(false),
     )
 
-    // The rejected request may STILL be rewriting the codes array
-    // server-side: even a DIFFERENT backup code must not be sent while the
-    // dispatch is unsettled (recover via update() or the TOTP page).
+    // Same code again: update-first runs (still pending), then the resend.
+    fireEvent.click(screen.getByRole('button', { name: 'backup.submit' }))
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    expect(update).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not burn another code while the session sync channel is broken', async () => {
+    const { update } = setup2FASession('/groups/bk-broken', {
+      updateBehavior: 'null',
+    })
+    const fetchMock = rejectingFetch()
+
+    render(<BackupCodePage />)
+    submitCode('ABCD1234')
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    await waitFor(() =>
+      expect(
+        (screen.getByLabelText('backup.codeLabel') as HTMLInputElement)
+          .disabled,
+      ).toBe(false),
+    )
+
+    // update() returned null — no explicit same-subject confirmation, so
+    // no resend (same or different code).
     submitCode('WXYZ9876')
     await waitFor(() => expect(update).toHaveBeenCalledTimes(1))
     await waitFor(() =>
@@ -383,6 +408,25 @@ describe('BackupCodePage recovery gating', () => {
       ).toBe(false),
     )
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats a RETRY_SYNC conflict as a committed verification and completes with the fragment', async () => {
+    // The server answers RETRY_SYNC when the code is gone but a fresh
+    // verification is on record (this user's own lost response).
+    const { replace, update } = setup2FASession('/groups/bk-rs')
+    statusFetch(409, {
+      error: 'Verification already recorded',
+      code: 'RETRY_SYNC',
+    })
+    setPendingFragment('/groups/bk-rs', 'KEYbkrs', SUBJECT)
+
+    render(<BackupCodePage />)
+    submitCode('ABCD1234')
+
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith('/groups/bk-rs#KEYbkrs'),
+    )
+    expect(update).toHaveBeenCalledTimes(1)
   })
 
   it('allows a different code after a 5xx: the request got an answer', async () => {

--- a/src/app/auth/verify-2fa/backup/page.test.tsx
+++ b/src/app/auth/verify-2fa/backup/page.test.tsx
@@ -33,7 +33,7 @@ jest.mock('next/link', () => ({
 }))
 
 import BackupCodePage from '@/app/auth/verify-2fa/backup/page'
-import { setPendingFragment } from '@/lib/pending-fragment'
+import { setPendingFragment, takePendingFragment } from '@/lib/pending-fragment'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useSession } from 'next-auth/react'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -44,19 +44,34 @@ const mockedUseSearchParams = useSearchParams as jest.MockedFunction<
   typeof useSearchParams
 >
 
-function setup2FASession(callbackUrl: string | null = null) {
+function setup2FASession(
+  callbackUrl: string | null = null,
+  { updateSucceeds = true } = {},
+) {
   const replace = jest.fn()
   mockedUseRouter.mockReturnValue({ replace } as never)
   mockedUseSearchParams.mockReturnValue({
     get: (key: string) => (key === 'callbackUrl' ? callbackUrl : null),
   } as never)
-  mockedUseSession.mockReturnValue({
-    data: {
-      user: { email: 'user@example.com', requiresTwoFactor: true },
-    },
-    status: 'authenticated',
-    update: jest.fn(() => Promise.resolve()),
-  } as never)
+  // Stateful mock mirroring production: update() makes the refreshed session
+  // come back with requiresTwoFactor=false, which re-fires the redirect-away
+  // effect (the race gated by the navigation ref).
+  let requiresTwoFactor = true
+  const update = jest.fn(() => {
+    if (!updateSucceeds) return Promise.resolve(null)
+    requiresTwoFactor = false
+    return Promise.resolve({ user: { email: 'user@example.com' } })
+  })
+  mockedUseSession.mockImplementation(
+    () =>
+      ({
+        data: {
+          user: { email: 'user@example.com', requiresTwoFactor },
+        },
+        status: 'authenticated',
+        update,
+      }) as never,
+  )
   return replace
 }
 
@@ -95,6 +110,14 @@ describe('BackupCodePage fragment restoration', () => {
     await waitFor(() =>
       expect(replace).toHaveBeenCalledWith('/groups/bk#KEYbk'),
     )
+    // Wait for the post-update re-render (requiresTwoFactor=false renders
+    // null) so the redirect-away effect has re-fired before asserting it did
+    // not steal the navigation with replace('/').
+    await waitFor(() =>
+      expect(screen.queryByLabelText('backup.codeLabel')).toBeNull(),
+    )
+    expect(replace).toHaveBeenCalledTimes(1)
+    expect(replace).not.toHaveBeenCalledWith('/')
   })
 
   it('navigates to the plain callback URL when no fragment is pending', async () => {
@@ -107,5 +130,28 @@ describe('BackupCodePage fragment restoration', () => {
     await waitFor(() =>
       expect(replace).toHaveBeenCalledWith('/groups/bk-plain'),
     )
+    await waitFor(() =>
+      expect(screen.queryByLabelText('backup.codeLabel')).toBeNull(),
+    )
+    expect(replace).toHaveBeenCalledTimes(1)
+    expect(replace).not.toHaveBeenCalledWith('/')
+  })
+
+  it('does not navigate or consume the fragment when the session update fails', async () => {
+    const replace = setup2FASession('/groups/bk-upfail', {
+      updateSucceeds: false,
+    })
+    succeedingFetch()
+    setPendingFragment('/groups/bk-upfail', 'KEYbkupfail')
+
+    render(<BackupCodePage />)
+    submitCode('ABCD1234')
+
+    await waitFor(() =>
+      expect(screen.getByText('backup.errors.networkError')).toBeTruthy(),
+    )
+    expect(replace).not.toHaveBeenCalled()
+    // The parked fragment must survive for the retry.
+    expect(takePendingFragment('/groups/bk-upfail')).toBe('KEYbkupfail')
   })
 })

--- a/src/app/auth/verify-2fa/backup/page.test.tsx
+++ b/src/app/auth/verify-2fa/backup/page.test.tsx
@@ -43,7 +43,7 @@ import {
   releaseTwoFactorLease,
   tryAcquireTwoFactorLease,
 } from '@/lib/two-factor-verify-flow'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useSession } from 'next-auth/react'
 import { useRouter, useSearchParams } from 'next/navigation'
 
@@ -103,6 +103,12 @@ function setup2FASession(
   return { replace, update }
 }
 
+function rejectingFetch() {
+  const fetchMock = jest.fn(() => Promise.reject(new Error('offline')))
+  global.fetch = fetchMock as unknown as typeof fetch
+  return fetchMock
+}
+
 function succeedingFetch() {
   const fetchMock = jest.fn(() =>
     Promise.resolve({
@@ -136,7 +142,7 @@ function submitCode(code: string) {
 
 function resetFlowState() {
   invalidateTwoFactorFlow()
-  const lease = tryAcquireTwoFactorLease()
+  const lease = tryAcquireTwoFactorLease(null)
   markVerifyIdle(lease)
   releaseTwoFactorLease(lease)
 }
@@ -151,7 +157,7 @@ describe('BackupCodePage fragment restoration', () => {
   it('re-attaches the parked fragment (E2EE key) to the callback URL after success', async () => {
     const { replace } = setup2FASession('/groups/bk')
     succeedingFetch()
-    setPendingFragment('/groups/bk', 'KEYbk')
+    setPendingFragment('/groups/bk', 'KEYbk', SUBJECT)
 
     render(<BackupCodePage />)
     submitCode('ABCD1234')
@@ -191,7 +197,7 @@ describe('BackupCodePage fragment restoration', () => {
       updateBehavior: 'null',
     })
     succeedingFetch()
-    setPendingFragment('/groups/bk-upnull', 'KEYbkupnull')
+    setPendingFragment('/groups/bk-upnull', 'KEYbkupnull', SUBJECT)
 
     render(<BackupCodePage />)
     submitCode('ABCD1234')
@@ -201,7 +207,9 @@ describe('BackupCodePage fragment restoration', () => {
     )
     expect(replace).not.toHaveBeenCalled()
     // The parked fragment must survive for the retry.
-    expect(takePendingFragment('/groups/bk-upnull')).toBe('KEYbkupnull')
+    expect(takePendingFragment('/groups/bk-upnull', SUBJECT)).toBe(
+      'KEYbkupnull',
+    )
   })
 
   it('treats a truthy session with requiresTwoFactor still true as a failure', async () => {
@@ -209,7 +217,7 @@ describe('BackupCodePage fragment restoration', () => {
       updateBehavior: 'staleTrue',
     })
     succeedingFetch()
-    setPendingFragment('/groups/bk-stale', 'KEYbkstale')
+    setPendingFragment('/groups/bk-stale', 'KEYbkstale', SUBJECT)
 
     render(<BackupCodePage />)
     submitCode('ABCD1234')
@@ -218,13 +226,13 @@ describe('BackupCodePage fragment restoration', () => {
       expect(screen.getByText('backup.errors.networkError')).toBeTruthy(),
     )
     expect(replace).not.toHaveBeenCalled()
-    expect(takePendingFragment('/groups/bk-stale')).toBe('KEYbkstale')
+    expect(takePendingFragment('/groups/bk-stale', SUBJECT)).toBe('KEYbkstale')
   })
 
   it('recovers from a post-commit 5xx via update() without re-sending the consumed code', async () => {
     const { replace, update } = setup2FASession('/groups/bk-5xx')
     const fetchMock = statusFetch(500, {})
-    setPendingFragment('/groups/bk-5xx', 'KEYbk5xx')
+    setPendingFragment('/groups/bk-5xx', 'KEYbk5xx', SUBJECT)
 
     render(<BackupCodePage />)
     submitCode('ABCD1234')
@@ -255,7 +263,7 @@ describe('BackupCodePage fragment restoration', () => {
       } as unknown as Response),
     )
     global.fetch = fetchMock as unknown as typeof fetch
-    setPendingFragment('/groups/bk-parse', 'KEYbkparse')
+    setPendingFragment('/groups/bk-parse', 'KEYbkparse', SUBJECT)
 
     render(<BackupCodePage />)
     submitCode('ABCD1234')
@@ -276,9 +284,11 @@ describe('BackupCodePage fragment restoration', () => {
     await waitFor(() =>
       expect(screen.getByText('backup.errors.invalidLength')).toBeTruthy(),
     )
-    const lease = tryAcquireTwoFactorLease()
-    expect(lease).not.toBeNull()
-    releaseTwoFactorLease(lease)
+    await act(async () => {
+      const lease = tryAcquireTwoFactorLease(SUBJECT)
+      expect(lease).not.toBeNull()
+      releaseTwoFactorLease(lease)
+    })
   })
 })
 
@@ -293,10 +303,10 @@ describe('BackupCodePage redirect-away behavior', () => {
   })
 
   it('completes a recovered verification with the callback + fragment instead of bouncing to /', async () => {
-    const lease = tryAcquireTwoFactorLease()
+    const lease = tryAcquireTwoFactorLease(SUBJECT)
     markVerifyServerVerified(lease, SUBJECT)
     releaseTwoFactorLease(lease)
-    setPendingFragment('/groups/bk-rc', 'KEYbkrc')
+    setPendingFragment('/groups/bk-rc', 'KEYbkrc', SUBJECT)
     const { replace } = setup2FASession('/groups/bk-rc', {
       requiresTwoFactor: false,
     })
@@ -319,5 +329,92 @@ describe('BackupCodePage redirect-away behavior', () => {
 
     await waitFor(() => expect(replace).toHaveBeenCalledWith('/'))
     expect(replace).toHaveBeenCalledTimes(1)
+  })
+})
+
+// Round-4 hardening: transport-unsettled backup dispatches, strict
+// fall-through gating, and ALREADY_VERIFIED completion.
+describe('BackupCodePage recovery gating', () => {
+  it('recovers from a rejected backup dispatch via update() only, without re-sending', async () => {
+    const { replace } = setup2FASession('/groups/bk-rej')
+    const fetchMock = rejectingFetch()
+    setPendingFragment('/groups/bk-rej', 'KEYbkrej', SUBJECT)
+
+    render(<BackupCodePage />)
+    submitCode('ABCD1234')
+    await waitFor(() =>
+      expect(screen.getByText('backup.errors.networkError')).toBeTruthy(),
+    )
+
+    // Same code again: update-first succeeds and completes the navigation
+    // without ever re-sending the (possibly consumed) code.
+    fireEvent.click(screen.getByRole('button', { name: 'backup.submit' }))
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith('/groups/bk-rej#KEYbkrej'),
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('never sends another backup code while a rejected dispatch may still be running', async () => {
+    const { update } = setup2FASession('/groups/bk-uns', {
+      updateBehavior: 'staleTrue',
+    })
+    const fetchMock = rejectingFetch()
+
+    render(<BackupCodePage />)
+    submitCode('ABCD1234')
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    await waitFor(() =>
+      expect(
+        (screen.getByLabelText('backup.codeLabel') as HTMLInputElement)
+          .disabled,
+      ).toBe(false),
+    )
+
+    // The rejected request may STILL be rewriting the codes array
+    // server-side: even a DIFFERENT backup code must not be sent while the
+    // dispatch is unsettled (recover via update() or the TOTP page).
+    submitCode('WXYZ9876')
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1))
+    await waitFor(() =>
+      expect(
+        (screen.getByLabelText('backup.codeLabel') as HTMLInputElement)
+          .disabled,
+      ).toBe(false),
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('allows a different code after a 5xx: the request got an answer', async () => {
+    const { update } = setup2FASession('/groups/bk-5xxd', {
+      updateBehavior: 'staleTrue',
+    })
+    const fetchMock = statusFetch(500, {})
+
+    render(<BackupCodePage />)
+    submitCode('ABCD1234')
+    await waitFor(() =>
+      expect(screen.getByText('backup.errors.verificationFailed')).toBeTruthy(),
+    )
+
+    // A 5xx settled the transport (no concurrent rewrite risk); with the
+    // sync channel confirmed healthy, a different code is a fresh attempt.
+    submitCode('WXYZ9876')
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    expect(update).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats an ALREADY_VERIFIED rejection as success and completes with the fragment', async () => {
+    const { replace, update } = setup2FASession('/groups/bk-av')
+    statusFetch(400, { error: 'Already verified', code: 'ALREADY_VERIFIED' })
+    setPendingFragment('/groups/bk-av', 'KEYbkav', SUBJECT)
+
+    render(<BackupCodePage />)
+    submitCode('ABCD1234')
+
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith('/groups/bk-av#KEYbkav'),
+    )
+    expect(update).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/app/auth/verify-2fa/backup/page.tsx
+++ b/src/app/auth/verify-2fa/backup/page.tsx
@@ -20,16 +20,24 @@ import {
 } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { restorePendingFragment } from '@/lib/pending-fragment'
+import {
+  clearPendingFragment,
+  restorePendingFragment,
+} from '@/lib/pending-fragment'
 import { sanitizeCallbackUrl } from '@/lib/safe-callback-url'
 import {
+  getTwoFactorFlowServerVersion,
+  getTwoFactorFlowVersion,
   getVerifyOutcome,
+  isBackupDispatchUnsettled,
   isTwoFactorLeaseOwner,
   isVerifyFlowPath,
   markVerifyDispatched,
   markVerifyIdle,
+  markVerifyResponded,
   markVerifyServerVerified,
   releaseTwoFactorLease,
+  subscribeTwoFactorFlow,
   tryAcquireTwoFactorLease,
   wasVerifyTokenDispatched,
 } from '@/lib/two-factor-verify-flow'
@@ -44,7 +52,7 @@ import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useSyncExternalStore } from 'react'
 
 export default function BackupCodePage() {
   const t = useTranslations('TwoFactorAuth')
@@ -62,6 +70,16 @@ export default function BackupCodePage() {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  // Lease-state version: re-arms the bounce/recovery effect below when the
+  // lease changes hands — a page that lost a tryAcquire race once would
+  // otherwise never get a second chance (lost wakeup) and render blank
+  // forever.
+  const flowVersion = useSyncExternalStore(
+    subscribeTwoFactorFlow,
+    getTwoFactorFlowVersion,
+    getTwoFactorFlowServerVersion,
+  )
+
   // Bounce direct visitors who don't need 2FA, and complete a recovered
   // verification. Navigating here requires acquiring the flow lease, so this
   // can never race an in-flight verification transaction (tryAcquire fails
@@ -69,28 +87,32 @@ export default function BackupCodePage() {
   // twice (the acquired lease is only invalidated by TwoFactorGuard after
   // landing outside the flow).
   useEffect(() => {
+    // Read the version so the lease subscription re-runs this effect.
+    void flowVersion
     if (status === 'loading') return
     if (session?.user?.requiresTwoFactor) return
 
-    const lease = tryAcquireTwoFactorLease()
+    const user = session?.user
+    const subject = user ? { id: user.id, isAdmin: user.isAdmin } : null
+    const lease = tryAcquireTwoFactorLease(subject)
     if (lease === null) return
 
-    const user = session?.user
-    if (
-      user &&
-      getVerifyOutcome({ id: user.id, isAdmin: user.isAdmin }) !== 'idle'
-    ) {
+    if (subject && getVerifyOutcome(subject) !== 'idle') {
       // A verification for this subject reached the server before the
       // session flipped (the transaction was interrupted): finish its
       // navigation instead of discarding the parked fragment with a '/'
       // bounce.
       markVerifyIdle(lease)
-      router.replace(restorePendingFragment(callbackUrl))
+      router.replace(restorePendingFragment(callbackUrl, subject))
       return
     }
 
+    // Discarding bounce (incl. signed-out): the parked fragment's completion
+    // chance is gone — destroy it so it can never re-attach to another
+    // subject's navigation.
+    clearPendingFragment()
     router.replace('/')
-  }, [session, status, router, callbackUrl])
+  }, [session, status, router, callbackUrl, flowVersion])
 
   // Handle code input - only allow alphanumeric and convert to uppercase
   const handleCodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -113,7 +135,7 @@ export default function BackupCodePage() {
     // switching from the TOTP page mid-request) joins it as a no-op — the
     // in-flight transaction drives the navigation, and its update() will
     // settle the session either way.
-    const lease = tryAcquireTwoFactorLease()
+    const lease = tryAcquireTwoFactorLease(subject)
     if (lease === null) return
 
     setIsLoading(true)
@@ -136,18 +158,29 @@ export default function BackupCodePage() {
           updated?.user?.requiresTwoFactor === false
         ) {
           markVerifyIdle(lease)
-          router.replace(restorePendingFragment(callbackUrl))
+          router.replace(restorePendingFragment(callbackUrl, subject))
           return
         }
+        // A fresh POST is only safe when the sync channel itself is
+        // healthy: update() explicitly returned the SAME subject still
+        // requiring 2FA. On null / foreign / malformed sessions, burning
+        // another code cannot help — keep the outcome and let the user
+        // retry the sync. The same dispatched code is never re-sent, and
+        // while a backup-code dispatch never got a response (the request
+        // may STILL be running server-side), sending a different backup
+        // code could race the server's non-CAS rewrite of the codes array
+        // (lost update / code resurrection) — recover via the session sync
+        // or the TOTP page instead.
+        const sessionConfirmsPending =
+          updated?.user?.id === subject.id &&
+          updated?.user?.isAdmin === subject.isAdmin &&
+          updated?.user?.requiresTwoFactor === true
         if (
-          mode === 'serverVerified' ||
+          !sessionConfirmsPending ||
           wasVerifyTokenDispatched(subject, code) ||
+          isBackupDispatchUnsettled(subject) ||
           code.length !== 8
         ) {
-          // Never auto-resend: 'serverVerified' means the server already
-          // committed, and an unknown outcome must not re-send the same
-          // code. Only a different, complete code falls through to a fresh
-          // attempt.
           releaseTwoFactorLease(lease)
           setError(t('backup.errors.networkError'))
           return
@@ -159,7 +192,7 @@ export default function BackupCodePage() {
         return
       }
 
-      markVerifyDispatched(lease, subject, code)
+      markVerifyDispatched(lease, subject, code, 'backup')
 
       const response = await fetch('/api/2fa/verify', {
         method: 'POST',
@@ -169,24 +202,70 @@ export default function BackupCodePage() {
         body: JSON.stringify({
           email: user.email,
           token: code,
+          // The server rejects a body subject that differs from its
+          // session, so any non-4xx outcome is attributable to THIS subject
+          // even if the cookie switched to a same-email account.
+          subjectId: subject.id,
+          subjectIsAdmin: subject.isAdmin,
         }),
       })
       if (!isTwoFactorLeaseOwner(lease)) return
+      // The dispatch got an answer — the request is no longer running
+      // server-side.
+      markVerifyResponded(lease)
+
+      // The server committed the verification for this subject: sync the
+      // session and finish the navigation. Reached on a 2xx and on the
+      // ALREADY_VERIFIED rejection (a success in disguise: e.g. another tab
+      // completed first).
+      const finishServerVerified = async (): Promise<void> => {
+        markVerifyServerVerified(lease, subject)
+        const updated = await update({ twoFactorVerified: true })
+        if (!isTwoFactorLeaseOwner(lease)) return
+        if (
+          !(
+            updated?.user?.id === subject.id &&
+            updated?.user?.isAdmin === subject.isAdmin &&
+            updated?.user?.requiresTwoFactor === false
+          )
+        ) {
+          // Session refresh failed (or returned a foreign session):
+          // navigating now would bounce back through the guard and consume
+          // the parked fragment for nothing. Keep it parked and keep
+          // 'serverVerified' — the retry syncs the session without
+          // re-sending the consumed code.
+          releaseTwoFactorLease(lease)
+          setError(t('backup.errors.networkError'))
+          return
+        }
+        markVerifyIdle(lease)
+        // The lease stays active through the navigation; TwoFactorGuard
+        // invalidates it synchronously on the first commit outside the
+        // flow. Re-attach the URL fragment (E2EE key) that TwoFactorGuard
+        // parked before redirecting here.
+        router.replace(restorePendingFragment(callbackUrl, subject))
+      }
 
       if (!response.ok) {
         if (response.status >= 400 && response.status < 500) {
-          // Definite rejection — the server recorded no verification.
-          markVerifyIdle(lease)
-          let message: string | null = null
+          let errorBody: { error?: string; code?: string } | null = null
           try {
-            message =
-              ((await response.json()) as { error?: string }).error ?? null
+            errorBody = (await response.json()) as {
+              error?: string
+              code?: string
+            }
           } catch {
             // The error body is best-effort.
           }
           if (!isTwoFactorLeaseOwner(lease)) return
+          if (errorBody?.code === 'ALREADY_VERIFIED') {
+            await finishServerVerified()
+            return
+          }
+          // Definite rejection — the server recorded no verification.
+          markVerifyIdle(lease)
           releaseTwoFactorLease(lease)
-          setError(message ?? t('backup.errors.verificationFailed'))
+          setError(errorBody?.error ?? t('backup.errors.verificationFailed'))
           setCode('')
           return
         }
@@ -201,33 +280,7 @@ export default function BackupCodePage() {
       // 2xx observed — the server committed (and consumed the backup code).
       // The body is not needed on success, and a parse failure must not
       // discard that result.
-      markVerifyServerVerified(lease, subject)
-
-      // Update session to mark 2FA as verified
-      const updated = await update({ twoFactorVerified: true })
-      if (!isTwoFactorLeaseOwner(lease)) return
-      if (
-        !(
-          updated?.user?.id === subject.id &&
-          updated?.user?.isAdmin === subject.isAdmin &&
-          updated?.user?.requiresTwoFactor === false
-        )
-      ) {
-        // Session refresh failed (or returned a foreign session): navigating
-        // now would bounce back through the guard and consume the parked
-        // fragment for nothing. Keep it parked and keep 'serverVerified' —
-        // the retry syncs the session without re-sending the consumed code.
-        releaseTwoFactorLease(lease)
-        setError(t('backup.errors.networkError'))
-        return
-      }
-
-      markVerifyIdle(lease)
-      // The lease stays active through the navigation; TwoFactorGuard
-      // invalidates it synchronously on the first commit outside the flow.
-      // Redirect to the callback URL, re-attaching the URL fragment
-      // (E2EE key) that TwoFactorGuard parked before redirecting here.
-      router.replace(restorePendingFragment(callbackUrl))
+      await finishServerVerified()
     } catch {
       if (!isTwoFactorLeaseOwner(lease)) return
       releaseTwoFactorLease(lease)

--- a/src/app/auth/verify-2fa/backup/page.tsx
+++ b/src/app/auth/verify-2fa/backup/page.tsx
@@ -33,7 +33,7 @@ import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 export default function BackupCodePage() {
   const t = useTranslations('TwoFactorAuth')
@@ -47,9 +47,19 @@ export default function BackupCodePage() {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
+  // Set while the success handler owns navigation: once update() reflects
+  // requiresTwoFactor=false, the redirect-away effect below re-fires and its
+  // replace('/') would race the success replace and strand the one-shot
+  // parked fragment (E2EE key). Reset if the session refresh fails.
+  const isNavigatingAfterVerifyRef = useRef(false)
+
   // Redirect if user doesn't require 2FA verification
   useEffect(() => {
     if (status === 'loading') return
+
+    // The success handler is navigating to the callback URL; the session
+    // refresh flipping requiresTwoFactor must not bounce to '/' instead.
+    if (isNavigatingAfterVerifyRef.current) return
 
     // If no session or doesn't require 2FA, redirect to home
     if (!session?.user?.requiresTwoFactor) {
@@ -100,13 +110,27 @@ export default function BackupCodePage() {
         return
       }
 
+      // From here the success handler owns navigation; set before the
+      // await so the redirect-away effect stays quiet while the session
+      // refresh lands (see the effect above).
+      isNavigatingAfterVerifyRef.current = true
+
       // Update session to mark 2FA as verified
-      await update({ twoFactorVerified: true })
+      const updatedSession = await update({ twoFactorVerified: true })
+      if (!updatedSession) {
+        // Session refresh failed: navigating now would bounce back through
+        // the guard and consume the parked fragment for nothing. Keep it
+        // parked and let the user retry.
+        isNavigatingAfterVerifyRef.current = false
+        setError(t('backup.errors.networkError'))
+        return
+      }
 
       // Redirect to callback URL or home, re-attaching the URL fragment
       // (E2EE key) that TwoFactorGuard parked before redirecting here.
       router.replace(restorePendingFragment(callbackUrl))
     } catch {
+      isNavigatingAfterVerifyRef.current = false
       setError(t('backup.errors.networkError'))
     } finally {
       setIsLoading(false)

--- a/src/app/auth/verify-2fa/backup/page.tsx
+++ b/src/app/auth/verify-2fa/backup/page.tsx
@@ -23,6 +23,17 @@ import { Label } from '@/components/ui/label'
 import { restorePendingFragment } from '@/lib/pending-fragment'
 import { sanitizeCallbackUrl } from '@/lib/safe-callback-url'
 import {
+  getVerifyOutcome,
+  isTwoFactorLeaseOwner,
+  isVerifyFlowPath,
+  markVerifyDispatched,
+  markVerifyIdle,
+  markVerifyServerVerified,
+  releaseTwoFactorLease,
+  tryAcquireTwoFactorLease,
+  wasVerifyTokenDispatched,
+} from '@/lib/two-factor-verify-flow'
+import {
   AlertCircle,
   AlertTriangle,
   KeyRound,
@@ -33,13 +44,17 @@ import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 
 export default function BackupCodePage() {
   const t = useTranslations('TwoFactorAuth')
   const router = useRouter()
   const searchParams = useSearchParams()
-  const callbackUrl = sanitizeCallbackUrl(searchParams.get('callbackUrl'))
+  const rawCallbackUrl = sanitizeCallbackUrl(searchParams.get('callbackUrl'))
+  // A callback pointing back into the verify flow would keep the navigation
+  // lease active forever (TwoFactorGuard only invalidates it outside the
+  // flow) and strand the user on a blank page; normalize it to '/'.
+  const callbackUrl = isVerifyFlowPath(rawCallbackUrl) ? '/' : rawCallbackUrl
 
   const { data: session, status, update } = useSession()
 
@@ -47,25 +62,35 @@ export default function BackupCodePage() {
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  // Set while the success handler owns navigation: once update() reflects
-  // requiresTwoFactor=false, the redirect-away effect below re-fires and its
-  // replace('/') would race the success replace and strand the one-shot
-  // parked fragment (E2EE key). Reset if the session refresh fails.
-  const isNavigatingAfterVerifyRef = useRef(false)
-
-  // Redirect if user doesn't require 2FA verification
+  // Bounce direct visitors who don't need 2FA, and complete a recovered
+  // verification. Navigating here requires acquiring the flow lease, so this
+  // can never race an in-flight verification transaction (tryAcquire fails
+  // while one is active, on THIS page or the TOTP page) and never fires
+  // twice (the acquired lease is only invalidated by TwoFactorGuard after
+  // landing outside the flow).
   useEffect(() => {
     if (status === 'loading') return
+    if (session?.user?.requiresTwoFactor) return
 
-    // The success handler is navigating to the callback URL; the session
-    // refresh flipping requiresTwoFactor must not bounce to '/' instead.
-    if (isNavigatingAfterVerifyRef.current) return
+    const lease = tryAcquireTwoFactorLease()
+    if (lease === null) return
 
-    // If no session or doesn't require 2FA, redirect to home
-    if (!session?.user?.requiresTwoFactor) {
-      router.replace('/')
+    const user = session?.user
+    if (
+      user &&
+      getVerifyOutcome({ id: user.id, isAdmin: user.isAdmin }) !== 'idle'
+    ) {
+      // A verification for this subject reached the server before the
+      // session flipped (the transaction was interrupted): finish its
+      // navigation instead of discarding the parked fragment with a '/'
+      // bounce.
+      markVerifyIdle(lease)
+      router.replace(restorePendingFragment(callbackUrl))
+      return
     }
-  }, [session, status, router])
+
+    router.replace('/')
+  }, [session, status, router, callbackUrl])
 
   // Handle code input - only allow alphanumeric and convert to uppercase
   const handleCodeChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -79,58 +104,135 @@ export default function BackupCodePage() {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
-    if (code.length !== 8) {
-      setError(t('backup.errors.invalidLength'))
-      return
-    }
+    const user = session?.user
+    if (!user) return
+    const subject = { id: user.id, isAdmin: user.isAdmin }
+
+    // Exclusive lease: one verification transaction at a time across BOTH
+    // verify pages. A second submit while one is in flight (e.g. after
+    // switching from the TOTP page mid-request) joins it as a no-op — the
+    // in-flight transaction drives the navigation, and its update() will
+    // settle the session either way.
+    const lease = tryAcquireTwoFactorLease()
+    if (lease === null) return
 
     setIsLoading(true)
     setError(null)
 
     try {
+      const mode = getVerifyOutcome(subject)
+
+      if (mode !== 'idle') {
+        // A previous attempt reached the server ('serverVerified') or its
+        // result is unknown (rejected fetch / 5xx may have committed):
+        // retry the session sync FIRST instead of re-sending a code. A
+        // resend would burn a second backup code or fail on the consumed
+        // one. Success requires the SAME subject with the flag cleared.
+        const updated = await update({ twoFactorVerified: true })
+        if (!isTwoFactorLeaseOwner(lease)) return
+        if (
+          updated?.user?.id === subject.id &&
+          updated?.user?.isAdmin === subject.isAdmin &&
+          updated?.user?.requiresTwoFactor === false
+        ) {
+          markVerifyIdle(lease)
+          router.replace(restorePendingFragment(callbackUrl))
+          return
+        }
+        if (
+          mode === 'serverVerified' ||
+          wasVerifyTokenDispatched(subject, code) ||
+          code.length !== 8
+        ) {
+          // Never auto-resend: 'serverVerified' means the server already
+          // committed, and an unknown outcome must not re-send the same
+          // code. Only a different, complete code falls through to a fresh
+          // attempt.
+          releaseTwoFactorLease(lease)
+          setError(t('backup.errors.networkError'))
+          return
+        }
+        // Fall through: fresh attempt with a different code.
+      } else if (code.length !== 8) {
+        releaseTwoFactorLease(lease)
+        setError(t('backup.errors.invalidLength'))
+        return
+      }
+
+      markVerifyDispatched(lease, subject, code)
+
       const response = await fetch('/api/2fa/verify', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({
-          email: session?.user?.email,
+          email: user.email,
           token: code,
         }),
       })
-
-      const data = (await response.json()) as {
-        error?: string
-        usedBackupCode?: boolean
-      }
+      if (!isTwoFactorLeaseOwner(lease)) return
 
       if (!response.ok) {
-        setError(data.error ?? t('backup.errors.verificationFailed'))
-        setCode('')
+        if (response.status >= 400 && response.status < 500) {
+          // Definite rejection — the server recorded no verification.
+          markVerifyIdle(lease)
+          let message: string | null = null
+          try {
+            message =
+              ((await response.json()) as { error?: string }).error ?? null
+          } catch {
+            // The error body is best-effort.
+          }
+          if (!isTwoFactorLeaseOwner(lease)) return
+          releaseTwoFactorLease(lease)
+          setError(message ?? t('backup.errors.verificationFailed'))
+          setCode('')
+          return
+        }
+        // 5xx: the server may have committed before failing (the rate-limit
+        // cleanup runs after the DB writes), so keep 'outcomeUnknown' — the
+        // retry goes update-first and never auto-resends this code.
+        releaseTwoFactorLease(lease)
+        setError(t('backup.errors.verificationFailed'))
         return
       }
 
-      // From here the success handler owns navigation; set before the
-      // await so the redirect-away effect stays quiet while the session
-      // refresh lands (see the effect above).
-      isNavigatingAfterVerifyRef.current = true
+      // 2xx observed — the server committed (and consumed the backup code).
+      // The body is not needed on success, and a parse failure must not
+      // discard that result.
+      markVerifyServerVerified(lease, subject)
 
       // Update session to mark 2FA as verified
-      const updatedSession = await update({ twoFactorVerified: true })
-      if (!updatedSession) {
-        // Session refresh failed: navigating now would bounce back through
-        // the guard and consume the parked fragment for nothing. Keep it
-        // parked and let the user retry.
-        isNavigatingAfterVerifyRef.current = false
+      const updated = await update({ twoFactorVerified: true })
+      if (!isTwoFactorLeaseOwner(lease)) return
+      if (
+        !(
+          updated?.user?.id === subject.id &&
+          updated?.user?.isAdmin === subject.isAdmin &&
+          updated?.user?.requiresTwoFactor === false
+        )
+      ) {
+        // Session refresh failed (or returned a foreign session): navigating
+        // now would bounce back through the guard and consume the parked
+        // fragment for nothing. Keep it parked and keep 'serverVerified' —
+        // the retry syncs the session without re-sending the consumed code.
+        releaseTwoFactorLease(lease)
         setError(t('backup.errors.networkError'))
         return
       }
 
-      // Redirect to callback URL or home, re-attaching the URL fragment
+      markVerifyIdle(lease)
+      // The lease stays active through the navigation; TwoFactorGuard
+      // invalidates it synchronously on the first commit outside the flow.
+      // Redirect to the callback URL, re-attaching the URL fragment
       // (E2EE key) that TwoFactorGuard parked before redirecting here.
       router.replace(restorePendingFragment(callbackUrl))
     } catch {
-      isNavigatingAfterVerifyRef.current = false
+      if (!isTwoFactorLeaseOwner(lease)) return
+      releaseTwoFactorLease(lease)
+      // A rejected fetch after dispatch keeps 'outcomeUnknown' (the request
+      // may have reached the server) — the retry goes update-first.
       setError(t('backup.errors.networkError'))
     } finally {
       setIsLoading(false)

--- a/src/app/auth/verify-2fa/backup/page.tsx
+++ b/src/app/auth/verify-2fa/backup/page.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { restorePendingFragment } from '@/lib/pending-fragment'
 import { sanitizeCallbackUrl } from '@/lib/safe-callback-url'
 import {
   AlertCircle,
@@ -102,8 +103,9 @@ export default function BackupCodePage() {
       // Update session to mark 2FA as verified
       await update({ twoFactorVerified: true })
 
-      // Redirect to callback URL or home
-      router.replace(callbackUrl)
+      // Redirect to callback URL or home, re-attaching the URL fragment
+      // (E2EE key) that TwoFactorGuard parked before redirecting here.
+      router.replace(restorePendingFragment(callbackUrl))
     } catch {
       setError(t('backup.errors.networkError'))
     } finally {

--- a/src/app/auth/verify-2fa/backup/page.tsx
+++ b/src/app/auth/verify-2fa/backup/page.tsx
@@ -29,17 +29,14 @@ import {
   getTwoFactorFlowServerVersion,
   getTwoFactorFlowVersion,
   getVerifyOutcome,
-  isBackupDispatchUnsettled,
   isTwoFactorLeaseOwner,
   isVerifyFlowPath,
   markVerifyDispatched,
   markVerifyIdle,
-  markVerifyResponded,
   markVerifyServerVerified,
   releaseTwoFactorLease,
   subscribeTwoFactorFlow,
   tryAcquireTwoFactorLease,
-  wasVerifyTokenDispatched,
 } from '@/lib/two-factor-verify-flow'
 import {
   AlertCircle,
@@ -165,34 +162,29 @@ export default function BackupCodePage() {
         // healthy: update() explicitly returned the SAME subject still
         // requiring 2FA. On null / foreign / malformed sessions, burning
         // another code cannot help — keep the outcome and let the user
-        // retry the sync. The same dispatched code is never re-sent, and
-        // while a backup-code dispatch never got a response (the request
-        // may STILL be running server-side), sending a different backup
-        // code could race the server's non-CAS rewrite of the codes array
-        // (lost update / code resurrection) — recover via the session sync
-        // or the TOTP page instead.
+        // retry the sync. With that explicit confirmation, even the SAME
+        // code may be re-sent manually: concurrent consumption is
+        // serialized server-side (CAS on the codes blob), and a code whose
+        // earlier dispatch actually committed answers RETRY_SYNC instead of
+        // burning an attempt — without this, a user whose only remaining
+        // code got an ambiguous response would be stuck.
         const sessionConfirmsPending =
           updated?.user?.id === subject.id &&
           updated?.user?.isAdmin === subject.isAdmin &&
           updated?.user?.requiresTwoFactor === true
-        if (
-          !sessionConfirmsPending ||
-          wasVerifyTokenDispatched(subject, code) ||
-          isBackupDispatchUnsettled(subject) ||
-          code.length !== 8
-        ) {
+        if (!sessionConfirmsPending || code.length !== 8) {
           releaseTwoFactorLease(lease)
           setError(t('backup.errors.networkError'))
           return
         }
-        // Fall through: fresh attempt with a different code.
+        // Fall through: fresh (or re-sent) attempt.
       } else if (code.length !== 8) {
         releaseTwoFactorLease(lease)
         setError(t('backup.errors.invalidLength'))
         return
       }
 
-      markVerifyDispatched(lease, subject, code, 'backup')
+      markVerifyDispatched(lease, subject, code)
 
       const response = await fetch('/api/2fa/verify', {
         method: 'POST',
@@ -210,14 +202,12 @@ export default function BackupCodePage() {
         }),
       })
       if (!isTwoFactorLeaseOwner(lease)) return
-      // The dispatch got an answer — the request is no longer running
-      // server-side.
-      markVerifyResponded(lease)
 
       // The server committed the verification for this subject: sync the
-      // session and finish the navigation. Reached on a 2xx and on the
+      // session and finish the navigation. Reached on a 2xx, on the
       // ALREADY_VERIFIED rejection (a success in disguise: e.g. another tab
-      // completed first).
+      // completed first) and on RETRY_SYNC (the server has a fresh
+      // verification on record — a lost response from an earlier attempt).
       const finishServerVerified = async (): Promise<void> => {
         markVerifyServerVerified(lease, subject)
         const updated = await update({ twoFactorVerified: true })
@@ -258,7 +248,10 @@ export default function BackupCodePage() {
             // The error body is best-effort.
           }
           if (!isTwoFactorLeaseOwner(lease)) return
-          if (errorBody?.code === 'ALREADY_VERIFIED') {
+          if (
+            errorBody?.code === 'ALREADY_VERIFIED' ||
+            errorBody?.code === 'RETRY_SYNC'
+          ) {
             await finishServerVerified()
             return
           }

--- a/src/app/auth/verify-2fa/page.test.tsx
+++ b/src/app/auth/verify-2fa/page.test.tsx
@@ -3,14 +3,15 @@
  */
 
 /**
- * Auto-submit loop regression test for the 2FA verification page (auth-gate
- * hardening).
+ * Tests for the TOTP verification page.
  *
- * A fetch rejection (offline) previously left the token intact while
- * `isLoading` flipped back to false, which re-triggered the auto-submit
- * effect in an infinite loop. A ref records the last attempted token so the
- * effect only fires for a not-yet-attempted token; manual submit bypasses
- * the gate; editing the token re-enables auto-submit.
+ * - Auto-submit gating (auth-gate hardening): a fetch rejection must not
+ *   re-fire the same token in a loop, and a code that already reached the
+ *   server is never auto-resent — recovery goes through update() first.
+ * - Fragment restoration (2FA fragment loss fix): the parked URL fragment
+ *   (E2EE key) is re-attached exactly once, the redirect-away effect can
+ *   never steal the navigation with replace('/'), and no failure path
+ *   consumes the fragment.
  */
 
 jest.mock('next-auth/react', () => ({
@@ -39,6 +40,13 @@ jest.mock('next/link', () => ({
 
 import Verify2FAPage from '@/app/auth/verify-2fa/page'
 import { setPendingFragment, takePendingFragment } from '@/lib/pending-fragment'
+import {
+  invalidateTwoFactorFlow,
+  markVerifyIdle,
+  markVerifyServerVerified,
+  releaseTwoFactorLease,
+  tryAcquireTwoFactorLease,
+} from '@/lib/two-factor-verify-flow'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useSession } from 'next-auth/react'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -50,35 +58,62 @@ const mockedUseSearchParams = useSearchParams as jest.MockedFunction<
   typeof useSearchParams
 >
 
+const SUBJECT = { id: 'u1', isAdmin: false }
+
+type UpdateBehavior = 'success' | 'staleTrue' | 'foreignSubject' | 'null'
+
 function setup2FASession(
   callbackUrl: string | null = null,
-  { updateSucceeds = true } = {},
+  {
+    updateBehavior = 'success',
+    requiresTwoFactor = true,
+  }: { updateBehavior?: UpdateBehavior; requiresTwoFactor?: boolean } = {},
 ) {
   const replace = jest.fn()
   mockedUseRouter.mockReturnValue({ replace } as never)
   mockedUseSearchParams.mockReturnValue({
     get: (key: string) => (key === 'callbackUrl' ? callbackUrl : null),
   } as never)
-  // Stateful mock mirroring production: update() makes the refreshed session
-  // come back with requiresTwoFactor=false, which re-fires the redirect-away
-  // effect (the race gated by the navigation ref).
-  let requiresTwoFactor = true
+  // Stateful mock mirroring production: a successful update() makes the
+  // refreshed session come back with requiresTwoFactor=false, re-firing the
+  // redirect-away effect (the race gated by the flow lease).
+  let currentRequiresTwoFactor = requiresTwoFactor
   const update = jest.fn(() => {
-    if (!updateSucceeds) return Promise.resolve(null)
-    requiresTwoFactor = false
-    return Promise.resolve({ user: { email: 'user@example.com' } })
+    if (updateBehavior === 'null') return Promise.resolve(null)
+    if (updateBehavior === 'staleTrue') {
+      // Truthy session whose flag did NOT clear (e.g. the 5-minute server
+      // window expired) — must not count as success.
+      return Promise.resolve({
+        user: { id: 'u1', isAdmin: false, requiresTwoFactor: true },
+      })
+    }
+    if (updateBehavior === 'foreignSubject') {
+      // A session for a different subject — must not count as success.
+      return Promise.resolve({
+        user: { id: 'u2', isAdmin: false, requiresTwoFactor: false },
+      })
+    }
+    currentRequiresTwoFactor = false
+    return Promise.resolve({
+      user: { id: 'u1', isAdmin: false, requiresTwoFactor: false },
+    })
   })
   mockedUseSession.mockImplementation(
     () =>
       ({
         data: {
-          user: { email: 'user@example.com', requiresTwoFactor },
+          user: {
+            id: 'u1',
+            email: 'user@example.com',
+            isAdmin: false,
+            requiresTwoFactor: currentRequiresTwoFactor,
+          },
         },
         status: 'authenticated',
         update,
       }) as never,
   )
-  return replace
+  return { replace, update }
 }
 
 function rejectingFetch() {
@@ -91,6 +126,7 @@ function succeedingFetch() {
   const fetchMock = jest.fn(() =>
     Promise.resolve({
       ok: true,
+      status: 200,
       json: () => Promise.resolve({}),
     } as Response),
   )
@@ -98,13 +134,39 @@ function succeedingFetch() {
   return fetchMock
 }
 
+function statusFetch(status: number, body: unknown = {}) {
+  const fetchMock = jest.fn(() =>
+    Promise.resolve({
+      ok: false,
+      status,
+      json: () => Promise.resolve(body),
+    } as Response),
+  )
+  global.fetch = fetchMock as unknown as typeof fetch
+  return fetchMock
+}
+
+function typeToken(value: string) {
+  fireEvent.change(screen.getByLabelText('verify.codeLabel'), {
+    target: { value },
+  })
+}
+
+function resetFlowState() {
+  invalidateTwoFactorFlow()
+  const lease = tryAcquireTwoFactorLease()
+  markVerifyIdle(lease)
+  releaseTwoFactorLease(lease)
+}
+
 beforeEach(() => {
   jest.clearAllMocks()
+  resetFlowState()
   setup2FASession()
 })
 
 describe('Verify2FAPage auto-submit gating', () => {
-  it('auto-submits once, does not resubmit after a rejected fetch, then a manual click submits once more', async () => {
+  it('auto-submits once and does not auto-resubmit after a rejected fetch', async () => {
     const fetchMock = rejectingFetch()
     render(<Verify2FAPage />)
 
@@ -122,13 +184,12 @@ describe('Verify2FAPage auto-submit gating', () => {
     await waitFor(() => expect(button.disabled).toBe(false))
     expect(input.value).toBe('123456')
     expect(fetchMock).toHaveBeenCalledTimes(1)
-
-    // A manual click submits exactly once more.
-    fireEvent.click(button)
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
   })
 
-  it('re-enables auto-submit after the user re-enters the same 6 digits', async () => {
+  it('never auto-resends the same code once its outcome is unknown; a different code retries', async () => {
+    // staleTrue: the update-first recovery does not resolve the session, so
+    // the resend rules decide what happens next.
+    setup2FASession(null, { updateBehavior: 'staleTrue' })
     const fetchMock = rejectingFetch()
     render(<Verify2FAPage />)
 
@@ -137,9 +198,17 @@ describe('Verify2FAPage auto-submit gating', () => {
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
     await waitFor(() => expect(input.disabled).toBe(false))
 
-    // Editing clears the ref; re-entering the same code retries.
+    // Re-entering the SAME code must not re-send it (its dispatch may have
+    // reached the server).
     fireEvent.change(input, { target: { value: '12345' } })
     fireEvent.change(input, { target: { value: '123456' } })
+    await waitFor(() =>
+      expect(screen.getByText('verify.errors.networkError')).toBeTruthy(),
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    // A DIFFERENT code is a fresh attempt.
+    fireEvent.change(input, { target: { value: '654321' } })
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
   })
 
@@ -155,26 +224,23 @@ describe('Verify2FAPage auto-submit gating', () => {
       </StrictMode>,
     )
 
-    const input = screen.getByLabelText('verify.codeLabel') as HTMLInputElement
-    fireEvent.change(input, { target: { value: '123456' } })
+    typeToken('123456')
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
     expect(fetchMock).toHaveBeenCalledTimes(1)
   })
 })
 
-// The pending-fragment store is module-level, so each test uses its own
-// unique callback path (see pending-fragment.test.ts for the convention).
+// The pending-fragment and verify-flow stores are module-level, so each test
+// uses its own unique callback path (see pending-fragment.test.ts).
 describe('Verify2FAPage fragment restoration', () => {
   it('re-attaches the parked fragment (E2EE key) to the callback URL after success', async () => {
-    const replace = setup2FASession('/groups/vf')
+    const { replace } = setup2FASession('/groups/vf')
     succeedingFetch()
     setPendingFragment('/groups/vf', 'KEYvf')
 
     render(<Verify2FAPage />)
-    fireEvent.change(screen.getByLabelText('verify.codeLabel'), {
-      target: { value: '123456' },
-    })
+    typeToken('123456')
 
     await waitFor(() =>
       expect(replace).toHaveBeenCalledWith('/groups/vf#KEYvf'),
@@ -190,13 +256,11 @@ describe('Verify2FAPage fragment restoration', () => {
   })
 
   it('navigates to the plain callback URL when no fragment is pending', async () => {
-    const replace = setup2FASession('/groups/vf-plain')
+    const { replace } = setup2FASession('/groups/vf-plain')
     succeedingFetch()
 
     render(<Verify2FAPage />)
-    fireEvent.change(screen.getByLabelText('verify.codeLabel'), {
-      target: { value: '123456' },
-    })
+    typeToken('123456')
 
     await waitFor(() =>
       expect(replace).toHaveBeenCalledWith('/groups/vf-plain'),
@@ -208,23 +272,207 @@ describe('Verify2FAPage fragment restoration', () => {
     expect(replace).not.toHaveBeenCalledWith('/')
   })
 
-  it('does not navigate or consume the fragment when the session update fails', async () => {
-    const replace = setup2FASession('/groups/vf-upfail', {
-      updateSucceeds: false,
+  it('does not navigate or consume the fragment when update() returns null', async () => {
+    const { replace } = setup2FASession('/groups/vf-upnull', {
+      updateBehavior: 'null',
     })
     succeedingFetch()
-    setPendingFragment('/groups/vf-upfail', 'KEYupfail')
+    setPendingFragment('/groups/vf-upnull', 'KEYupnull')
 
     render(<Verify2FAPage />)
-    fireEvent.change(screen.getByLabelText('verify.codeLabel'), {
-      target: { value: '123456' },
-    })
+    typeToken('123456')
 
     await waitFor(() =>
       expect(screen.getByText('verify.errors.networkError')).toBeTruthy(),
     )
     expect(replace).not.toHaveBeenCalled()
     // The parked fragment must survive for the retry.
-    expect(takePendingFragment('/groups/vf-upfail')).toBe('KEYupfail')
+    expect(takePendingFragment('/groups/vf-upnull')).toBe('KEYupnull')
+  })
+
+  it('treats a truthy session with requiresTwoFactor still true as a failure', async () => {
+    const { replace } = setup2FASession('/groups/vf-stale', {
+      updateBehavior: 'staleTrue',
+    })
+    succeedingFetch()
+    setPendingFragment('/groups/vf-stale', 'KEYstale')
+
+    render(<Verify2FAPage />)
+    typeToken('123456')
+
+    await waitFor(() =>
+      expect(screen.getByText('verify.errors.networkError')).toBeTruthy(),
+    )
+    expect(replace).not.toHaveBeenCalled()
+    expect(takePendingFragment('/groups/vf-stale')).toBe('KEYstale')
+  })
+
+  it('treats a session for a different subject as a failure', async () => {
+    const { replace } = setup2FASession('/groups/vf-foreign', {
+      updateBehavior: 'foreignSubject',
+    })
+    succeedingFetch()
+    setPendingFragment('/groups/vf-foreign', 'KEYforeign')
+
+    render(<Verify2FAPage />)
+    typeToken('123456')
+
+    await waitFor(() =>
+      expect(screen.getByText('verify.errors.networkError')).toBeTruthy(),
+    )
+    expect(replace).not.toHaveBeenCalled()
+    expect(takePendingFragment('/groups/vf-foreign')).toBe('KEYforeign')
+  })
+
+  it('resets to idle on a 4xx rejection: the same code can be re-sent', async () => {
+    const { replace } = setup2FASession('/groups/vf-4xx')
+    const fetchMock = statusFetch(401, { error: 'Invalid token' })
+    setPendingFragment('/groups/vf-4xx', 'KEY4xx')
+
+    render(<Verify2FAPage />)
+    const input = screen.getByLabelText('verify.codeLabel') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '123456' } })
+
+    await waitFor(() => expect(screen.getByText('Invalid token')).toBeTruthy())
+    expect(input.value).toBe('')
+    expect(replace).not.toHaveBeenCalled()
+
+    // A definite rejection resets the outcome: re-entering the same code is
+    // a fresh POST, not an update-first recovery.
+    fireEvent.change(input, { target: { value: '123456' } })
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    expect(takePendingFragment('/groups/vf-4xx')).toBe('KEY4xx')
+  })
+
+  it('recovers from a post-commit 5xx via update() without re-sending the code', async () => {
+    const { replace, update } = setup2FASession('/groups/vf-5xx')
+    const fetchMock = statusFetch(500, {})
+    setPendingFragment('/groups/vf-5xx', 'KEY5xx')
+
+    render(<Verify2FAPage />)
+    typeToken('123456')
+
+    await waitFor(() =>
+      expect(screen.getByText('verify.errors.verificationFailed')).toBeTruthy(),
+    )
+    expect(replace).not.toHaveBeenCalled()
+
+    // The server may have committed before the 5xx (rate-limit cleanup runs
+    // after the DB writes): the retry syncs the session first and never
+    // re-sends the consumed code.
+    fireEvent.click(screen.getByRole('button', { name: 'verify.submit' }))
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith('/groups/vf-5xx#KEY5xx'),
+    )
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(replace).not.toHaveBeenCalledWith('/')
+  })
+
+  it('recovers from a rejected fetch (commit unknown) via update() without re-sending', async () => {
+    const { replace } = setup2FASession('/groups/vf-rej')
+    const fetchMock = rejectingFetch()
+    setPendingFragment('/groups/vf-rej', 'KEYrej')
+
+    render(<Verify2FAPage />)
+    typeToken('123456')
+
+    await waitFor(() =>
+      expect(screen.getByText('verify.errors.networkError')).toBeTruthy(),
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'verify.submit' }))
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith('/groups/vf-rej#KEYrej'),
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('completes on a 2xx even when the response body fails to parse', async () => {
+    const { replace, update } = setup2FASession('/groups/vf-parse')
+    const fetchMock = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.reject(new Error('bad body')),
+      } as unknown as Response),
+    )
+    global.fetch = fetchMock as unknown as typeof fetch
+    setPendingFragment('/groups/vf-parse', 'KEYparse')
+
+    render(<Verify2FAPage />)
+    typeToken('123456')
+
+    // A 2xx means the server committed; a broken body must not discard it.
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith('/groups/vf-parse#KEYparse'),
+    )
+    expect(update).toHaveBeenCalledTimes(1)
+  })
+
+  it('releases the lease when the token fails length validation', async () => {
+    setup2FASession('/groups/vf-len')
+    succeedingFetch()
+
+    render(<Verify2FAPage />)
+    typeToken('123')
+    fireEvent.click(screen.getByRole('button', { name: 'verify.submit' }))
+
+    await waitFor(() =>
+      expect(screen.getByText('verify.errors.invalidLength')).toBeTruthy(),
+    )
+    // The aborted submit must not leave the flow lease held.
+    const lease = tryAcquireTwoFactorLease()
+    expect(lease).not.toBeNull()
+    releaseTwoFactorLease(lease)
+  })
+})
+
+describe('Verify2FAPage redirect-away behavior', () => {
+  it('bounces a direct visit that does not require 2FA to / exactly once (StrictMode)', async () => {
+    const { replace } = setup2FASession(null, { requiresTwoFactor: false })
+
+    render(
+      <StrictMode>
+        <Verify2FAPage />
+      </StrictMode>,
+    )
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith('/'))
+    expect(replace).toHaveBeenCalledTimes(1)
+  })
+
+  it('completes a recovered verification with the callback + fragment instead of bouncing to /', async () => {
+    // A prior transaction reached the server and the session has since
+    // flipped (e.g. it was interrupted after update()): the outcome for this
+    // subject must finish the navigation, not discard the parked key.
+    const lease = tryAcquireTwoFactorLease()
+    markVerifyServerVerified(lease, SUBJECT)
+    releaseTwoFactorLease(lease)
+    setPendingFragment('/groups/vf-rc', 'KEYrc')
+    const { replace } = setup2FASession('/groups/vf-rc', {
+      requiresTwoFactor: false,
+    })
+
+    render(<Verify2FAPage />)
+
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith('/groups/vf-rc#KEYrc'),
+    )
+    expect(replace).toHaveBeenCalledTimes(1)
+    expect(replace).not.toHaveBeenCalledWith('/')
+  })
+
+  it('normalizes a callback pointing back into the verify flow to /', async () => {
+    const { replace } = setup2FASession('/auth/verify-2fa')
+    succeedingFetch()
+
+    render(<Verify2FAPage />)
+    typeToken('123456')
+
+    // Landing back inside the flow would keep the lease active forever and
+    // strand the user on a blank page.
+    await waitFor(() => expect(replace).toHaveBeenCalledWith('/'))
+    expect(replace).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/app/auth/verify-2fa/page.test.tsx
+++ b/src/app/auth/verify-2fa/page.test.tsx
@@ -38,6 +38,7 @@ jest.mock('next/link', () => ({
 }))
 
 import Verify2FAPage from '@/app/auth/verify-2fa/page'
+import { setPendingFragment } from '@/lib/pending-fragment'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useSession } from 'next-auth/react'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -49,9 +50,12 @@ const mockedUseSearchParams = useSearchParams as jest.MockedFunction<
   typeof useSearchParams
 >
 
-function setup2FASession() {
-  mockedUseRouter.mockReturnValue({ replace: jest.fn() } as never)
-  mockedUseSearchParams.mockReturnValue({ get: () => null } as never)
+function setup2FASession(callbackUrl: string | null = null) {
+  const replace = jest.fn()
+  mockedUseRouter.mockReturnValue({ replace } as never)
+  mockedUseSearchParams.mockReturnValue({
+    get: (key: string) => (key === 'callbackUrl' ? callbackUrl : null),
+  } as never)
   mockedUseSession.mockReturnValue({
     data: {
       user: { email: 'user@example.com', requiresTwoFactor: true },
@@ -59,10 +63,22 @@ function setup2FASession() {
     status: 'authenticated',
     update: jest.fn(() => Promise.resolve()),
   } as never)
+  return replace
 }
 
 function rejectingFetch() {
   const fetchMock = jest.fn(() => Promise.reject(new Error('offline')))
+  global.fetch = fetchMock as unknown as typeof fetch
+  return fetchMock
+}
+
+function succeedingFetch() {
+  const fetchMock = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({}),
+    } as Response),
+  )
   global.fetch = fetchMock as unknown as typeof fetch
   return fetchMock
 }
@@ -129,5 +145,38 @@ describe('Verify2FAPage auto-submit gating', () => {
 
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+// The pending-fragment store is module-level, so each test uses its own
+// unique callback path (see pending-fragment.test.ts for the convention).
+describe('Verify2FAPage fragment restoration', () => {
+  it('re-attaches the parked fragment (E2EE key) to the callback URL after success', async () => {
+    const replace = setup2FASession('/groups/vf')
+    succeedingFetch()
+    setPendingFragment('/groups/vf', 'KEYvf')
+
+    render(<Verify2FAPage />)
+    fireEvent.change(screen.getByLabelText('verify.codeLabel'), {
+      target: { value: '123456' },
+    })
+
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith('/groups/vf#KEYvf'),
+    )
+  })
+
+  it('navigates to the plain callback URL when no fragment is pending', async () => {
+    const replace = setup2FASession('/groups/vf-plain')
+    succeedingFetch()
+
+    render(<Verify2FAPage />)
+    fireEvent.change(screen.getByLabelText('verify.codeLabel'), {
+      target: { value: '123456' },
+    })
+
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith('/groups/vf-plain'),
+    )
   })
 })

--- a/src/app/auth/verify-2fa/page.test.tsx
+++ b/src/app/auth/verify-2fa/page.test.tsx
@@ -42,12 +42,13 @@ import Verify2FAPage from '@/app/auth/verify-2fa/page'
 import { setPendingFragment, takePendingFragment } from '@/lib/pending-fragment'
 import {
   invalidateTwoFactorFlow,
+  markVerifyDispatched,
   markVerifyIdle,
   markVerifyServerVerified,
   releaseTwoFactorLease,
   tryAcquireTwoFactorLease,
 } from '@/lib/two-factor-verify-flow'
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useSession } from 'next-auth/react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { StrictMode } from 'react'
@@ -154,7 +155,7 @@ function typeToken(value: string) {
 
 function resetFlowState() {
   invalidateTwoFactorFlow()
-  const lease = tryAcquireTwoFactorLease()
+  const lease = tryAcquireTwoFactorLease(null)
   markVerifyIdle(lease)
   releaseTwoFactorLease(lease)
 }
@@ -237,7 +238,7 @@ describe('Verify2FAPage fragment restoration', () => {
   it('re-attaches the parked fragment (E2EE key) to the callback URL after success', async () => {
     const { replace } = setup2FASession('/groups/vf')
     succeedingFetch()
-    setPendingFragment('/groups/vf', 'KEYvf')
+    setPendingFragment('/groups/vf', 'KEYvf', SUBJECT)
 
     render(<Verify2FAPage />)
     typeToken('123456')
@@ -277,7 +278,7 @@ describe('Verify2FAPage fragment restoration', () => {
       updateBehavior: 'null',
     })
     succeedingFetch()
-    setPendingFragment('/groups/vf-upnull', 'KEYupnull')
+    setPendingFragment('/groups/vf-upnull', 'KEYupnull', SUBJECT)
 
     render(<Verify2FAPage />)
     typeToken('123456')
@@ -287,7 +288,7 @@ describe('Verify2FAPage fragment restoration', () => {
     )
     expect(replace).not.toHaveBeenCalled()
     // The parked fragment must survive for the retry.
-    expect(takePendingFragment('/groups/vf-upnull')).toBe('KEYupnull')
+    expect(takePendingFragment('/groups/vf-upnull', SUBJECT)).toBe('KEYupnull')
   })
 
   it('treats a truthy session with requiresTwoFactor still true as a failure', async () => {
@@ -295,7 +296,7 @@ describe('Verify2FAPage fragment restoration', () => {
       updateBehavior: 'staleTrue',
     })
     succeedingFetch()
-    setPendingFragment('/groups/vf-stale', 'KEYstale')
+    setPendingFragment('/groups/vf-stale', 'KEYstale', SUBJECT)
 
     render(<Verify2FAPage />)
     typeToken('123456')
@@ -304,7 +305,7 @@ describe('Verify2FAPage fragment restoration', () => {
       expect(screen.getByText('verify.errors.networkError')).toBeTruthy(),
     )
     expect(replace).not.toHaveBeenCalled()
-    expect(takePendingFragment('/groups/vf-stale')).toBe('KEYstale')
+    expect(takePendingFragment('/groups/vf-stale', SUBJECT)).toBe('KEYstale')
   })
 
   it('treats a session for a different subject as a failure', async () => {
@@ -312,7 +313,7 @@ describe('Verify2FAPage fragment restoration', () => {
       updateBehavior: 'foreignSubject',
     })
     succeedingFetch()
-    setPendingFragment('/groups/vf-foreign', 'KEYforeign')
+    setPendingFragment('/groups/vf-foreign', 'KEYforeign', SUBJECT)
 
     render(<Verify2FAPage />)
     typeToken('123456')
@@ -321,13 +322,15 @@ describe('Verify2FAPage fragment restoration', () => {
       expect(screen.getByText('verify.errors.networkError')).toBeTruthy(),
     )
     expect(replace).not.toHaveBeenCalled()
-    expect(takePendingFragment('/groups/vf-foreign')).toBe('KEYforeign')
+    expect(takePendingFragment('/groups/vf-foreign', SUBJECT)).toBe(
+      'KEYforeign',
+    )
   })
 
   it('resets to idle on a 4xx rejection: the same code can be re-sent', async () => {
     const { replace } = setup2FASession('/groups/vf-4xx')
     const fetchMock = statusFetch(401, { error: 'Invalid token' })
-    setPendingFragment('/groups/vf-4xx', 'KEY4xx')
+    setPendingFragment('/groups/vf-4xx', 'KEY4xx', SUBJECT)
 
     render(<Verify2FAPage />)
     const input = screen.getByLabelText('verify.codeLabel') as HTMLInputElement
@@ -341,13 +344,13 @@ describe('Verify2FAPage fragment restoration', () => {
     // a fresh POST, not an update-first recovery.
     fireEvent.change(input, { target: { value: '123456' } })
     await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
-    expect(takePendingFragment('/groups/vf-4xx')).toBe('KEY4xx')
+    expect(takePendingFragment('/groups/vf-4xx', SUBJECT)).toBe('KEY4xx')
   })
 
   it('recovers from a post-commit 5xx via update() without re-sending the code', async () => {
     const { replace, update } = setup2FASession('/groups/vf-5xx')
     const fetchMock = statusFetch(500, {})
-    setPendingFragment('/groups/vf-5xx', 'KEY5xx')
+    setPendingFragment('/groups/vf-5xx', 'KEY5xx', SUBJECT)
 
     render(<Verify2FAPage />)
     typeToken('123456')
@@ -372,7 +375,7 @@ describe('Verify2FAPage fragment restoration', () => {
   it('recovers from a rejected fetch (commit unknown) via update() without re-sending', async () => {
     const { replace } = setup2FASession('/groups/vf-rej')
     const fetchMock = rejectingFetch()
-    setPendingFragment('/groups/vf-rej', 'KEYrej')
+    setPendingFragment('/groups/vf-rej', 'KEYrej', SUBJECT)
 
     render(<Verify2FAPage />)
     typeToken('123456')
@@ -398,7 +401,7 @@ describe('Verify2FAPage fragment restoration', () => {
       } as unknown as Response),
     )
     global.fetch = fetchMock as unknown as typeof fetch
-    setPendingFragment('/groups/vf-parse', 'KEYparse')
+    setPendingFragment('/groups/vf-parse', 'KEYparse', SUBJECT)
 
     render(<Verify2FAPage />)
     typeToken('123456')
@@ -421,10 +424,13 @@ describe('Verify2FAPage fragment restoration', () => {
     await waitFor(() =>
       expect(screen.getByText('verify.errors.invalidLength')).toBeTruthy(),
     )
-    // The aborted submit must not leave the flow lease held.
-    const lease = tryAcquireTwoFactorLease()
-    expect(lease).not.toBeNull()
-    releaseTwoFactorLease(lease)
+    // The aborted submit must not leave the flow lease held. (Wrapped in
+    // act: acquiring bumps the store version the mounted page subscribes to.)
+    await act(async () => {
+      const lease = tryAcquireTwoFactorLease(SUBJECT)
+      expect(lease).not.toBeNull()
+      releaseTwoFactorLease(lease)
+    })
   })
 })
 
@@ -446,10 +452,10 @@ describe('Verify2FAPage redirect-away behavior', () => {
     // A prior transaction reached the server and the session has since
     // flipped (e.g. it was interrupted after update()): the outcome for this
     // subject must finish the navigation, not discard the parked key.
-    const lease = tryAcquireTwoFactorLease()
+    const lease = tryAcquireTwoFactorLease(SUBJECT)
     markVerifyServerVerified(lease, SUBJECT)
     releaseTwoFactorLease(lease)
-    setPendingFragment('/groups/vf-rc', 'KEYrc')
+    setPendingFragment('/groups/vf-rc', 'KEYrc', SUBJECT)
     const { replace } = setup2FASession('/groups/vf-rc', {
       requiresTwoFactor: false,
     })
@@ -474,5 +480,157 @@ describe('Verify2FAPage redirect-away behavior', () => {
     // strand the user on a blank page.
     await waitFor(() => expect(replace).toHaveBeenCalledWith('/'))
     expect(replace).toHaveBeenCalledTimes(1)
+  })
+})
+
+// Round-4 hardening: strict fall-through gating, subject-bound fragment and
+// recovery, ALREADY_VERIFIED completion, and lease-subscription re-arming.
+describe('Verify2FAPage recovery gating and subject binding', () => {
+  it('in serverVerified, blocks re-sending the dispatched code but allows a different one', async () => {
+    // Seed via the real transitions — a bare serverVerified without a
+    // dispatched token would make the same-code assertion vacuous.
+    {
+      const lease = tryAcquireTwoFactorLease(SUBJECT)
+      markVerifyDispatched(lease, SUBJECT, '123456', 'totp')
+      markVerifyServerVerified(lease, SUBJECT)
+      releaseTwoFactorLease(lease)
+    }
+    const { update } = setup2FASession('/groups/vf-sv', {
+      updateBehavior: 'staleTrue',
+    })
+    const fetchMock = succeedingFetch()
+
+    render(<Verify2FAPage />)
+    const input = screen.getByLabelText('verify.codeLabel') as HTMLInputElement
+
+    // The very code that was dispatched: update-first only, never re-sent.
+    fireEvent.change(input, { target: { value: '123456' } })
+    await waitFor(() =>
+      expect(screen.getByText('verify.errors.networkError')).toBeTruthy(),
+    )
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(fetchMock).not.toHaveBeenCalled()
+
+    // A different code is a fresh attempt (the session sync channel is
+    // healthy: update() returned the same subject still requiring 2FA).
+    fireEvent.change(input, { target: { value: '654321' } })
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+  })
+
+  it('does not burn another code while the session sync channel is broken', async () => {
+    const { update } = setup2FASession(null, { updateBehavior: 'null' })
+    const fetchMock = rejectingFetch()
+
+    render(<Verify2FAPage />)
+    const input = screen.getByLabelText('verify.codeLabel') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '123456' } })
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(input.disabled).toBe(false))
+
+    // update() returns null — no explicit same-subject requiresTwoFactor
+    // confirmation, so even a DIFFERENT code must not be posted.
+    fireEvent.change(input, { target: { value: '654321' } })
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(input.disabled).toBe(false))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('a re-entered pending code triggers exactly one update-first and no autonomous repeat', async () => {
+    const { update } = setup2FASession(null, { updateBehavior: 'staleTrue' })
+    const fetchMock = rejectingFetch()
+
+    render(<Verify2FAPage />)
+    const input = screen.getByLabelText('verify.codeLabel') as HTMLInputElement
+    fireEvent.change(input, { target: { value: '123456' } })
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(input.disabled).toBe(false))
+    expect(update).not.toHaveBeenCalled()
+
+    // Erase and retype the SAME pending code: one update-first, and the
+    // auto-submit effect must not fire an autonomous second one (the ref is
+    // recorded on every submit path, including recovery bailouts).
+    fireEvent.change(input, { target: { value: '12345' } })
+    fireEvent.change(input, { target: { value: '123456' } })
+    await waitFor(() => expect(update).toHaveBeenCalledTimes(1))
+    await waitFor(() => expect(input.disabled).toBe(false))
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats an ALREADY_VERIFIED rejection as success and completes with the fragment', async () => {
+    const { replace, update } = setup2FASession('/groups/vf-av')
+    statusFetch(400, { error: 'Already verified', code: 'ALREADY_VERIFIED' })
+    setPendingFragment('/groups/vf-av', 'KEYav', SUBJECT)
+
+    render(<Verify2FAPage />)
+    typeToken('123456')
+
+    // e.g. another tab completed first: this is a success in disguise, not
+    // a rejection that discards recovery state or the parked key.
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith('/groups/vf-av#KEYav'),
+    )
+    expect(update).toHaveBeenCalledTimes(1)
+  })
+
+  it("never re-attaches another subject's parked fragment and destroys it", async () => {
+    const OTHER = { id: 'other', isAdmin: false }
+    const { replace } = setup2FASession('/groups/vf-xa')
+    succeedingFetch()
+    setPendingFragment('/groups/vf-xa', 'KEYother', OTHER)
+
+    render(<Verify2FAPage />)
+    typeToken('123456')
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith('/groups/vf-xa'))
+    expect(replace).not.toHaveBeenCalledWith('/groups/vf-xa#KEYother')
+    // Destroyed, not left parked for anyone.
+    expect(takePendingFragment('/groups/vf-xa', OTHER)).toBeNull()
+  })
+
+  it('destroys the parked fragment on a discarding bounce to /', async () => {
+    setPendingFragment('/groups/vf-db', 'KEYdb', SUBJECT)
+    const { replace } = setup2FASession('/groups/vf-db', {
+      requiresTwoFactor: false,
+    })
+
+    render(<Verify2FAPage />)
+
+    await waitFor(() => expect(replace).toHaveBeenCalledWith('/'))
+    expect(takePendingFragment('/groups/vf-db', SUBJECT)).toBeNull()
+  })
+
+  it('re-arms the bounce effect when the lease frees (no lost wakeup)', async () => {
+    // A STABLE session mock (same object every render): the only thing that
+    // may re-run the effect is the flowVersion dependency — a per-render
+    // fresh session object would mask a missing dep.
+    const replace = jest.fn()
+    mockedUseRouter.mockReturnValue({ replace } as never)
+    mockedUseSearchParams.mockReturnValue({ get: () => null } as never)
+    mockedUseSession.mockReturnValue({
+      data: {
+        user: {
+          id: 'u1',
+          email: 'user@example.com',
+          isAdmin: false,
+          requiresTwoFactor: false,
+        },
+      },
+      status: 'authenticated',
+      update: jest.fn(),
+    } as never)
+    const held = tryAcquireTwoFactorLease(SUBJECT)
+
+    render(<Verify2FAPage />)
+    await act(async () => {})
+    // Lost the tryAcquire race: no navigation yet, but no permanent stall
+    // either —
+    expect(replace).not.toHaveBeenCalled()
+
+    // — releasing the lease re-runs the effect via the store subscription.
+    await act(async () => {
+      releaseTwoFactorLease(held)
+    })
+    await waitFor(() => expect(replace).toHaveBeenCalledWith('/'))
   })
 })

--- a/src/app/auth/verify-2fa/page.test.tsx
+++ b/src/app/auth/verify-2fa/page.test.tsx
@@ -491,7 +491,7 @@ describe('Verify2FAPage recovery gating and subject binding', () => {
     // dispatched token would make the same-code assertion vacuous.
     {
       const lease = tryAcquireTwoFactorLease(SUBJECT)
-      markVerifyDispatched(lease, SUBJECT, '123456', 'totp')
+      markVerifyDispatched(lease, SUBJECT, '123456')
       markVerifyServerVerified(lease, SUBJECT)
       releaseTwoFactorLease(lease)
     }
@@ -555,6 +555,23 @@ describe('Verify2FAPage recovery gating and subject binding', () => {
     await waitFor(() => expect(input.disabled).toBe(false))
     expect(update).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats a RETRY_SYNC conflict as a committed verification and completes with the fragment', async () => {
+    const { replace, update } = setup2FASession('/groups/vf-rs')
+    statusFetch(409, {
+      error: 'Verification already recorded',
+      code: 'RETRY_SYNC',
+    })
+    setPendingFragment('/groups/vf-rs', 'KEYrs', SUBJECT)
+
+    render(<Verify2FAPage />)
+    typeToken('123456')
+
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith('/groups/vf-rs#KEYrs'),
+    )
+    expect(update).toHaveBeenCalledTimes(1)
   })
 
   it('treats an ALREADY_VERIFIED rejection as success and completes with the fragment', async () => {

--- a/src/app/auth/verify-2fa/page.test.tsx
+++ b/src/app/auth/verify-2fa/page.test.tsx
@@ -38,7 +38,7 @@ jest.mock('next/link', () => ({
 }))
 
 import Verify2FAPage from '@/app/auth/verify-2fa/page'
-import { setPendingFragment } from '@/lib/pending-fragment'
+import { setPendingFragment, takePendingFragment } from '@/lib/pending-fragment'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { useSession } from 'next-auth/react'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -50,19 +50,34 @@ const mockedUseSearchParams = useSearchParams as jest.MockedFunction<
   typeof useSearchParams
 >
 
-function setup2FASession(callbackUrl: string | null = null) {
+function setup2FASession(
+  callbackUrl: string | null = null,
+  { updateSucceeds = true } = {},
+) {
   const replace = jest.fn()
   mockedUseRouter.mockReturnValue({ replace } as never)
   mockedUseSearchParams.mockReturnValue({
     get: (key: string) => (key === 'callbackUrl' ? callbackUrl : null),
   } as never)
-  mockedUseSession.mockReturnValue({
-    data: {
-      user: { email: 'user@example.com', requiresTwoFactor: true },
-    },
-    status: 'authenticated',
-    update: jest.fn(() => Promise.resolve()),
-  } as never)
+  // Stateful mock mirroring production: update() makes the refreshed session
+  // come back with requiresTwoFactor=false, which re-fires the redirect-away
+  // effect (the race gated by the navigation ref).
+  let requiresTwoFactor = true
+  const update = jest.fn(() => {
+    if (!updateSucceeds) return Promise.resolve(null)
+    requiresTwoFactor = false
+    return Promise.resolve({ user: { email: 'user@example.com' } })
+  })
+  mockedUseSession.mockImplementation(
+    () =>
+      ({
+        data: {
+          user: { email: 'user@example.com', requiresTwoFactor },
+        },
+        status: 'authenticated',
+        update,
+      }) as never,
+  )
   return replace
 }
 
@@ -164,6 +179,14 @@ describe('Verify2FAPage fragment restoration', () => {
     await waitFor(() =>
       expect(replace).toHaveBeenCalledWith('/groups/vf#KEYvf'),
     )
+    // Wait for the post-update re-render (requiresTwoFactor=false renders
+    // null) so the redirect-away effect has re-fired before asserting it did
+    // not steal the navigation with replace('/').
+    await waitFor(() =>
+      expect(screen.queryByLabelText('verify.codeLabel')).toBeNull(),
+    )
+    expect(replace).toHaveBeenCalledTimes(1)
+    expect(replace).not.toHaveBeenCalledWith('/')
   })
 
   it('navigates to the plain callback URL when no fragment is pending', async () => {
@@ -178,5 +201,30 @@ describe('Verify2FAPage fragment restoration', () => {
     await waitFor(() =>
       expect(replace).toHaveBeenCalledWith('/groups/vf-plain'),
     )
+    await waitFor(() =>
+      expect(screen.queryByLabelText('verify.codeLabel')).toBeNull(),
+    )
+    expect(replace).toHaveBeenCalledTimes(1)
+    expect(replace).not.toHaveBeenCalledWith('/')
+  })
+
+  it('does not navigate or consume the fragment when the session update fails', async () => {
+    const replace = setup2FASession('/groups/vf-upfail', {
+      updateSucceeds: false,
+    })
+    succeedingFetch()
+    setPendingFragment('/groups/vf-upfail', 'KEYupfail')
+
+    render(<Verify2FAPage />)
+    fireEvent.change(screen.getByLabelText('verify.codeLabel'), {
+      target: { value: '123456' },
+    })
+
+    await waitFor(() =>
+      expect(screen.getByText('verify.errors.networkError')).toBeTruthy(),
+    )
+    expect(replace).not.toHaveBeenCalled()
+    // The parked fragment must survive for the retry.
+    expect(takePendingFragment('/groups/vf-upfail')).toBe('KEYupfail')
   })
 })

--- a/src/app/auth/verify-2fa/page.tsx
+++ b/src/app/auth/verify-2fa/page.tsx
@@ -19,16 +19,23 @@ import {
 } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
-import { restorePendingFragment } from '@/lib/pending-fragment'
+import {
+  clearPendingFragment,
+  restorePendingFragment,
+} from '@/lib/pending-fragment'
 import { sanitizeCallbackUrl } from '@/lib/safe-callback-url'
 import {
+  getTwoFactorFlowServerVersion,
+  getTwoFactorFlowVersion,
   getVerifyOutcome,
   isTwoFactorLeaseOwner,
   isVerifyFlowPath,
   markVerifyDispatched,
   markVerifyIdle,
+  markVerifyResponded,
   markVerifyServerVerified,
   releaseTwoFactorLease,
+  subscribeTwoFactorFlow,
   tryAcquireTwoFactorLease,
   wasVerifyTokenDispatched,
 } from '@/lib/two-factor-verify-flow'
@@ -37,7 +44,13 @@ import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react'
 
 export default function Verify2FAPage() {
   const t = useTranslations('TwoFactorAuth')
@@ -60,6 +73,16 @@ export default function Verify2FAPage() {
   // once `isLoading` clears. Cleared on user edit so a re-typed code retries.
   const lastAttemptedTokenRef = useRef<string | null>(null)
 
+  // Lease-state version: re-arms the bounce/recovery effect below when the
+  // lease changes hands — a page that lost a tryAcquire race once would
+  // otherwise never get a second chance (lost wakeup) and render blank
+  // forever.
+  const flowVersion = useSyncExternalStore(
+    subscribeTwoFactorFlow,
+    getTwoFactorFlowVersion,
+    getTwoFactorFlowServerVersion,
+  )
+
   // Bounce direct visitors who don't need 2FA, and complete a recovered
   // verification. Navigating here requires acquiring the flow lease, so this
   // can never race an in-flight verification transaction (tryAcquire fails
@@ -67,28 +90,32 @@ export default function Verify2FAPage() {
   // twice (the acquired lease is only invalidated by TwoFactorGuard after
   // landing outside the flow).
   useEffect(() => {
+    // Read the version so the lease subscription re-runs this effect.
+    void flowVersion
     if (status === 'loading') return
     if (session?.user?.requiresTwoFactor) return
 
-    const lease = tryAcquireTwoFactorLease()
+    const user = session?.user
+    const subject = user ? { id: user.id, isAdmin: user.isAdmin } : null
+    const lease = tryAcquireTwoFactorLease(subject)
     if (lease === null) return
 
-    const user = session?.user
-    if (
-      user &&
-      getVerifyOutcome({ id: user.id, isAdmin: user.isAdmin }) !== 'idle'
-    ) {
+    if (subject && getVerifyOutcome(subject) !== 'idle') {
       // A verification for this subject reached the server before the
       // session flipped (the transaction was interrupted): finish its
       // navigation instead of discarding the parked fragment with a '/'
       // bounce.
       markVerifyIdle(lease)
-      router.replace(restorePendingFragment(callbackUrl))
+      router.replace(restorePendingFragment(callbackUrl, subject))
       return
     }
 
+    // Discarding bounce (incl. signed-out): the parked fragment's completion
+    // chance is gone — destroy it so it can never re-attach to another
+    // subject's navigation.
+    clearPendingFragment()
     router.replace('/')
-  }, [session, status, router, callbackUrl])
+  }, [session, status, router, callbackUrl, flowVersion])
 
   // Handle token input - only allow digits and max 6 characters
   const handleTokenChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -115,8 +142,15 @@ export default function Verify2FAPage() {
       // switching to the backup page mid-request) joins it as a no-op — the
       // in-flight transaction drives the navigation, and its update() will
       // settle the session either way.
-      const lease = tryAcquireTwoFactorLease()
+      const lease = tryAcquireTwoFactorLease(subject)
       if (lease === null) return
+
+      // Record the attempted token synchronously, before the first await and
+      // on EVERY path (including recovery bailouts): the auto-submit effect
+      // must not re-fire for a token that has already driven an attempt, or
+      // an edit back to the same pending code would stack redundant
+      // update() calls. Cleared on user edit so a re-typed code retries.
+      lastAttemptedTokenRef.current = token
 
       setIsLoading(true)
       setError(null)
@@ -138,18 +172,23 @@ export default function Verify2FAPage() {
             updated?.user?.requiresTwoFactor === false
           ) {
             markVerifyIdle(lease)
-            router.replace(restorePendingFragment(callbackUrl))
+            router.replace(restorePendingFragment(callbackUrl, subject))
             return
           }
+          // A fresh POST is only safe when the sync channel itself is
+          // healthy: update() explicitly returned the SAME subject still
+          // requiring 2FA. On null / foreign / malformed sessions, burning
+          // another code cannot help — keep the outcome and let the user
+          // retry the sync. The same dispatched code is never re-sent.
+          const sessionConfirmsPending =
+            updated?.user?.id === subject.id &&
+            updated?.user?.isAdmin === subject.isAdmin &&
+            updated?.user?.requiresTwoFactor === true
           if (
-            mode === 'serverVerified' ||
+            !sessionConfirmsPending ||
             wasVerifyTokenDispatched(subject, token) ||
             token.length !== 6
           ) {
-            // Never auto-resend: 'serverVerified' means the server already
-            // committed, and an unknown outcome must not re-send the same
-            // code. Only a different, complete code falls through to a
-            // fresh attempt.
             releaseTwoFactorLease(lease)
             setError(t('verify.errors.networkError'))
             return
@@ -161,13 +200,7 @@ export default function Verify2FAPage() {
           return
         }
 
-        // Record the attempted token synchronously before the request. The
-        // auto-submit effect will not re-fire while the ref still equals the
-        // current token, so a fetch rejection cannot loop. Setting it here
-        // (in both auto and manual paths) also makes a StrictMode
-        // double-invoke of the effect a no-op on the second call.
-        lastAttemptedTokenRef.current = token
-        markVerifyDispatched(lease, subject, token)
+        markVerifyDispatched(lease, subject, token, 'totp')
 
         const response = await fetch('/api/2fa/verify', {
           method: 'POST',
@@ -177,24 +210,70 @@ export default function Verify2FAPage() {
           body: JSON.stringify({
             email: user.email,
             token,
+            // The server rejects a body subject that differs from its
+            // session, so any non-4xx outcome is attributable to THIS
+            // subject even if the cookie switched to a same-email account.
+            subjectId: subject.id,
+            subjectIsAdmin: subject.isAdmin,
           }),
         })
         if (!isTwoFactorLeaseOwner(lease)) return
+        // The dispatch got an answer — the request is no longer running
+        // server-side.
+        markVerifyResponded(lease)
+
+        // The server committed the verification for this subject: sync the
+        // session and finish the navigation. Reached on a 2xx and on the
+        // ALREADY_VERIFIED rejection (a success in disguise: e.g. another
+        // tab completed first).
+        const finishServerVerified = async (): Promise<void> => {
+          markVerifyServerVerified(lease, subject)
+          const updated = await update({ twoFactorVerified: true })
+          if (!isTwoFactorLeaseOwner(lease)) return
+          if (
+            !(
+              updated?.user?.id === subject.id &&
+              updated?.user?.isAdmin === subject.isAdmin &&
+              updated?.user?.requiresTwoFactor === false
+            )
+          ) {
+            // Session refresh failed (or returned a foreign session):
+            // navigating now would bounce back through the guard and
+            // consume the parked fragment for nothing. Keep it parked and
+            // keep 'serverVerified' — the retry syncs the session without
+            // touching the server again.
+            releaseTwoFactorLease(lease)
+            setError(t('verify.errors.networkError'))
+            return
+          }
+          markVerifyIdle(lease)
+          // The lease stays active through the navigation; TwoFactorGuard
+          // invalidates it synchronously on the first commit outside the
+          // flow. Re-attach the URL fragment (E2EE key) that TwoFactorGuard
+          // parked before redirecting here.
+          router.replace(restorePendingFragment(callbackUrl, subject))
+        }
 
         if (!response.ok) {
           if (response.status >= 400 && response.status < 500) {
-            // Definite rejection — the server recorded no verification.
-            markVerifyIdle(lease)
-            let message: string | null = null
+            let errorBody: { error?: string; code?: string } | null = null
             try {
-              message =
-                ((await response.json()) as { error?: string }).error ?? null
+              errorBody = (await response.json()) as {
+                error?: string
+                code?: string
+              }
             } catch {
               // The error body is best-effort.
             }
             if (!isTwoFactorLeaseOwner(lease)) return
+            if (errorBody?.code === 'ALREADY_VERIFIED') {
+              await finishServerVerified()
+              return
+            }
+            // Definite rejection — the server recorded no verification.
+            markVerifyIdle(lease)
             releaseTwoFactorLease(lease)
-            setError(message ?? t('verify.errors.verificationFailed'))
+            setError(errorBody?.error ?? t('verify.errors.verificationFailed'))
             setToken('')
             return
           }
@@ -209,34 +288,7 @@ export default function Verify2FAPage() {
 
         // 2xx observed — the server committed. The body is not needed on
         // success, and a parse failure must not discard that result.
-        markVerifyServerVerified(lease, subject)
-
-        // Update session to mark 2FA as verified
-        const updated = await update({ twoFactorVerified: true })
-        if (!isTwoFactorLeaseOwner(lease)) return
-        if (
-          !(
-            updated?.user?.id === subject.id &&
-            updated?.user?.isAdmin === subject.isAdmin &&
-            updated?.user?.requiresTwoFactor === false
-          )
-        ) {
-          // Session refresh failed (or returned a foreign session):
-          // navigating now would bounce back through the guard and consume
-          // the parked fragment for nothing. Keep it parked and keep
-          // 'serverVerified' — the retry syncs the session without touching
-          // the server again.
-          releaseTwoFactorLease(lease)
-          setError(t('verify.errors.networkError'))
-          return
-        }
-
-        markVerifyIdle(lease)
-        // The lease stays active through the navigation; TwoFactorGuard
-        // invalidates it synchronously on the first commit outside the flow.
-        // Redirect to the callback URL, re-attaching the URL fragment
-        // (E2EE key) that TwoFactorGuard parked before redirecting here.
-        router.replace(restorePendingFragment(callbackUrl))
+        await finishServerVerified()
       } catch {
         if (!isTwoFactorLeaseOwner(lease)) return
         releaseTwoFactorLease(lease)

--- a/src/app/auth/verify-2fa/page.tsx
+++ b/src/app/auth/verify-2fa/page.tsx
@@ -21,6 +21,17 @@ import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { restorePendingFragment } from '@/lib/pending-fragment'
 import { sanitizeCallbackUrl } from '@/lib/safe-callback-url'
+import {
+  getVerifyOutcome,
+  isTwoFactorLeaseOwner,
+  isVerifyFlowPath,
+  markVerifyDispatched,
+  markVerifyIdle,
+  markVerifyServerVerified,
+  releaseTwoFactorLease,
+  tryAcquireTwoFactorLease,
+  wasVerifyTokenDispatched,
+} from '@/lib/two-factor-verify-flow'
 import { AlertCircle, KeyRound, Loader2, ShieldCheck } from 'lucide-react'
 import { useSession } from 'next-auth/react'
 import { useTranslations } from 'next-intl'
@@ -32,7 +43,11 @@ export default function Verify2FAPage() {
   const t = useTranslations('TwoFactorAuth')
   const router = useRouter()
   const searchParams = useSearchParams()
-  const callbackUrl = sanitizeCallbackUrl(searchParams.get('callbackUrl'))
+  const rawCallbackUrl = sanitizeCallbackUrl(searchParams.get('callbackUrl'))
+  // A callback pointing back into the verify flow would keep the navigation
+  // lease active forever (TwoFactorGuard only invalidates it outside the
+  // flow) and strand the user on a blank page; normalize it to '/'.
+  const callbackUrl = isVerifyFlowPath(rawCallbackUrl) ? '/' : rawCallbackUrl
 
   const { data: session, status, update } = useSession()
 
@@ -45,25 +60,35 @@ export default function Verify2FAPage() {
   // once `isLoading` clears. Cleared on user edit so a re-typed code retries.
   const lastAttemptedTokenRef = useRef<string | null>(null)
 
-  // Set while the success handler owns navigation: once update() reflects
-  // requiresTwoFactor=false, the redirect-away effect below re-fires and its
-  // replace('/') would race the success replace and strand the one-shot
-  // parked fragment (E2EE key). Reset if the session refresh fails.
-  const isNavigatingAfterVerifyRef = useRef(false)
-
-  // Redirect if user doesn't require 2FA verification
+  // Bounce direct visitors who don't need 2FA, and complete a recovered
+  // verification. Navigating here requires acquiring the flow lease, so this
+  // can never race an in-flight verification transaction (tryAcquire fails
+  // while one is active, on THIS page or the backup page) and never fires
+  // twice (the acquired lease is only invalidated by TwoFactorGuard after
+  // landing outside the flow).
   useEffect(() => {
     if (status === 'loading') return
+    if (session?.user?.requiresTwoFactor) return
 
-    // The success handler is navigating to the callback URL; the session
-    // refresh flipping requiresTwoFactor must not bounce to '/' instead.
-    if (isNavigatingAfterVerifyRef.current) return
+    const lease = tryAcquireTwoFactorLease()
+    if (lease === null) return
 
-    // If no session or doesn't require 2FA, redirect to home
-    if (!session?.user?.requiresTwoFactor) {
-      router.replace('/')
+    const user = session?.user
+    if (
+      user &&
+      getVerifyOutcome({ id: user.id, isAdmin: user.isAdmin }) !== 'idle'
+    ) {
+      // A verification for this subject reached the server before the
+      // session flipped (the transaction was interrupted): finish its
+      // navigation instead of discarding the parked fragment with a '/'
+      // bounce.
+      markVerifyIdle(lease)
+      router.replace(restorePendingFragment(callbackUrl))
+      return
     }
-  }, [session, status, router])
+
+    router.replace('/')
+  }, [session, status, router, callbackUrl])
 
   // Handle token input - only allow digits and max 6 characters
   const handleTokenChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -81,68 +106,149 @@ export default function Verify2FAPage() {
         e.preventDefault()
       }
 
-      if (token.length !== 6) {
-        setError(t('verify.errors.invalidLength'))
-        return
-      }
+      const user = session?.user
+      if (!user) return
+      const subject = { id: user.id, isAdmin: user.isAdmin }
 
-      // Record the attempted token synchronously before the request. The
-      // auto-submit effect will not re-fire while the ref still equals the
-      // current token, so a fetch rejection cannot loop. Setting it here (in
-      // both auto and manual paths) also makes a StrictMode double-invoke of
-      // the effect a no-op on the second call. Not cleared in catch/finally.
-      lastAttemptedTokenRef.current = token
+      // Exclusive lease: one verification transaction at a time across BOTH
+      // verify pages. A second submit while one is in flight (e.g. after
+      // switching to the backup page mid-request) joins it as a no-op — the
+      // in-flight transaction drives the navigation, and its update() will
+      // settle the session either way.
+      const lease = tryAcquireTwoFactorLease()
+      if (lease === null) return
 
       setIsLoading(true)
       setError(null)
 
       try {
+        const mode = getVerifyOutcome(subject)
+
+        if (mode !== 'idle') {
+          // A previous attempt reached the server ('serverVerified') or its
+          // result is unknown (rejected fetch / 5xx may have committed):
+          // retry the session sync FIRST instead of re-sending a code. A
+          // resend would burn a second backup code or fail on the consumed
+          // one. Success requires the SAME subject with the flag cleared.
+          const updated = await update({ twoFactorVerified: true })
+          if (!isTwoFactorLeaseOwner(lease)) return
+          if (
+            updated?.user?.id === subject.id &&
+            updated?.user?.isAdmin === subject.isAdmin &&
+            updated?.user?.requiresTwoFactor === false
+          ) {
+            markVerifyIdle(lease)
+            router.replace(restorePendingFragment(callbackUrl))
+            return
+          }
+          if (
+            mode === 'serverVerified' ||
+            wasVerifyTokenDispatched(subject, token) ||
+            token.length !== 6
+          ) {
+            // Never auto-resend: 'serverVerified' means the server already
+            // committed, and an unknown outcome must not re-send the same
+            // code. Only a different, complete code falls through to a
+            // fresh attempt.
+            releaseTwoFactorLease(lease)
+            setError(t('verify.errors.networkError'))
+            return
+          }
+          // Fall through: fresh attempt with a different code.
+        } else if (token.length !== 6) {
+          releaseTwoFactorLease(lease)
+          setError(t('verify.errors.invalidLength'))
+          return
+        }
+
+        // Record the attempted token synchronously before the request. The
+        // auto-submit effect will not re-fire while the ref still equals the
+        // current token, so a fetch rejection cannot loop. Setting it here
+        // (in both auto and manual paths) also makes a StrictMode
+        // double-invoke of the effect a no-op on the second call.
+        lastAttemptedTokenRef.current = token
+        markVerifyDispatched(lease, subject, token)
+
         const response = await fetch('/api/2fa/verify', {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
           },
           body: JSON.stringify({
-            email: session?.user?.email,
+            email: user.email,
             token,
           }),
         })
-
-        const data = (await response.json()) as { error?: string }
+        if (!isTwoFactorLeaseOwner(lease)) return
 
         if (!response.ok) {
-          setError(data.error ?? t('verify.errors.verificationFailed'))
-          setToken('')
+          if (response.status >= 400 && response.status < 500) {
+            // Definite rejection — the server recorded no verification.
+            markVerifyIdle(lease)
+            let message: string | null = null
+            try {
+              message =
+                ((await response.json()) as { error?: string }).error ?? null
+            } catch {
+              // The error body is best-effort.
+            }
+            if (!isTwoFactorLeaseOwner(lease)) return
+            releaseTwoFactorLease(lease)
+            setError(message ?? t('verify.errors.verificationFailed'))
+            setToken('')
+            return
+          }
+          // 5xx: the server may have committed before failing (the
+          // rate-limit cleanup runs after the DB writes), so keep
+          // 'outcomeUnknown' — the retry goes update-first and never
+          // auto-resends this code.
+          releaseTwoFactorLease(lease)
+          setError(t('verify.errors.verificationFailed'))
           return
         }
 
-        // From here the success handler owns navigation; set before the
-        // await so the redirect-away effect stays quiet while the session
-        // refresh lands (see the effect above).
-        isNavigatingAfterVerifyRef.current = true
+        // 2xx observed — the server committed. The body is not needed on
+        // success, and a parse failure must not discard that result.
+        markVerifyServerVerified(lease, subject)
 
         // Update session to mark 2FA as verified
-        const updatedSession = await update({ twoFactorVerified: true })
-        if (!updatedSession) {
-          // Session refresh failed: navigating now would bounce back through
-          // the guard and consume the parked fragment for nothing. Keep it
-          // parked and let the user retry.
-          isNavigatingAfterVerifyRef.current = false
+        const updated = await update({ twoFactorVerified: true })
+        if (!isTwoFactorLeaseOwner(lease)) return
+        if (
+          !(
+            updated?.user?.id === subject.id &&
+            updated?.user?.isAdmin === subject.isAdmin &&
+            updated?.user?.requiresTwoFactor === false
+          )
+        ) {
+          // Session refresh failed (or returned a foreign session):
+          // navigating now would bounce back through the guard and consume
+          // the parked fragment for nothing. Keep it parked and keep
+          // 'serverVerified' — the retry syncs the session without touching
+          // the server again.
+          releaseTwoFactorLease(lease)
           setError(t('verify.errors.networkError'))
           return
         }
 
-        // Redirect to callback URL or home, re-attaching the URL fragment
+        markVerifyIdle(lease)
+        // The lease stays active through the navigation; TwoFactorGuard
+        // invalidates it synchronously on the first commit outside the flow.
+        // Redirect to the callback URL, re-attaching the URL fragment
         // (E2EE key) that TwoFactorGuard parked before redirecting here.
         router.replace(restorePendingFragment(callbackUrl))
       } catch {
-        isNavigatingAfterVerifyRef.current = false
+        if (!isTwoFactorLeaseOwner(lease)) return
+        releaseTwoFactorLease(lease)
+        // A rejected fetch after dispatch keeps 'outcomeUnknown' (the
+        // request may have reached the server) — the retry goes
+        // update-first.
         setError(t('verify.errors.networkError'))
       } finally {
         setIsLoading(false)
       }
     },
-    [token, session?.user?.email, t, update, router, callbackUrl],
+    [token, session?.user, t, update, router, callbackUrl],
   )
 
   // Auto-submit when 6 digits are entered. Gated on the ref so it fires only

--- a/src/app/auth/verify-2fa/page.tsx
+++ b/src/app/auth/verify-2fa/page.tsx
@@ -32,7 +32,6 @@ import {
   isVerifyFlowPath,
   markVerifyDispatched,
   markVerifyIdle,
-  markVerifyResponded,
   markVerifyServerVerified,
   releaseTwoFactorLease,
   subscribeTwoFactorFlow,
@@ -200,7 +199,7 @@ export default function Verify2FAPage() {
           return
         }
 
-        markVerifyDispatched(lease, subject, token, 'totp')
+        markVerifyDispatched(lease, subject, token)
 
         const response = await fetch('/api/2fa/verify', {
           method: 'POST',
@@ -218,14 +217,12 @@ export default function Verify2FAPage() {
           }),
         })
         if (!isTwoFactorLeaseOwner(lease)) return
-        // The dispatch got an answer — the request is no longer running
-        // server-side.
-        markVerifyResponded(lease)
 
         // The server committed the verification for this subject: sync the
-        // session and finish the navigation. Reached on a 2xx and on the
+        // session and finish the navigation. Reached on a 2xx, on the
         // ALREADY_VERIFIED rejection (a success in disguise: e.g. another
-        // tab completed first).
+        // tab completed first) and on RETRY_SYNC (the server has a fresh
+        // verification on record — a lost response from an earlier attempt).
         const finishServerVerified = async (): Promise<void> => {
           markVerifyServerVerified(lease, subject)
           const updated = await update({ twoFactorVerified: true })
@@ -266,7 +263,10 @@ export default function Verify2FAPage() {
               // The error body is best-effort.
             }
             if (!isTwoFactorLeaseOwner(lease)) return
-            if (errorBody?.code === 'ALREADY_VERIFIED') {
+            if (
+              errorBody?.code === 'ALREADY_VERIFIED' ||
+              errorBody?.code === 'RETRY_SYNC'
+            ) {
               await finishServerVerified()
               return
             }

--- a/src/app/auth/verify-2fa/page.tsx
+++ b/src/app/auth/verify-2fa/page.tsx
@@ -45,9 +45,19 @@ export default function Verify2FAPage() {
   // once `isLoading` clears. Cleared on user edit so a re-typed code retries.
   const lastAttemptedTokenRef = useRef<string | null>(null)
 
+  // Set while the success handler owns navigation: once update() reflects
+  // requiresTwoFactor=false, the redirect-away effect below re-fires and its
+  // replace('/') would race the success replace and strand the one-shot
+  // parked fragment (E2EE key). Reset if the session refresh fails.
+  const isNavigatingAfterVerifyRef = useRef(false)
+
   // Redirect if user doesn't require 2FA verification
   useEffect(() => {
     if (status === 'loading') return
+
+    // The success handler is navigating to the callback URL; the session
+    // refresh flipping requiresTwoFactor must not bounce to '/' instead.
+    if (isNavigatingAfterVerifyRef.current) return
 
     // If no session or doesn't require 2FA, redirect to home
     if (!session?.user?.requiresTwoFactor) {
@@ -106,13 +116,27 @@ export default function Verify2FAPage() {
           return
         }
 
+        // From here the success handler owns navigation; set before the
+        // await so the redirect-away effect stays quiet while the session
+        // refresh lands (see the effect above).
+        isNavigatingAfterVerifyRef.current = true
+
         // Update session to mark 2FA as verified
-        await update({ twoFactorVerified: true })
+        const updatedSession = await update({ twoFactorVerified: true })
+        if (!updatedSession) {
+          // Session refresh failed: navigating now would bounce back through
+          // the guard and consume the parked fragment for nothing. Keep it
+          // parked and let the user retry.
+          isNavigatingAfterVerifyRef.current = false
+          setError(t('verify.errors.networkError'))
+          return
+        }
 
         // Redirect to callback URL or home, re-attaching the URL fragment
         // (E2EE key) that TwoFactorGuard parked before redirecting here.
         router.replace(restorePendingFragment(callbackUrl))
       } catch {
+        isNavigatingAfterVerifyRef.current = false
         setError(t('verify.errors.networkError'))
       } finally {
         setIsLoading(false)

--- a/src/app/auth/verify-2fa/page.tsx
+++ b/src/app/auth/verify-2fa/page.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { restorePendingFragment } from '@/lib/pending-fragment'
 import { sanitizeCallbackUrl } from '@/lib/safe-callback-url'
 import { AlertCircle, KeyRound, Loader2, ShieldCheck } from 'lucide-react'
 import { useSession } from 'next-auth/react'
@@ -108,8 +109,9 @@ export default function Verify2FAPage() {
         // Update session to mark 2FA as verified
         await update({ twoFactorVerified: true })
 
-        // Redirect to callback URL or home
-        router.replace(callbackUrl)
+        // Redirect to callback URL or home, re-attaching the URL fragment
+        // (E2EE key) that TwoFactorGuard parked before redirecting here.
+        router.replace(restorePendingFragment(callbackUrl))
       } catch {
         setError(t('verify.errors.networkError'))
       } finally {

--- a/src/app/auth/verify-2fa/verify-flow-integration.test.tsx
+++ b/src/app/auth/verify-2fa/verify-flow-integration.test.tsx
@@ -1,0 +1,271 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Cross-page integration tests for the 2FA verify-flow lease: a verification
+ * transaction started on one page must survive a TOTP <-> backup page switch
+ * (closures outlive unmounts), a second submit must join it as a no-op
+ * instead of double-posting, and leaving the flow must strip ownership so an
+ * orphaned closure can neither consume the parked fragment nor navigate.
+ */
+
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+}))
+
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  useSearchParams: jest.fn(),
+}))
+
+jest.mock('next/link', () => ({
+  __esModule: true,
+  default: ({
+    children,
+    href,
+  }: {
+    children: React.ReactNode
+    href: string
+  }) => <a href={href}>{children}</a>,
+}))
+
+import BackupCodePage from '@/app/auth/verify-2fa/backup/page'
+import Verify2FAPage from '@/app/auth/verify-2fa/page'
+import { setPendingFragment, takePendingFragment } from '@/lib/pending-fragment'
+import {
+  invalidateTwoFactorFlow,
+  isTwoFactorLeaseOwner,
+  markVerifyIdle,
+  releaseTwoFactorLease,
+  tryAcquireTwoFactorLease,
+} from '@/lib/two-factor-verify-flow'
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { useSession } from 'next-auth/react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import { StrictMode } from 'react'
+
+const mockedUseSession = useSession as jest.MockedFunction<typeof useSession>
+const mockedUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
+const mockedUseSearchParams = useSearchParams as jest.MockedFunction<
+  typeof useSearchParams
+>
+
+function setupSession(callbackUrl: string) {
+  const replace = jest.fn()
+  mockedUseRouter.mockReturnValue({ replace } as never)
+  mockedUseSearchParams.mockReturnValue({
+    get: (key: string) => (key === 'callbackUrl' ? callbackUrl : null),
+  } as never)
+  let requiresTwoFactor = true
+  const update = jest.fn(() => {
+    requiresTwoFactor = false
+    return Promise.resolve({
+      user: { id: 'u1', isAdmin: false, requiresTwoFactor: false },
+    })
+  })
+  mockedUseSession.mockImplementation(
+    () =>
+      ({
+        data: {
+          user: {
+            id: 'u1',
+            email: 'user@example.com',
+            isAdmin: false,
+            requiresTwoFactor,
+          },
+        },
+        status: 'authenticated',
+        update,
+      }) as never,
+  )
+  return {
+    replace,
+    update,
+    setRequiresTwoFactor: (value: boolean) => {
+      requiresTwoFactor = value
+    },
+  }
+}
+
+function deferredFetch() {
+  let resolveFetch: (r: Response) => void = () => {}
+  let rejectFetch: (e: unknown) => void = () => {}
+  const fetchMock = jest.fn(
+    () =>
+      new Promise<Response>((res, rej) => {
+        resolveFetch = res
+        rejectFetch = rej
+      }),
+  )
+  global.fetch = fetchMock as unknown as typeof fetch
+  return {
+    fetchMock,
+    resolveOk: () =>
+      act(async () => {
+        resolveFetch({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({}),
+        } as Response)
+        // Drain the transaction's microtask chain (owner check, update()).
+        await Promise.resolve()
+      }),
+    reject: () =>
+      act(async () => {
+        rejectFetch(new Error('offline'))
+        await Promise.resolve()
+      }),
+  }
+}
+
+function typeTotp(value: string) {
+  fireEvent.change(screen.getByLabelText('verify.codeLabel'), {
+    target: { value },
+  })
+}
+
+function resetFlowState() {
+  invalidateTwoFactorFlow()
+  const lease = tryAcquireTwoFactorLease()
+  markVerifyIdle(lease)
+  releaseTwoFactorLease(lease)
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  resetFlowState()
+})
+
+describe('verify-flow transaction across a TOTP <-> backup page switch', () => {
+  it('lets the in-flight transaction finish after the page switch: one navigation, fragment consumed once, no / bounce', async () => {
+    const { replace, update } = setupSession('/groups/x1')
+    const { fetchMock, resolveOk } = deferredFetch()
+    setPendingFragment('/groups/x1', 'KEYx1')
+
+    const totp = render(<Verify2FAPage />)
+    typeTotp('123456')
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    // User switches to the backup page while the request is in flight. The
+    // unmount must NOT release the lease — the transaction is still live.
+    totp.unmount()
+    render(<BackupCodePage />)
+
+    await resolveOk()
+
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith('/groups/x1#KEYx1'),
+    )
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(replace).toHaveBeenCalledTimes(1)
+    expect(replace).not.toHaveBeenCalledWith('/')
+    // One-shot: the transaction consumed the fragment exactly once.
+    expect(takePendingFragment('/groups/x1')).toBeNull()
+  })
+
+  it('joins a second submit into the in-flight transaction: no extra fetch, one navigation', async () => {
+    const { replace, update } = setupSession('/groups/x2')
+    const { fetchMock, resolveOk } = deferredFetch()
+    setPendingFragment('/groups/x2', 'KEYx2')
+
+    const totp = render(<Verify2FAPage />)
+    typeTotp('123456')
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    totp.unmount()
+    render(<BackupCodePage />)
+
+    // Impatient second submit on the backup page: tryAcquire fails (no
+    // steal), so it must be a complete no-op — no second POST, and the
+    // original transaction still owns the navigation.
+    fireEvent.change(screen.getByLabelText('backup.codeLabel'), {
+      target: { value: 'ABCD1234' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'backup.submit' }))
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+
+    await resolveOk()
+
+    await waitFor(() =>
+      expect(replace).toHaveBeenCalledWith('/groups/x2#KEYx2'),
+    )
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    expect(update).toHaveBeenCalledTimes(1)
+    expect(replace).toHaveBeenCalledTimes(1)
+    expect(takePendingFragment('/groups/x2')).toBeNull()
+  })
+
+  it('strips ownership when the user leaves the flow: the orphaned closure must not update, navigate, or consume the fragment', async () => {
+    const { replace, update } = setupSession('/groups/x3')
+    const { fetchMock, resolveOk } = deferredFetch()
+    setPendingFragment('/groups/x3', 'KEYx3')
+
+    const totp = render(<Verify2FAPage />)
+    typeTotp('123456')
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    // User navigates outside the verify flow; TwoFactorGuard invalidates the
+    // flow synchronously on that commit.
+    totp.unmount()
+    invalidateTwoFactorFlow()
+
+    await resolveOk()
+    // Give any (incorrect) continuation a chance to run.
+    await act(async () => {})
+
+    expect(update).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalled()
+    // The parked fragment must survive untouched.
+    expect(takePendingFragment('/groups/x3')).toBe('KEYx3')
+  })
+
+  it('does not let the other page bounce to / when the session flips while the old POST is in flight', async () => {
+    const session = setupSession('/groups/x4')
+    const { fetchMock, resolveOk } = deferredFetch()
+    setPendingFragment('/groups/x4', 'KEYx4')
+
+    const totp = render(<Verify2FAPage />)
+    typeTotp('123456')
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    totp.unmount()
+    // The session reflects requiresTwoFactor=false (e.g. another tab) while
+    // the old transaction still owns the lease: the freshly mounted backup
+    // page must not steal the navigation with replace('/').
+    session.setRequiresTwoFactor(false)
+    render(<BackupCodePage />)
+    await act(async () => {})
+    expect(session.replace).not.toHaveBeenCalled()
+
+    await resolveOk()
+
+    await waitFor(() =>
+      expect(session.replace).toHaveBeenCalledWith('/groups/x4#KEYx4'),
+    )
+    expect(session.replace).toHaveBeenCalledTimes(1)
+    expect(session.replace).not.toHaveBeenCalledWith('/')
+  })
+
+  it('StrictMode mount/replay of a verify page does not release a lease it does not own', async () => {
+    setupSession('/groups/x5')
+
+    // Simulates a transaction owned by the other page being in flight.
+    const foreign = tryAcquireTwoFactorLease()
+    expect(foreign).not.toBeNull()
+
+    render(
+      <StrictMode>
+        <BackupCodePage />
+      </StrictMode>,
+    )
+    await act(async () => {})
+
+    expect(isTwoFactorLeaseOwner(foreign)).toBe(true)
+    releaseTwoFactorLease(foreign)
+  })
+})

--- a/src/app/auth/verify-2fa/verify-flow-integration.test.tsx
+++ b/src/app/auth/verify-2fa/verify-flow-integration.test.tsx
@@ -55,6 +55,8 @@ const mockedUseSearchParams = useSearchParams as jest.MockedFunction<
   typeof useSearchParams
 >
 
+const SUBJECT = { id: 'u1', isAdmin: false }
+
 function setupSession(callbackUrl: string) {
   const replace = jest.fn()
   mockedUseRouter.mockReturnValue({ replace } as never)
@@ -131,7 +133,7 @@ function typeTotp(value: string) {
 
 function resetFlowState() {
   invalidateTwoFactorFlow()
-  const lease = tryAcquireTwoFactorLease()
+  const lease = tryAcquireTwoFactorLease(null)
   markVerifyIdle(lease)
   releaseTwoFactorLease(lease)
 }
@@ -145,7 +147,7 @@ describe('verify-flow transaction across a TOTP <-> backup page switch', () => {
   it('lets the in-flight transaction finish after the page switch: one navigation, fragment consumed once, no / bounce', async () => {
     const { replace, update } = setupSession('/groups/x1')
     const { fetchMock, resolveOk } = deferredFetch()
-    setPendingFragment('/groups/x1', 'KEYx1')
+    setPendingFragment('/groups/x1', 'KEYx1', SUBJECT)
 
     const totp = render(<Verify2FAPage />)
     typeTotp('123456')
@@ -165,13 +167,13 @@ describe('verify-flow transaction across a TOTP <-> backup page switch', () => {
     expect(replace).toHaveBeenCalledTimes(1)
     expect(replace).not.toHaveBeenCalledWith('/')
     // One-shot: the transaction consumed the fragment exactly once.
-    expect(takePendingFragment('/groups/x1')).toBeNull()
+    expect(takePendingFragment('/groups/x1', SUBJECT)).toBeNull()
   })
 
   it('joins a second submit into the in-flight transaction: no extra fetch, one navigation', async () => {
     const { replace, update } = setupSession('/groups/x2')
     const { fetchMock, resolveOk } = deferredFetch()
-    setPendingFragment('/groups/x2', 'KEYx2')
+    setPendingFragment('/groups/x2', 'KEYx2', SUBJECT)
 
     const totp = render(<Verify2FAPage />)
     typeTotp('123456')
@@ -197,13 +199,13 @@ describe('verify-flow transaction across a TOTP <-> backup page switch', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(update).toHaveBeenCalledTimes(1)
     expect(replace).toHaveBeenCalledTimes(1)
-    expect(takePendingFragment('/groups/x2')).toBeNull()
+    expect(takePendingFragment('/groups/x2', SUBJECT)).toBeNull()
   })
 
   it('strips ownership when the user leaves the flow: the orphaned closure must not update, navigate, or consume the fragment', async () => {
     const { replace, update } = setupSession('/groups/x3')
     const { fetchMock, resolveOk } = deferredFetch()
-    setPendingFragment('/groups/x3', 'KEYx3')
+    setPendingFragment('/groups/x3', 'KEYx3', SUBJECT)
 
     const totp = render(<Verify2FAPage />)
     typeTotp('123456')
@@ -221,13 +223,13 @@ describe('verify-flow transaction across a TOTP <-> backup page switch', () => {
     expect(update).not.toHaveBeenCalled()
     expect(replace).not.toHaveBeenCalled()
     // The parked fragment must survive untouched.
-    expect(takePendingFragment('/groups/x3')).toBe('KEYx3')
+    expect(takePendingFragment('/groups/x3', SUBJECT)).toBe('KEYx3')
   })
 
   it('does not let the other page bounce to / when the session flips while the old POST is in flight', async () => {
     const session = setupSession('/groups/x4')
     const { fetchMock, resolveOk } = deferredFetch()
-    setPendingFragment('/groups/x4', 'KEYx4')
+    setPendingFragment('/groups/x4', 'KEYx4', SUBJECT)
 
     const totp = render(<Verify2FAPage />)
     typeTotp('123456')
@@ -255,7 +257,7 @@ describe('verify-flow transaction across a TOTP <-> backup page switch', () => {
     setupSession('/groups/x5')
 
     // Simulates a transaction owned by the other page being in flight.
-    const foreign = tryAcquireTwoFactorLease()
+    const foreign = tryAcquireTwoFactorLease(SUBJECT)
     expect(foreign).not.toBeNull()
 
     render(
@@ -266,6 +268,8 @@ describe('verify-flow transaction across a TOTP <-> backup page switch', () => {
     await act(async () => {})
 
     expect(isTwoFactorLeaseOwner(foreign)).toBe(true)
-    releaseTwoFactorLease(foreign)
+    await act(async () => {
+      releaseTwoFactorLease(foreign)
+    })
   })
 })

--- a/src/components/two-factor-guard-fragment.test.tsx
+++ b/src/components/two-factor-guard-fragment.test.tsx
@@ -37,12 +37,14 @@ const mockedUseSession = useSession as jest.MockedFunction<typeof useSession>
 const mockedUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
 const mockedUsePathname = usePathname as jest.MockedFunction<typeof usePathname>
 
+const GUARD_SUBJECT = { id: 'g1', isAdmin: false }
+
 function setup(pathname: string, hash: string) {
   const push = jest.fn()
   mockedUseRouter.mockReturnValue({ push } as never)
   mockedUsePathname.mockReturnValue(pathname)
   mockedUseSession.mockReturnValue({
-    data: { user: { requiresTwoFactor: true } },
+    data: { user: { id: 'g1', isAdmin: false, requiresTwoFactor: true } },
     status: 'authenticated',
   } as never)
   window.location.hash = hash
@@ -76,17 +78,17 @@ describe('TwoFactorGuard fragment capture', () => {
     for (const call of push.mock.calls) {
       expect(String(call[0])).not.toContain('KEYcap')
     }
-    expect(takePendingFragment('/groups/cap')).toBe('KEYcap')
+    expect(takePendingFragment('/groups/cap', GUARD_SUBJECT)).toBe('KEYcap')
   })
 
   it('leaves a previously parked fragment intact when the hash is empty', () => {
     // Simulates the effect re-running after router.push already stripped the
     // hash from the address bar: the earlier capture must survive.
-    setPendingFragment('/groups/empty', 'KEYempty')
+    setPendingFragment('/groups/empty', 'KEYempty', GUARD_SUBJECT)
     setup('/groups/empty', '')
     renderGuard((node) => <>{node}</>)
 
-    expect(takePendingFragment('/groups/empty')).toBe('KEYempty')
+    expect(takePendingFragment('/groups/empty', GUARD_SUBJECT)).toBe('KEYempty')
   })
 
   it('parks exactly one copy under StrictMode effect replay', () => {
@@ -94,9 +96,11 @@ describe('TwoFactorGuard fragment capture', () => {
     renderGuard((node) => <StrictMode>{node}</StrictMode>)
 
     expect(push).toHaveBeenCalled()
-    expect(takePendingFragment('/groups/strict')).toBe('KEYstrict')
+    expect(takePendingFragment('/groups/strict', GUARD_SUBJECT)).toBe(
+      'KEYstrict',
+    )
     // One-shot: the replayed effect must not have left a second copy behind.
-    expect(takePendingFragment('/groups/strict')).toBeNull()
+    expect(takePendingFragment('/groups/strict', GUARD_SUBJECT)).toBeNull()
   })
 })
 
@@ -104,7 +108,7 @@ describe('TwoFactorGuard verify-flow invalidation', () => {
   it('invalidates an active verify lease on a commit outside the flow', () => {
     // An in-flight verify transaction (its page just unmounted) must lose
     // ownership the moment the app lands anywhere outside /auth/verify-2fa.
-    const lease = tryAcquireTwoFactorLease()
+    const lease = tryAcquireTwoFactorLease(GUARD_SUBJECT)
     setup('/groups/leave', '')
     renderGuard((node) => <>{node}</>)
 
@@ -115,7 +119,7 @@ describe('TwoFactorGuard verify-flow invalidation', () => {
     // Inside the flow (TOTP <-> backup switches) the transaction survives;
     // a StrictMode layout-effect replay must not release someone else's
     // lease either.
-    const lease = tryAcquireTwoFactorLease()
+    const lease = tryAcquireTwoFactorLease(GUARD_SUBJECT)
     setup('/auth/verify-2fa', '')
     renderGuard((node) => <StrictMode>{node}</StrictMode>)
 

--- a/src/components/two-factor-guard-fragment.test.tsx
+++ b/src/components/two-factor-guard-fragment.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Fragment-preservation test for TwoFactorGuard (2FA fragment loss fix).
+ *
+ * The URL fragment carries the group's E2EE key. When the guard intercepts
+ * a navigation and redirects to /auth/verify-2fa, it must park the fragment
+ * in the client-only pending-fragment store — never in callbackUrl, which
+ * is a query string the server can see — so the verification pages can
+ * re-attach it after a successful check.
+ */
+
+jest.mock('next-auth/react', () => ({
+  useSession: jest.fn(),
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+  usePathname: jest.fn(),
+}))
+
+import { TwoFactorGuard } from '@/components/two-factor-guard'
+import { setPendingFragment, takePendingFragment } from '@/lib/pending-fragment'
+import { render } from '@testing-library/react'
+import { useSession } from 'next-auth/react'
+import { usePathname, useRouter } from 'next/navigation'
+import { StrictMode } from 'react'
+
+const mockedUseSession = useSession as jest.MockedFunction<typeof useSession>
+const mockedUseRouter = useRouter as jest.MockedFunction<typeof useRouter>
+const mockedUsePathname = usePathname as jest.MockedFunction<typeof usePathname>
+
+function setup(pathname: string, hash: string) {
+  const push = jest.fn()
+  mockedUseRouter.mockReturnValue({ push } as never)
+  mockedUsePathname.mockReturnValue(pathname)
+  mockedUseSession.mockReturnValue({
+    data: { user: { requiresTwoFactor: true } },
+    status: 'authenticated',
+  } as never)
+  window.location.hash = hash
+  return push
+}
+
+function renderGuard(wrapper: (node: React.ReactNode) => React.ReactElement) {
+  render(
+    wrapper(
+      <TwoFactorGuard enabled>
+        <div>content</div>
+      </TwoFactorGuard>,
+    ),
+  )
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('TwoFactorGuard fragment capture', () => {
+  it('parks the fragment for the intercepted path and keeps it out of the redirect URL', () => {
+    const push = setup('/groups/cap', '#KEYcap')
+    renderGuard((node) => <>{node}</>)
+
+    expect(push).toHaveBeenCalledWith(
+      `/auth/verify-2fa?callbackUrl=${encodeURIComponent('/groups/cap')}`,
+    )
+    // The key must never appear in the navigation target: the query string
+    // reaches the server. It is parked in the client-only store instead.
+    for (const call of push.mock.calls) {
+      expect(String(call[0])).not.toContain('KEYcap')
+    }
+    expect(takePendingFragment('/groups/cap')).toBe('KEYcap')
+  })
+
+  it('leaves a previously parked fragment intact when the hash is empty', () => {
+    // Simulates the effect re-running after router.push already stripped the
+    // hash from the address bar: the earlier capture must survive.
+    setPendingFragment('/groups/empty', 'KEYempty')
+    setup('/groups/empty', '')
+    renderGuard((node) => <>{node}</>)
+
+    expect(takePendingFragment('/groups/empty')).toBe('KEYempty')
+  })
+
+  it('parks exactly one copy under StrictMode effect replay', () => {
+    const push = setup('/groups/strict', '#KEYstrict')
+    renderGuard((node) => <StrictMode>{node}</StrictMode>)
+
+    expect(push).toHaveBeenCalled()
+    expect(takePendingFragment('/groups/strict')).toBe('KEYstrict')
+    // One-shot: the replayed effect must not have left a second copy behind.
+    expect(takePendingFragment('/groups/strict')).toBeNull()
+  })
+})

--- a/src/components/two-factor-guard-fragment.test.tsx
+++ b/src/components/two-factor-guard-fragment.test.tsx
@@ -23,6 +23,11 @@ jest.mock('next/navigation', () => ({
 
 import { TwoFactorGuard } from '@/components/two-factor-guard'
 import { setPendingFragment, takePendingFragment } from '@/lib/pending-fragment'
+import {
+  isTwoFactorLeaseOwner,
+  releaseTwoFactorLease,
+  tryAcquireTwoFactorLease,
+} from '@/lib/two-factor-verify-flow'
 import { render } from '@testing-library/react'
 import { useSession } from 'next-auth/react'
 import { usePathname, useRouter } from 'next/navigation'
@@ -92,5 +97,29 @@ describe('TwoFactorGuard fragment capture', () => {
     expect(takePendingFragment('/groups/strict')).toBe('KEYstrict')
     // One-shot: the replayed effect must not have left a second copy behind.
     expect(takePendingFragment('/groups/strict')).toBeNull()
+  })
+})
+
+describe('TwoFactorGuard verify-flow invalidation', () => {
+  it('invalidates an active verify lease on a commit outside the flow', () => {
+    // An in-flight verify transaction (its page just unmounted) must lose
+    // ownership the moment the app lands anywhere outside /auth/verify-2fa.
+    const lease = tryAcquireTwoFactorLease()
+    setup('/groups/leave', '')
+    renderGuard((node) => <>{node}</>)
+
+    expect(isTwoFactorLeaseOwner(lease)).toBe(false)
+  })
+
+  it('keeps a foreign lease across verify-flow commits, incl. StrictMode replay', () => {
+    // Inside the flow (TOTP <-> backup switches) the transaction survives;
+    // a StrictMode layout-effect replay must not release someone else's
+    // lease either.
+    const lease = tryAcquireTwoFactorLease()
+    setup('/auth/verify-2fa', '')
+    renderGuard((node) => <StrictMode>{node}</StrictMode>)
+
+    expect(isTwoFactorLeaseOwner(lease)).toBe(true)
+    releaseTwoFactorLease(lease)
   })
 })

--- a/src/components/two-factor-guard.tsx
+++ b/src/components/two-factor-guard.tsx
@@ -6,10 +6,14 @@
  */
 
 import { setPendingFragment } from '@/lib/pending-fragment'
+import {
+  invalidateTwoFactorFlow,
+  isVerifyFlowPath,
+} from '@/lib/two-factor-verify-flow'
 import { Loader2 } from 'lucide-react'
 import { useSession } from 'next-auth/react'
 import { usePathname, useRouter } from 'next/navigation'
-import { useEffect, useState } from 'react'
+import { useEffect, useLayoutEffect, useState } from 'react'
 
 interface TwoFactorGuardProps {
   children: React.ReactNode
@@ -41,6 +45,16 @@ function TwoFactorGuardContent({ children }: { children: React.ReactNode }) {
   const router = useRouter()
   const pathname = usePathname()
   const [isChecking, setIsChecking] = useState(true)
+
+  // Leaving the verify flow ends any in-flight verification transaction.
+  // Layout effect: it must run synchronously with the commit, before pending
+  // promise continuations (microtasks) can resume a surviving closure that
+  // would otherwise still own the lease and consume the parked fragment.
+  useLayoutEffect(() => {
+    if (!isVerifyFlowPath(pathname)) {
+      invalidateTwoFactorFlow()
+    }
+  }, [pathname])
 
   useEffect(() => {
     // Wait for session to load

--- a/src/components/two-factor-guard.tsx
+++ b/src/components/two-factor-guard.tsx
@@ -5,6 +5,7 @@
  * Redirects users to 2FA verification page if requiresTwoFactor is true
  */
 
+import { setPendingFragment } from '@/lib/pending-fragment'
 import { Loader2 } from 'lucide-react'
 import { useSession } from 'next-auth/react'
 import { usePathname, useRouter } from 'next/navigation'
@@ -59,6 +60,12 @@ function TwoFactorGuardContent({ children }: { children: React.ReactNode }) {
 
     // Redirect to 2FA verification if required
     if (session?.user?.requiresTwoFactor) {
+      // Park the URL fragment (the group's E2EE key) before redirecting: it
+      // must not ride on callbackUrl (query strings reach the server) and
+      // would otherwise be dropped. The store ignores empty writes, so an
+      // effect re-run after router.push has already stripped the hash cannot
+      // clobber the capture.
+      setPendingFragment(pathname, window.location.hash.slice(1))
       const callbackUrl = encodeURIComponent(pathname)
       router.push(`/auth/verify-2fa?callbackUrl=${callbackUrl}`)
       return

--- a/src/components/two-factor-guard.tsx
+++ b/src/components/two-factor-guard.tsx
@@ -79,7 +79,10 @@ function TwoFactorGuardContent({ children }: { children: React.ReactNode }) {
       // would otherwise be dropped. The store ignores empty writes, so an
       // effect re-run after router.push has already stripped the hash cannot
       // clobber the capture.
-      setPendingFragment(pathname, window.location.hash.slice(1))
+      setPendingFragment(pathname, window.location.hash.slice(1), {
+        id: session.user.id,
+        isAdmin: session.user.isAdmin,
+      })
       const callbackUrl = encodeURIComponent(pathname)
       router.push(`/auth/verify-2fa?callbackUrl=${callbackUrl}`)
       return

--- a/src/lib/pending-fragment.server.test.ts
+++ b/src/lib/pending-fragment.server.test.ts
@@ -1,0 +1,10 @@
+/** @jest-environment node */
+
+import { setPendingFragment, takePendingFragment } from './pending-fragment'
+
+describe('pending-fragment on the server (no window)', () => {
+  it('ignores writes so key material never enters shared process memory', () => {
+    setPendingFragment('/groups/srv', 'SRVKEY')
+    expect(takePendingFragment('/groups/srv')).toBeNull()
+  })
+})

--- a/src/lib/pending-fragment.server.test.ts
+++ b/src/lib/pending-fragment.server.test.ts
@@ -2,9 +2,11 @@
 
 import { setPendingFragment, takePendingFragment } from './pending-fragment'
 
+const SUBJECT = { id: 'srv', isAdmin: false }
+
 describe('pending-fragment on the server (no window)', () => {
   it('ignores writes so key material never enters shared process memory', () => {
-    setPendingFragment('/groups/srv', 'SRVKEY')
-    expect(takePendingFragment('/groups/srv')).toBeNull()
+    setPendingFragment('/groups/srv', 'SRVKEY', SUBJECT)
+    expect(takePendingFragment('/groups/srv', SUBJECT)).toBeNull()
   })
 })

--- a/src/lib/pending-fragment.test.ts
+++ b/src/lib/pending-fragment.test.ts
@@ -1,8 +1,13 @@
 import {
+  clearPendingFragment,
   restorePendingFragment,
   setPendingFragment,
   takePendingFragment,
 } from './pending-fragment'
+
+const ALICE = { id: 'alice', isAdmin: false }
+const BOB = { id: 'bob', isAdmin: false }
+const ALICE_ADMIN = { id: 'alice', isAdmin: true }
 
 // The store is a single module-level slot. Every test uses its own unique
 // path and seeds its own value, so cases never depend on execution order:
@@ -10,68 +15,98 @@ import {
 // be overwritten by the test's own write.
 describe('pending-fragment', () => {
   it('returns null when nothing is pending for the path', () => {
-    expect(takePendingFragment('/groups/none')).toBeNull()
+    clearPendingFragment()
+    expect(takePendingFragment('/groups/none', ALICE)).toBeNull()
   })
 
-  it('round-trips a fragment for the path it was captured on, one-shot', () => {
-    setPendingFragment('/groups/rt', 'KEYrt')
-    expect(takePendingFragment('/groups/rt')).toBe('KEYrt')
-    expect(takePendingFragment('/groups/rt')).toBeNull()
+  it('round-trips a fragment for the path and subject it was captured on, one-shot', () => {
+    setPendingFragment('/groups/rt', 'KEYrt', ALICE)
+    expect(takePendingFragment('/groups/rt', ALICE)).toBe('KEYrt')
+    expect(takePendingFragment('/groups/rt', ALICE)).toBeNull()
   })
 
   it('does not hand a fragment to a different path and keeps it for its own', () => {
-    setPendingFragment('/groups/mine', 'KEYmine')
-    expect(takePendingFragment('/groups/other')).toBeNull()
-    expect(takePendingFragment('/groups/mine')).toBe('KEYmine')
+    setPendingFragment('/groups/mine', 'KEYmine', ALICE)
+    expect(takePendingFragment('/groups/other', ALICE)).toBeNull()
+    expect(takePendingFragment('/groups/mine', ALICE)).toBe('KEYmine')
+  })
+
+  it('DESTROYS the entry when a different subject takes: no cross-account re-attach', () => {
+    // A's key parked, then B completes 2FA on the same path in the same
+    // browser context: B must not receive A's key, and A's key must not
+    // stay parked either (fail-closed).
+    setPendingFragment('/groups/xacct', 'KEYalice', ALICE)
+    expect(takePendingFragment('/groups/xacct', BOB)).toBeNull()
+    expect(takePendingFragment('/groups/xacct', ALICE)).toBeNull()
+  })
+
+  it('treats the same id with a different role as a different subject', () => {
+    // Admin and WhitelistUser ids/emails are separate namespaces.
+    setPendingFragment('/groups/role', 'KEYrole', ALICE)
+    expect(takePendingFragment('/groups/role', ALICE_ADMIN)).toBeNull()
+    expect(takePendingFragment('/groups/role', ALICE)).toBeNull()
+  })
+
+  it('clearPendingFragment destroys the slot', () => {
+    setPendingFragment('/groups/clear', 'KEYclear', ALICE)
+    clearPendingFragment()
+    expect(takePendingFragment('/groups/clear', ALICE)).toBeNull()
   })
 
   it('ignores empty writes so a late empty capture cannot clobber a key', () => {
-    setPendingFragment('/groups/keep', 'KEYkeep')
-    setPendingFragment('/groups/keep', '')
-    expect(takePendingFragment('/groups/keep')).toBe('KEYkeep')
+    setPendingFragment('/groups/keep', 'KEYkeep', ALICE)
+    setPendingFragment('/groups/keep', '', ALICE)
+    expect(takePendingFragment('/groups/keep', ALICE)).toBe('KEYkeep')
   })
 
   it('lets a newer capture replace an older one (latest interception wins)', () => {
-    setPendingFragment('/groups/older', 'KEYolder')
-    setPendingFragment('/groups/newer', 'KEYnewer')
-    expect(takePendingFragment('/groups/older')).toBeNull()
-    expect(takePendingFragment('/groups/newer')).toBe('KEYnewer')
+    setPendingFragment('/groups/older', 'KEYolder', ALICE)
+    setPendingFragment('/groups/newer', 'KEYnewer', ALICE)
+    expect(takePendingFragment('/groups/older', ALICE)).toBeNull()
+    expect(takePendingFragment('/groups/newer', ALICE)).toBe('KEYnewer')
   })
 
   describe('restorePendingFragment', () => {
     it('re-attaches a pending fragment to the callback URL', () => {
-      setPendingFragment('/groups/attach', 'KEYattach')
-      expect(restorePendingFragment('/groups/attach')).toBe(
+      setPendingFragment('/groups/attach', 'KEYattach', ALICE)
+      expect(restorePendingFragment('/groups/attach', ALICE)).toBe(
         '/groups/attach#KEYattach',
       )
     })
 
     it('consumes the fragment (one-shot through restore as well)', () => {
-      setPendingFragment('/groups/once', 'KEYonce')
-      restorePendingFragment('/groups/once')
-      expect(restorePendingFragment('/groups/once')).toBe('/groups/once')
+      setPendingFragment('/groups/once', 'KEYonce', ALICE)
+      restorePendingFragment('/groups/once', ALICE)
+      expect(restorePendingFragment('/groups/once', ALICE)).toBe('/groups/once')
+    })
+
+    it("does not re-attach another subject's fragment and destroys it", () => {
+      setPendingFragment('/groups/xrest', 'KEYxrest', ALICE)
+      expect(restorePendingFragment('/groups/xrest', BOB)).toBe('/groups/xrest')
+      expect(takePendingFragment('/groups/xrest', ALICE)).toBeNull()
     })
 
     it('replaces a hash already present on the callback URL', () => {
-      setPendingFragment('/groups/swap', 'KEYswap')
-      expect(restorePendingFragment('/groups/swap#stale')).toBe(
+      setPendingFragment('/groups/swap', 'KEYswap', ALICE)
+      expect(restorePendingFragment('/groups/swap#stale', ALICE)).toBe(
         '/groups/swap#KEYswap',
       )
     })
 
     it('returns the URL untouched, existing hash included, when nothing is pending', () => {
-      expect(restorePendingFragment('/groups/plain#kept')).toBe(
+      clearPendingFragment()
+      expect(restorePendingFragment('/groups/plain#kept', ALICE)).toBe(
         '/groups/plain#kept',
       )
     })
 
     it('does not match a callback URL carrying a query the capture did not have', () => {
-      setPendingFragment('/groups/q', 'KEYq')
-      expect(restorePendingFragment('/groups/q?tab=stats')).toBe(
+      setPendingFragment('/groups/q', 'KEYq', ALICE)
+      expect(restorePendingFragment('/groups/q?tab=stats', ALICE)).toBe(
         '/groups/q?tab=stats',
       )
       // The mismatched restore must not have consumed the entry.
-      expect(takePendingFragment('/groups/q')).toBe('KEYq')
+      expect(takePendingFragment('/groups/q', ALICE)).toBe('KEYq')
     })
   })
 })

--- a/src/lib/pending-fragment.test.ts
+++ b/src/lib/pending-fragment.test.ts
@@ -1,0 +1,77 @@
+import {
+  restorePendingFragment,
+  setPendingFragment,
+  takePendingFragment,
+} from './pending-fragment'
+
+// The store is a single module-level slot. Every test uses its own unique
+// path and seeds its own value, so cases never depend on execution order:
+// a leftover entry from another test can only mismatch (returning null) or
+// be overwritten by the test's own write.
+describe('pending-fragment', () => {
+  it('returns null when nothing is pending for the path', () => {
+    expect(takePendingFragment('/groups/none')).toBeNull()
+  })
+
+  it('round-trips a fragment for the path it was captured on, one-shot', () => {
+    setPendingFragment('/groups/rt', 'KEYrt')
+    expect(takePendingFragment('/groups/rt')).toBe('KEYrt')
+    expect(takePendingFragment('/groups/rt')).toBeNull()
+  })
+
+  it('does not hand a fragment to a different path and keeps it for its own', () => {
+    setPendingFragment('/groups/mine', 'KEYmine')
+    expect(takePendingFragment('/groups/other')).toBeNull()
+    expect(takePendingFragment('/groups/mine')).toBe('KEYmine')
+  })
+
+  it('ignores empty writes so a late empty capture cannot clobber a key', () => {
+    setPendingFragment('/groups/keep', 'KEYkeep')
+    setPendingFragment('/groups/keep', '')
+    expect(takePendingFragment('/groups/keep')).toBe('KEYkeep')
+  })
+
+  it('lets a newer capture replace an older one (latest interception wins)', () => {
+    setPendingFragment('/groups/older', 'KEYolder')
+    setPendingFragment('/groups/newer', 'KEYnewer')
+    expect(takePendingFragment('/groups/older')).toBeNull()
+    expect(takePendingFragment('/groups/newer')).toBe('KEYnewer')
+  })
+
+  describe('restorePendingFragment', () => {
+    it('re-attaches a pending fragment to the callback URL', () => {
+      setPendingFragment('/groups/attach', 'KEYattach')
+      expect(restorePendingFragment('/groups/attach')).toBe(
+        '/groups/attach#KEYattach',
+      )
+    })
+
+    it('consumes the fragment (one-shot through restore as well)', () => {
+      setPendingFragment('/groups/once', 'KEYonce')
+      restorePendingFragment('/groups/once')
+      expect(restorePendingFragment('/groups/once')).toBe('/groups/once')
+    })
+
+    it('replaces a hash already present on the callback URL', () => {
+      setPendingFragment('/groups/swap', 'KEYswap')
+      expect(restorePendingFragment('/groups/swap#stale')).toBe(
+        '/groups/swap#KEYswap',
+      )
+    })
+
+    it('returns the URL untouched, existing hash included, when nothing is pending', () => {
+      expect(restorePendingFragment('/groups/plain#kept')).toBe(
+        '/groups/plain#kept',
+      )
+    })
+
+    it('does not match a callback URL carrying a query the capture did not have', () => {
+      setPendingFragment('/groups/q', 'KEYq')
+      expect(restorePendingFragment('/groups/q?tab=stats')).toBe(
+        '/groups/q?tab=stats',
+      )
+      // The mismatched restore must not have consumed the entry.
+      expect(takePendingFragment('/groups/q')).toBe('KEYq')
+    })
+  })
+})

--- a/src/lib/pending-fragment.ts
+++ b/src/lib/pending-fragment.ts
@@ -1,0 +1,66 @@
+/**
+ * In-memory store for a URL fragment (E2EE key material) across the 2FA
+ * verification redirect.
+ *
+ * When TwoFactorGuard intercepts a navigation such as `/groups/<id>#<key>`,
+ * it redirects to `/auth/verify-2fa?callbackUrl=<path>`. The fragment is the
+ * group's encryption key: it must never ride on `callbackUrl`, because the
+ * query string is sent to the server on navigation (RSC fetch or a full
+ * reload), which would break the E2EE invariant that the server never
+ * receives key material. sessionStorage is ruled out for the same reason we
+ * avoid it elsewhere: it would persist the key at rest beyond the redirect's
+ * lifetime.
+ *
+ * Instead the guard parks the fragment here, in module memory, bound to the
+ * destination path, and the verification pages re-attach it after a
+ * successful 2FA check. A hard reload during verification loses the entry
+ * and the user lands on the key-entry screen exactly as before this store
+ * existed — privacy is chosen over convenience (the same trade-off as
+ * reimbursement-prefill).
+ *
+ * A single slot (not a map) is deliberate: only the most recent interception
+ * can still be completed, and one slot keeps at most one copy of key
+ * material in process memory.
+ */
+
+let pendingPath: string | null = null
+let pendingFragment: string | null = null
+
+export function setPendingFragment(path: string, fragment: string): void {
+  // Client-only: a server-side write would share one user's key material
+  // across every request handled by the Node process (cross-tenant leak).
+  if (typeof window === 'undefined') return
+  // Ignore empty writes: by the time a caller re-runs after the redirect has
+  // already stripped the hash from the address bar, an empty capture must
+  // not clobber the fragment that was just parked.
+  if (!fragment) return
+  pendingPath = path
+  pendingFragment = fragment
+}
+
+/**
+ * One-shot read: returns the fragment if it was captured for exactly this
+ * path and clears the slot. A mismatched path returns null and leaves the
+ * slot intact — a fragment may only re-attach to the destination it was
+ * captured on, never to a different page's URL.
+ */
+export function takePendingFragment(path: string): string | null {
+  if (pendingFragment === null || pendingPath !== path) return null
+  const fragment = pendingFragment
+  pendingPath = null
+  pendingFragment = null
+  return fragment
+}
+
+/**
+ * Re-attach a pending fragment to `callbackUrl` if one was captured for it.
+ * A hash already present on `callbackUrl` is replaced in that case (it
+ * survived a query-string round-trip, so it was server-visible and cannot be
+ * the key the guard captured); when nothing is pending the URL is returned
+ * untouched.
+ */
+export function restorePendingFragment(callbackUrl: string): string {
+  const base = callbackUrl.split('#')[0]
+  const fragment = takePendingFragment(base)
+  return fragment === null ? callbackUrl : `${base}#${fragment}`
+}

--- a/src/lib/pending-fragment.ts
+++ b/src/lib/pending-fragment.ts
@@ -12,21 +12,37 @@
  * lifetime.
  *
  * Instead the guard parks the fragment here, in module memory, bound to the
- * destination path, and the verification pages re-attach it after a
- * successful 2FA check. A hard reload during verification loses the entry
- * and the user lands on the key-entry screen exactly as before this store
- * existed — privacy is chosen over convenience (the same trade-off as
- * reimbursement-prefill).
+ * destination path AND to the subject ({id, isAdmin}) whose interception
+ * parked it, and the verification pages re-attach it after a successful 2FA
+ * check. The subject binding is load-bearing: without it, user A's key could
+ * survive a discarded bounce and re-attach to user B's navigation after B
+ * completes 2FA on the same path in the same browser context (cross-account
+ * key disclosure). A take by a different subject therefore DESTROYS the
+ * entry (fail-closed); a path mismatch by the same subject keeps it
+ * (fail-safe to no-fragment, latest-interception-wins). A hard reload during
+ * verification loses the entry and the user lands on the key-entry screen
+ * exactly as before this store existed — privacy is chosen over convenience
+ * (the same trade-off as reimbursement-prefill).
  *
  * A single slot (not a map) is deliberate: only the most recent interception
  * can still be completed, and one slot keeps at most one copy of key
  * material in process memory.
  */
 
+import {
+  verifySubjectKey,
+  type VerifySubject,
+} from '@/lib/two-factor-verify-flow'
+
 let pendingPath: string | null = null
 let pendingFragment: string | null = null
+let pendingSubjectKey: string | null = null
 
-export function setPendingFragment(path: string, fragment: string): void {
+export function setPendingFragment(
+  path: string,
+  fragment: string,
+  subject: VerifySubject,
+): void {
   // Client-only: a server-side write would share one user's key material
   // across every request handled by the Node process (cross-tenant leak).
   if (typeof window === 'undefined') return
@@ -36,31 +52,55 @@ export function setPendingFragment(path: string, fragment: string): void {
   if (!fragment) return
   pendingPath = path
   pendingFragment = fragment
+  pendingSubjectKey = verifySubjectKey(subject)
+}
+
+/**
+ * Destroy the slot. Called when the fragment's completion chance is gone —
+ * a discarding bounce to '/' or a signed-out landing on the verify pages —
+ * so a stale key can never re-attach to a later navigation.
+ */
+export function clearPendingFragment(): void {
+  pendingPath = null
+  pendingFragment = null
+  pendingSubjectKey = null
 }
 
 /**
  * One-shot read: returns the fragment if it was captured for exactly this
- * path and clears the slot. A mismatched path returns null and leaves the
- * slot intact — a fragment may only re-attach to the destination it was
- * captured on, never to a different page's URL.
+ * path by exactly this subject, and clears the slot. A different subject
+ * clears the slot and gets null (another account's key must never re-attach
+ * to this subject's navigation). A mismatched path by the same subject
+ * returns null and leaves the slot intact — a fragment may only re-attach to
+ * the destination it was captured on, never to a different page's URL.
  */
-export function takePendingFragment(path: string): string | null {
-  if (pendingFragment === null || pendingPath !== path) return null
+export function takePendingFragment(
+  path: string,
+  subject: VerifySubject,
+): string | null {
+  if (pendingFragment === null) return null
+  if (pendingSubjectKey !== verifySubjectKey(subject)) {
+    clearPendingFragment()
+    return null
+  }
+  if (pendingPath !== path) return null
   const fragment = pendingFragment
-  pendingPath = null
-  pendingFragment = null
+  clearPendingFragment()
   return fragment
 }
 
 /**
- * Re-attach a pending fragment to `callbackUrl` if one was captured for it.
- * A hash already present on `callbackUrl` is replaced in that case (it
- * survived a query-string round-trip, so it was server-visible and cannot be
- * the key the guard captured); when nothing is pending the URL is returned
- * untouched.
+ * Re-attach a pending fragment to `callbackUrl` if one was captured for it
+ * by this subject. A hash already present on `callbackUrl` is replaced in
+ * that case (it survived a query-string round-trip, so it was server-visible
+ * and cannot be the key the guard captured); when nothing is pending the URL
+ * is returned untouched.
  */
-export function restorePendingFragment(callbackUrl: string): string {
+export function restorePendingFragment(
+  callbackUrl: string,
+  subject: VerifySubject,
+): string {
   const base = callbackUrl.split('#')[0]
-  const fragment = takePendingFragment(base)
+  const fragment = takePendingFragment(base, subject)
   return fragment === null ? callbackUrl : `${base}#${fragment}`
 }

--- a/src/lib/two-factor-verify-flow.server.test.ts
+++ b/src/lib/two-factor-verify-flow.server.test.ts
@@ -1,0 +1,18 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Server-side guard for the verify-flow lease: on the server (no `window`)
+ * a lease must never be handed out — module state there is shared across
+ * every request handled by the process.
+ */
+
+import { tryAcquireTwoFactorLease } from '@/lib/two-factor-verify-flow'
+
+describe('two-factor-verify-flow on the server', () => {
+  it('never grants a lease', () => {
+    expect(typeof window).toBe('undefined')
+    expect(tryAcquireTwoFactorLease()).toBeNull()
+  })
+})

--- a/src/lib/two-factor-verify-flow.server.test.ts
+++ b/src/lib/two-factor-verify-flow.server.test.ts
@@ -13,6 +13,6 @@ import { tryAcquireTwoFactorLease } from '@/lib/two-factor-verify-flow'
 describe('two-factor-verify-flow on the server', () => {
   it('never grants a lease', () => {
     expect(typeof window).toBe('undefined')
-    expect(tryAcquireTwoFactorLease()).toBeNull()
+    expect(tryAcquireTwoFactorLease({ id: 'srv', isAdmin: false })).toBeNull()
   })
 })

--- a/src/lib/two-factor-verify-flow.test.ts
+++ b/src/lib/two-factor-verify-flow.test.ts
@@ -3,29 +3,37 @@
  */
 
 /**
- * Unit tests for the 2FA verify-flow store: exclusive lease semantics
- * (no steal, owner-only release, flow-wide invalidation) and the
- * subject-bound recovery outcome.
+ * Unit tests for the 2FA verify-flow store: subject-bound exclusive lease
+ * semantics (join for the same subject, synchronous invalidation on a
+ * subject change, owner-only release), the subject-bound recovery outcome
+ * with transport-settlement tracking, the version/subscription pair, and
+ * the dot-segment-safe flow-path check.
  */
 
 import {
+  getTwoFactorFlowVersion,
   getVerifyOutcome,
   invalidateTwoFactorFlow,
+  isBackupDispatchUnsettled,
   isTwoFactorLeaseOwner,
   isVerifyFlowPath,
   markVerifyDispatched,
   markVerifyIdle,
+  markVerifyResponded,
   markVerifyServerVerified,
   releaseTwoFactorLease,
+  subscribeTwoFactorFlow,
   tryAcquireTwoFactorLease,
   wasVerifyTokenDispatched,
 } from '@/lib/two-factor-verify-flow'
 
 const USER = { id: 'u1', isAdmin: false }
+const OTHER_USER = { id: 'u2', isAdmin: false }
+const SAME_ID_ADMIN = { id: 'u1', isAdmin: true }
 
 function resetFlowState() {
   invalidateTwoFactorFlow()
-  const lease = tryAcquireTwoFactorLease()
+  const lease = tryAcquireTwoFactorLease(USER)
   markVerifyIdle(lease)
   releaseTwoFactorLease(lease)
 }
@@ -33,43 +41,84 @@ function resetFlowState() {
 beforeEach(resetFlowState)
 
 describe('two-factor verify lease', () => {
-  it('is exclusive: a second acquire fails while one is active (no steal)', () => {
-    const first = tryAcquireTwoFactorLease()
+  it('is exclusive for the same subject: a second acquire joins (returns null)', () => {
+    const first = tryAcquireTwoFactorLease(USER)
     expect(first).not.toBeNull()
-    expect(tryAcquireTwoFactorLease()).toBeNull()
+    expect(tryAcquireTwoFactorLease(USER)).toBeNull()
     expect(isTwoFactorLeaseOwner(first)).toBe(true)
   })
 
+  it('invalidates synchronously when a DIFFERENT subject acquires', () => {
+    // Account switch in the same browser context: the previous user's
+    // transaction must not survive into the next user's session.
+    const first = tryAcquireTwoFactorLease(USER)
+    const second = tryAcquireTwoFactorLease(OTHER_USER)
+    expect(second).not.toBeNull()
+    expect(isTwoFactorLeaseOwner(first)).toBe(false)
+    expect(isTwoFactorLeaseOwner(second)).toBe(true)
+    releaseTwoFactorLease(second)
+  })
+
+  it('treats the same id with a different role, and logout (null), as different subjects', () => {
+    const first = tryAcquireTwoFactorLease(USER)
+    const admin = tryAcquireTwoFactorLease(SAME_ID_ADMIN)
+    expect(admin).not.toBeNull()
+    expect(isTwoFactorLeaseOwner(first)).toBe(false)
+
+    const anon = tryAcquireTwoFactorLease(null)
+    expect(anon).not.toBeNull()
+    expect(isTwoFactorLeaseOwner(admin)).toBe(false)
+    releaseTwoFactorLease(anon)
+  })
+
   it('only the owner can release; a stale id is a no-op', () => {
-    const first = tryAcquireTwoFactorLease()
+    const first = tryAcquireTwoFactorLease(USER)
     releaseTwoFactorLease(first)
-    const second = tryAcquireTwoFactorLease()
+    const second = tryAcquireTwoFactorLease(USER)
     expect(second).not.toBeNull()
 
     // The already-released first id must not free the second owner's lease.
     releaseTwoFactorLease(first)
     expect(isTwoFactorLeaseOwner(second)).toBe(true)
-    expect(tryAcquireTwoFactorLease()).toBeNull()
+    expect(tryAcquireTwoFactorLease(USER)).toBeNull()
   })
 
   it('invalidateTwoFactorFlow ends ownership but keeps the recovery outcome', () => {
-    const lease = tryAcquireTwoFactorLease()
+    const lease = tryAcquireTwoFactorLease(USER)
     markVerifyServerVerified(lease, USER)
     invalidateTwoFactorFlow()
 
     expect(isTwoFactorLeaseOwner(lease)).toBe(false)
     // Surviving closures must see themselves as non-owners...
-    expect(tryAcquireTwoFactorLease()).not.toBeNull()
+    expect(tryAcquireTwoFactorLease(USER)).not.toBeNull()
     // ...but the subject can still recover via update-first.
     expect(getVerifyOutcome(USER)).toBe('serverVerified')
+  })
+
+  it('bumps the version on acquire, release and invalidate (for useSyncExternalStore)', () => {
+    let notified = 0
+    const unsubscribe = subscribeTwoFactorFlow(() => {
+      notified++
+    })
+    const before = getTwoFactorFlowVersion()
+
+    const lease = tryAcquireTwoFactorLease(USER)
+    releaseTwoFactorLease(lease)
+    const again = tryAcquireTwoFactorLease(USER)
+    invalidateTwoFactorFlow()
+    void again
+
+    expect(getTwoFactorFlowVersion()).toBe(before + 4)
+    expect(notified).toBe(4)
+    unsubscribe()
   })
 })
 
 describe('verify outcome (subject-bound recovery state)', () => {
   it('tracks dispatched -> serverVerified -> idle for the owner', () => {
-    const lease = tryAcquireTwoFactorLease()
+    const lease = tryAcquireTwoFactorLease(USER)
 
-    markVerifyDispatched(lease, USER, 'ABCD1234')
+    markVerifyDispatched(lease, USER, 'ABCD1234', 'backup')
     expect(getVerifyOutcome(USER)).toBe('outcomeUnknown')
     expect(wasVerifyTokenDispatched(USER, 'ABCD1234')).toBe(true)
     expect(wasVerifyTokenDispatched(USER, 'WXYZ9876')).toBe(false)
@@ -82,25 +131,46 @@ describe('verify outcome (subject-bound recovery state)', () => {
     expect(wasVerifyTokenDispatched(USER, 'ABCD1234')).toBe(false)
   })
 
+  it('flags an unresponded backup dispatch and clears it once a response arrives', () => {
+    const lease = tryAcquireTwoFactorLease(USER)
+
+    markVerifyDispatched(lease, USER, 'ABCD1234', 'backup')
+    // No response yet (e.g. the fetch rejected): the request may still be
+    // running server-side.
+    expect(isBackupDispatchUnsettled(USER)).toBe(true)
+    expect(isBackupDispatchUnsettled(OTHER_USER)).toBe(false)
+
+    markVerifyResponded(lease)
+    expect(isBackupDispatchUnsettled(USER)).toBe(false)
+    expect(getVerifyOutcome(USER)).toBe('outcomeUnknown')
+  })
+
+  it('does not flag a TOTP dispatch as an unsettled backup dispatch', () => {
+    const lease = tryAcquireTwoFactorLease(USER)
+    markVerifyDispatched(lease, USER, '123456', 'totp')
+    expect(isBackupDispatchUnsettled(USER)).toBe(false)
+  })
+
   it('ignores writes from a non-owner lease', () => {
-    const owner = tryAcquireTwoFactorLease()
-    markVerifyDispatched(owner, USER, '123456')
+    const owner = tryAcquireTwoFactorLease(USER)
+    markVerifyDispatched(owner, USER, '123456', 'totp')
     invalidateTwoFactorFlow()
 
     // The orphaned closure keeps its old id; its writes must be no-ops.
     markVerifyServerVerified(owner, USER)
+    markVerifyResponded(owner)
     markVerifyIdle(owner)
     expect(getVerifyOutcome(USER)).toBe('outcomeUnknown')
   })
 
   it('is bound to {id, isAdmin}, not email: a different id or role reads idle', () => {
-    const lease = tryAcquireTwoFactorLease()
+    const lease = tryAcquireTwoFactorLease(USER)
     markVerifyServerVerified(lease, USER)
 
     // Admin and WhitelistUser emails are not cross-table unique — the same
     // email under a different id or role must not inherit the outcome.
-    expect(getVerifyOutcome({ id: 'u2', isAdmin: false })).toBe('idle')
-    expect(getVerifyOutcome({ id: 'u1', isAdmin: true })).toBe('idle')
+    expect(getVerifyOutcome(OTHER_USER)).toBe('idle')
+    expect(getVerifyOutcome(SAME_ID_ADMIN)).toBe('idle')
     expect(getVerifyOutcome(USER)).toBe('serverVerified')
   })
 })
@@ -116,5 +186,18 @@ describe('isVerifyFlowPath', () => {
     expect(isVerifyFlowPath('/auth/verify-2fa-evil')).toBe(false)
     expect(isVerifyFlowPath('/groups/x')).toBe(false)
     expect(isVerifyFlowPath('/')).toBe(false)
+  })
+
+  it('normalizes dot segments, including percent-encoded forms', () => {
+    // WHATWG URL parsing collapses these back into the flow — a plain
+    // string check would misclassify them as outside it.
+    expect(isVerifyFlowPath('/x/../auth/verify-2fa')).toBe(true)
+    expect(isVerifyFlowPath('/x/%2e%2e/auth/verify-2fa')).toBe(true)
+    expect(isVerifyFlowPath('/x/.%2e/auth/verify-2fa')).toBe(true)
+    expect(isVerifyFlowPath('/x/%2e./auth/verify-2fa')).toBe(true)
+    expect(isVerifyFlowPath('/auth/./verify-2fa')).toBe(true)
+    expect(isVerifyFlowPath('/auth/verify-2fa/../verify-2fa/backup')).toBe(true)
+    // And the inverse: dot segments escaping OUT of the flow.
+    expect(isVerifyFlowPath('/auth/verify-2fa/../../groups/x')).toBe(false)
   })
 })

--- a/src/lib/two-factor-verify-flow.test.ts
+++ b/src/lib/two-factor-verify-flow.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @jest-environment jsdom
+ */
+
+/**
+ * Unit tests for the 2FA verify-flow store: exclusive lease semantics
+ * (no steal, owner-only release, flow-wide invalidation) and the
+ * subject-bound recovery outcome.
+ */
+
+import {
+  getVerifyOutcome,
+  invalidateTwoFactorFlow,
+  isTwoFactorLeaseOwner,
+  isVerifyFlowPath,
+  markVerifyDispatched,
+  markVerifyIdle,
+  markVerifyServerVerified,
+  releaseTwoFactorLease,
+  tryAcquireTwoFactorLease,
+  wasVerifyTokenDispatched,
+} from '@/lib/two-factor-verify-flow'
+
+const USER = { id: 'u1', isAdmin: false }
+
+function resetFlowState() {
+  invalidateTwoFactorFlow()
+  const lease = tryAcquireTwoFactorLease()
+  markVerifyIdle(lease)
+  releaseTwoFactorLease(lease)
+}
+
+beforeEach(resetFlowState)
+
+describe('two-factor verify lease', () => {
+  it('is exclusive: a second acquire fails while one is active (no steal)', () => {
+    const first = tryAcquireTwoFactorLease()
+    expect(first).not.toBeNull()
+    expect(tryAcquireTwoFactorLease()).toBeNull()
+    expect(isTwoFactorLeaseOwner(first)).toBe(true)
+  })
+
+  it('only the owner can release; a stale id is a no-op', () => {
+    const first = tryAcquireTwoFactorLease()
+    releaseTwoFactorLease(first)
+    const second = tryAcquireTwoFactorLease()
+    expect(second).not.toBeNull()
+
+    // The already-released first id must not free the second owner's lease.
+    releaseTwoFactorLease(first)
+    expect(isTwoFactorLeaseOwner(second)).toBe(true)
+    expect(tryAcquireTwoFactorLease()).toBeNull()
+  })
+
+  it('invalidateTwoFactorFlow ends ownership but keeps the recovery outcome', () => {
+    const lease = tryAcquireTwoFactorLease()
+    markVerifyServerVerified(lease, USER)
+    invalidateTwoFactorFlow()
+
+    expect(isTwoFactorLeaseOwner(lease)).toBe(false)
+    // Surviving closures must see themselves as non-owners...
+    expect(tryAcquireTwoFactorLease()).not.toBeNull()
+    // ...but the subject can still recover via update-first.
+    expect(getVerifyOutcome(USER)).toBe('serverVerified')
+  })
+})
+
+describe('verify outcome (subject-bound recovery state)', () => {
+  it('tracks dispatched -> serverVerified -> idle for the owner', () => {
+    const lease = tryAcquireTwoFactorLease()
+
+    markVerifyDispatched(lease, USER, 'ABCD1234')
+    expect(getVerifyOutcome(USER)).toBe('outcomeUnknown')
+    expect(wasVerifyTokenDispatched(USER, 'ABCD1234')).toBe(true)
+    expect(wasVerifyTokenDispatched(USER, 'WXYZ9876')).toBe(false)
+
+    markVerifyServerVerified(lease, USER)
+    expect(getVerifyOutcome(USER)).toBe('serverVerified')
+
+    markVerifyIdle(lease)
+    expect(getVerifyOutcome(USER)).toBe('idle')
+    expect(wasVerifyTokenDispatched(USER, 'ABCD1234')).toBe(false)
+  })
+
+  it('ignores writes from a non-owner lease', () => {
+    const owner = tryAcquireTwoFactorLease()
+    markVerifyDispatched(owner, USER, '123456')
+    invalidateTwoFactorFlow()
+
+    // The orphaned closure keeps its old id; its writes must be no-ops.
+    markVerifyServerVerified(owner, USER)
+    markVerifyIdle(owner)
+    expect(getVerifyOutcome(USER)).toBe('outcomeUnknown')
+  })
+
+  it('is bound to {id, isAdmin}, not email: a different id or role reads idle', () => {
+    const lease = tryAcquireTwoFactorLease()
+    markVerifyServerVerified(lease, USER)
+
+    // Admin and WhitelistUser emails are not cross-table unique — the same
+    // email under a different id or role must not inherit the outcome.
+    expect(getVerifyOutcome({ id: 'u2', isAdmin: false })).toBe('idle')
+    expect(getVerifyOutcome({ id: 'u1', isAdmin: true })).toBe('idle')
+    expect(getVerifyOutcome(USER)).toBe('serverVerified')
+  })
+})
+
+describe('isVerifyFlowPath', () => {
+  it('matches the flow base and its children only (no prefix bleed)', () => {
+    expect(isVerifyFlowPath('/auth/verify-2fa')).toBe(true)
+    expect(isVerifyFlowPath('/auth/verify-2fa/backup')).toBe(true)
+    expect(isVerifyFlowPath('/auth/verify-2fa?callbackUrl=%2Fgroups%2Fx')).toBe(
+      true,
+    )
+    expect(isVerifyFlowPath('/auth/verify-2fa#frag')).toBe(true)
+    expect(isVerifyFlowPath('/auth/verify-2fa-evil')).toBe(false)
+    expect(isVerifyFlowPath('/groups/x')).toBe(false)
+    expect(isVerifyFlowPath('/')).toBe(false)
+  })
+})

--- a/src/lib/two-factor-verify-flow.test.ts
+++ b/src/lib/two-factor-verify-flow.test.ts
@@ -14,12 +14,10 @@ import {
   getTwoFactorFlowVersion,
   getVerifyOutcome,
   invalidateTwoFactorFlow,
-  isBackupDispatchUnsettled,
   isTwoFactorLeaseOwner,
   isVerifyFlowPath,
   markVerifyDispatched,
   markVerifyIdle,
-  markVerifyResponded,
   markVerifyServerVerified,
   releaseTwoFactorLease,
   subscribeTwoFactorFlow,
@@ -118,7 +116,7 @@ describe('verify outcome (subject-bound recovery state)', () => {
   it('tracks dispatched -> serverVerified -> idle for the owner', () => {
     const lease = tryAcquireTwoFactorLease(USER)
 
-    markVerifyDispatched(lease, USER, 'ABCD1234', 'backup')
+    markVerifyDispatched(lease, USER, 'ABCD1234')
     expect(getVerifyOutcome(USER)).toBe('outcomeUnknown')
     expect(wasVerifyTokenDispatched(USER, 'ABCD1234')).toBe(true)
     expect(wasVerifyTokenDispatched(USER, 'WXYZ9876')).toBe(false)
@@ -131,34 +129,13 @@ describe('verify outcome (subject-bound recovery state)', () => {
     expect(wasVerifyTokenDispatched(USER, 'ABCD1234')).toBe(false)
   })
 
-  it('flags an unresponded backup dispatch and clears it once a response arrives', () => {
-    const lease = tryAcquireTwoFactorLease(USER)
-
-    markVerifyDispatched(lease, USER, 'ABCD1234', 'backup')
-    // No response yet (e.g. the fetch rejected): the request may still be
-    // running server-side.
-    expect(isBackupDispatchUnsettled(USER)).toBe(true)
-    expect(isBackupDispatchUnsettled(OTHER_USER)).toBe(false)
-
-    markVerifyResponded(lease)
-    expect(isBackupDispatchUnsettled(USER)).toBe(false)
-    expect(getVerifyOutcome(USER)).toBe('outcomeUnknown')
-  })
-
-  it('does not flag a TOTP dispatch as an unsettled backup dispatch', () => {
-    const lease = tryAcquireTwoFactorLease(USER)
-    markVerifyDispatched(lease, USER, '123456', 'totp')
-    expect(isBackupDispatchUnsettled(USER)).toBe(false)
-  })
-
   it('ignores writes from a non-owner lease', () => {
     const owner = tryAcquireTwoFactorLease(USER)
-    markVerifyDispatched(owner, USER, '123456', 'totp')
+    markVerifyDispatched(owner, USER, '123456')
     invalidateTwoFactorFlow()
 
     // The orphaned closure keeps its old id; its writes must be no-ops.
     markVerifyServerVerified(owner, USER)
-    markVerifyResponded(owner)
     markVerifyIdle(owner)
     expect(getVerifyOutcome(USER)).toBe('outcomeUnknown')
   })

--- a/src/lib/two-factor-verify-flow.ts
+++ b/src/lib/two-factor-verify-flow.ts
@@ -24,15 +24,13 @@
  *   emails are not unique across the Admin and WhitelistUser tables):
  *   'outcomeUnknown' from the moment a code is dispatched until the
  *   server's answer is known, 'serverVerified' once a 2xx (or an
- *   ALREADY_VERIFIED rejection, which is a success in disguise) was
- *   observed. Either state makes the next submit retry the session sync
- *   FIRST instead of re-sending a code. The dispatched token and its kind
- *   are remembered so the same code is never auto-resent, and — because a
- *   rejected fetch means the request may STILL be running server-side —
- *   whether the dispatch ever got a response: while a backup-code dispatch
- *   is transport-unsettled, sending a different backup code could race the
- *   server's non-CAS read-modify-write of the codes array (lost update /
- *   code resurrection), so it is blocked. The outcome survives
+ *   ALREADY_VERIFIED / RETRY_SYNC rejection, which is a success in
+ *   disguise) was observed. Either state makes the next submit retry the
+ *   session sync FIRST instead of re-sending a code. The dispatched token
+ *   is remembered so the TOTP page never auto-resends the same code.
+ *   Concurrent backup-code consumption is serialized SERVER-side (CAS on
+ *   the encrypted codes blob in the verify route), so no client-side
+ *   transport tracking is needed. The outcome survives
  *   `invalidateTwoFactorFlow` so a user bounced back into the flow can
  *   still recover; it holds a short-lived one-time code (never E2EE key
  *   material) and is cleared when the flow completes or definitively fails.
@@ -51,8 +49,6 @@ export interface VerifySubject {
 
 export type VerifyOutcome = 'idle' | 'outcomeUnknown' | 'serverVerified'
 
-export type VerifyTokenKind = 'totp' | 'backup'
-
 let leaseSeq = 0
 let activeLease: number | null = null
 let leaseSubjectKey: string | null = null
@@ -60,8 +56,6 @@ let leaseSubjectKey: string | null = null
 let outcome: VerifyOutcome = 'idle'
 let outcomeSubjectKey: string | null = null
 let dispatchedToken: string | null = null
-let dispatchedKind: VerifyTokenKind | null = null
-let transportUnsettled = false
 
 let version = 0
 const listeners = new Set<() => void>()
@@ -158,23 +152,11 @@ export function markVerifyDispatched(
   lease: number | null,
   subject: VerifySubject,
   token: string,
-  kind: VerifyTokenKind,
 ): void {
   if (!isTwoFactorLeaseOwner(lease)) return
   outcome = 'outcomeUnknown'
   outcomeSubjectKey = verifySubjectKey(subject)
   dispatchedToken = token
-  dispatchedKind = kind
-  transportUnsettled = true
-}
-
-/**
- * Owner-only: the dispatch got an HTTP response (any status) — the request
- * is no longer running server-side.
- */
-export function markVerifyResponded(lease: number | null): void {
-  if (!isTwoFactorLeaseOwner(lease)) return
-  transportUnsettled = false
 }
 
 /** Owner-only: the server committed the verification for this subject. */
@@ -185,7 +167,6 @@ export function markVerifyServerVerified(
   if (!isTwoFactorLeaseOwner(lease)) return
   outcome = 'serverVerified'
   outcomeSubjectKey = verifySubjectKey(subject)
-  transportUnsettled = false
 }
 
 /** Owner-only: the flow completed or the server definitively rejected. */
@@ -194,8 +175,6 @@ export function markVerifyIdle(lease: number | null): void {
   outcome = 'idle'
   outcomeSubjectKey = null
   dispatchedToken = null
-  dispatchedKind = null
-  transportUnsettled = false
 }
 
 export function getVerifyOutcome(subject: VerifySubject): VerifyOutcome {
@@ -214,19 +193,5 @@ export function wasVerifyTokenDispatched(
     outcome !== 'idle' &&
     outcomeSubjectKey === verifySubjectKey(subject) &&
     dispatchedToken === token
-  )
-}
-
-/**
- * True while a backup-code dispatch for this subject never got a response:
- * the request may still be running server-side, so sending another backup
- * code could race the non-CAS rewrite of the codes array.
- */
-export function isBackupDispatchUnsettled(subject: VerifySubject): boolean {
-  return (
-    outcome === 'outcomeUnknown' &&
-    outcomeSubjectKey === verifySubjectKey(subject) &&
-    transportUnsettled &&
-    dispatchedKind === 'backup'
   )
 }

--- a/src/lib/two-factor-verify-flow.ts
+++ b/src/lib/two-factor-verify-flow.ts
@@ -2,31 +2,46 @@
  * Client-only module store coordinating the 2FA verification transaction
  * across the TOTP page and the backup-code page.
  *
- * Two pieces of state:
+ * Three pieces of state:
  *
- * - A single exclusive **lease**: exactly one verification transaction may
- *   run at a time across BOTH pages. `tryAcquireTwoFactorLease` never steals
- *   an active lease — a second submit while one is in flight joins it as a
- *   no-op (the in-flight transaction drives the navigation). A transaction
- *   must re-check ownership after every await; a non-owner must not call
- *   `update()`, consume the pending fragment, or navigate. Ownership is only
- *   ended by the owner itself or by `invalidateTwoFactorFlow`, which
+ * - A single exclusive **lease**, bound to the subject that acquired it:
+ *   exactly one verification transaction may run at a time across BOTH
+ *   pages. `tryAcquireTwoFactorLease` never steals a lease held by the SAME
+ *   subject — a second submit while one is in flight joins it as a no-op
+ *   (the in-flight transaction drives the navigation). A DIFFERENT subject
+ *   (account switch in the same browser context, or logout — `null`)
+ *   invalidates the old lease synchronously and acquires a fresh one: the
+ *   previous user's transaction must not survive into the next user's
+ *   session. A transaction must re-check ownership after every await; a
+ *   non-owner must not call `update()`, consume the pending fragment, or
+ *   navigate. Ownership is only ended by the owner itself, by a
+ *   subject-change acquire, or by `invalidateTwoFactorFlow`, which
  *   TwoFactorGuard calls synchronously (layout effect) on the first commit
  *   outside the verify flow. Pages never release the lease on unmount: the
  *   transaction outlives a TOTP <-> backup page switch by design.
  *
  * - A **recovery outcome** bound to the verified subject ({id, isAdmin} —
  *   emails are not unique across the Admin and WhitelistUser tables):
- *   'outcomeUnknown' from the moment a code is dispatched until the server's
- *   answer is known (a rejected fetch or a 5xx may have committed
- *   server-side), 'serverVerified' once a 2xx was observed. Either state
- *   makes the next submit retry the session sync FIRST instead of re-sending
- *   a code — for backup codes a resend would burn a second code or fail on
- *   the consumed one. The dispatched token is remembered so an unknown
- *   outcome never auto-resends the same code. The outcome survives
- *   `invalidateTwoFactorFlow` so a user bounced back into the flow can still
- *   recover; it holds a short-lived one-time code (never E2EE key material)
- *   and is cleared when the flow completes or definitively fails.
+ *   'outcomeUnknown' from the moment a code is dispatched until the
+ *   server's answer is known, 'serverVerified' once a 2xx (or an
+ *   ALREADY_VERIFIED rejection, which is a success in disguise) was
+ *   observed. Either state makes the next submit retry the session sync
+ *   FIRST instead of re-sending a code. The dispatched token and its kind
+ *   are remembered so the same code is never auto-resent, and — because a
+ *   rejected fetch means the request may STILL be running server-side —
+ *   whether the dispatch ever got a response: while a backup-code dispatch
+ *   is transport-unsettled, sending a different backup code could race the
+ *   server's non-CAS read-modify-write of the codes array (lost update /
+ *   code resurrection), so it is blocked. The outcome survives
+ *   `invalidateTwoFactorFlow` so a user bounced back into the flow can
+ *   still recover; it holds a short-lived one-time code (never E2EE key
+ *   material) and is cleared when the flow completes or definitively fails.
+ *
+ * - A monotonically increasing **version**, exposed through a
+ *   subscribe/snapshot pair for `useSyncExternalStore`: the pages' bounce/
+ *   recovery effect must re-arm when the lease state changes, otherwise a
+ *   page that lost a `tryAcquire` race once would never get a second chance
+ *   (lost wakeup) and could render blank forever.
  */
 
 export interface VerifySubject {
@@ -36,23 +51,51 @@ export interface VerifySubject {
 
 export type VerifyOutcome = 'idle' | 'outcomeUnknown' | 'serverVerified'
 
+export type VerifyTokenKind = 'totp' | 'backup'
+
 let leaseSeq = 0
 let activeLease: number | null = null
+let leaseSubjectKey: string | null = null
 
 let outcome: VerifyOutcome = 'idle'
 let outcomeSubjectKey: string | null = null
 let dispatchedToken: string | null = null
+let dispatchedKind: VerifyTokenKind | null = null
+let transportUnsettled = false
 
-function subjectKey(subject: VerifySubject): string {
-  return `${subject.isAdmin ? 'admin' : 'user'}:${subject.id}`
+let version = 0
+const listeners = new Set<() => void>()
+
+function bumpVersion(): void {
+  version++
+  listeners.forEach((listener) => listener())
 }
 
-export function tryAcquireTwoFactorLease(): number | null {
+/** Key for a subject, or for the signed-out state (`null`). */
+export function verifySubjectKey(subject: VerifySubject | null): string {
+  return subject === null
+    ? 'anon'
+    : `${subject.isAdmin ? 'admin' : 'user'}:${subject.id}`
+}
+
+export function tryAcquireTwoFactorLease(
+  subject: VerifySubject | null,
+): number | null {
   // Client-only: a server-side lease would be shared across every request
   // handled by the Node process.
   if (typeof window === 'undefined') return null
-  if (activeLease !== null) return null
+  const key = verifySubjectKey(subject)
+  if (activeLease !== null) {
+    // Same subject: join the in-flight transaction (no steal). A different
+    // subject (account switch / logout) kills it synchronously instead —
+    // its closures become non-owners before they can touch anything.
+    if (leaseSubjectKey === key) return null
+    activeLease = null
+    leaseSubjectKey = null
+  }
   activeLease = ++leaseSeq
+  leaseSubjectKey = key
+  bumpVersion()
   return activeLease
 }
 
@@ -63,6 +106,8 @@ export function isTwoFactorLeaseOwner(lease: number | null): boolean {
 export function releaseTwoFactorLease(lease: number | null): void {
   if (isTwoFactorLeaseOwner(lease)) {
     activeLease = null
+    leaseSubjectKey = null
+    bumpVersion()
   }
 }
 
@@ -70,12 +115,39 @@ export function invalidateTwoFactorFlow(): void {
   // Leaving the verify flow ends any transaction: surviving closures lose
   // ownership and their continuations become no-ops. The recovery outcome is
   // intentionally kept (see module doc).
-  activeLease = null
+  if (activeLease !== null) {
+    activeLease = null
+    leaseSubjectKey = null
+    bumpVersion()
+  }
+}
+
+export function subscribeTwoFactorFlow(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+export function getTwoFactorFlowVersion(): number {
+  return version
+}
+
+export function getTwoFactorFlowServerVersion(): number {
+  return 0
 }
 
 /** True when `path`'s path portion is inside the verify flow. */
 export function isVerifyFlowPath(path: string): boolean {
-  const pathOnly = path.split(/[?#]/)[0]
+  // WHATWG URL normalization collapses dot segments including their
+  // percent-encoded forms (%2e%2e, .%2e, %2e.) — a hand-rolled split would
+  // let a crafted callbackUrl sneak back into the flow and strand the lease.
+  let pathOnly: string
+  try {
+    pathOnly = new URL(path, 'http://localhost').pathname
+  } catch {
+    return false
+  }
   return (
     pathOnly === '/auth/verify-2fa' || pathOnly.startsWith('/auth/verify-2fa/')
   )
@@ -86,21 +158,34 @@ export function markVerifyDispatched(
   lease: number | null,
   subject: VerifySubject,
   token: string,
+  kind: VerifyTokenKind,
 ): void {
   if (!isTwoFactorLeaseOwner(lease)) return
   outcome = 'outcomeUnknown'
-  outcomeSubjectKey = subjectKey(subject)
+  outcomeSubjectKey = verifySubjectKey(subject)
   dispatchedToken = token
+  dispatchedKind = kind
+  transportUnsettled = true
 }
 
-/** Owner-only: a 2xx was observed — the server committed the verification. */
+/**
+ * Owner-only: the dispatch got an HTTP response (any status) — the request
+ * is no longer running server-side.
+ */
+export function markVerifyResponded(lease: number | null): void {
+  if (!isTwoFactorLeaseOwner(lease)) return
+  transportUnsettled = false
+}
+
+/** Owner-only: the server committed the verification for this subject. */
 export function markVerifyServerVerified(
   lease: number | null,
   subject: VerifySubject,
 ): void {
   if (!isTwoFactorLeaseOwner(lease)) return
   outcome = 'serverVerified'
-  outcomeSubjectKey = subjectKey(subject)
+  outcomeSubjectKey = verifySubjectKey(subject)
+  transportUnsettled = false
 }
 
 /** Owner-only: the flow completed or the server definitively rejected. */
@@ -109,10 +194,12 @@ export function markVerifyIdle(lease: number | null): void {
   outcome = 'idle'
   outcomeSubjectKey = null
   dispatchedToken = null
+  dispatchedKind = null
+  transportUnsettled = false
 }
 
 export function getVerifyOutcome(subject: VerifySubject): VerifyOutcome {
-  if (outcome === 'idle' || outcomeSubjectKey !== subjectKey(subject)) {
+  if (outcome === 'idle' || outcomeSubjectKey !== verifySubjectKey(subject)) {
     return 'idle'
   }
   return outcome
@@ -125,7 +212,21 @@ export function wasVerifyTokenDispatched(
 ): boolean {
   return (
     outcome !== 'idle' &&
-    outcomeSubjectKey === subjectKey(subject) &&
+    outcomeSubjectKey === verifySubjectKey(subject) &&
     dispatchedToken === token
+  )
+}
+
+/**
+ * True while a backup-code dispatch for this subject never got a response:
+ * the request may still be running server-side, so sending another backup
+ * code could race the non-CAS rewrite of the codes array.
+ */
+export function isBackupDispatchUnsettled(subject: VerifySubject): boolean {
+  return (
+    outcome === 'outcomeUnknown' &&
+    outcomeSubjectKey === verifySubjectKey(subject) &&
+    transportUnsettled &&
+    dispatchedKind === 'backup'
   )
 }

--- a/src/lib/two-factor-verify-flow.ts
+++ b/src/lib/two-factor-verify-flow.ts
@@ -1,0 +1,131 @@
+/**
+ * Client-only module store coordinating the 2FA verification transaction
+ * across the TOTP page and the backup-code page.
+ *
+ * Two pieces of state:
+ *
+ * - A single exclusive **lease**: exactly one verification transaction may
+ *   run at a time across BOTH pages. `tryAcquireTwoFactorLease` never steals
+ *   an active lease — a second submit while one is in flight joins it as a
+ *   no-op (the in-flight transaction drives the navigation). A transaction
+ *   must re-check ownership after every await; a non-owner must not call
+ *   `update()`, consume the pending fragment, or navigate. Ownership is only
+ *   ended by the owner itself or by `invalidateTwoFactorFlow`, which
+ *   TwoFactorGuard calls synchronously (layout effect) on the first commit
+ *   outside the verify flow. Pages never release the lease on unmount: the
+ *   transaction outlives a TOTP <-> backup page switch by design.
+ *
+ * - A **recovery outcome** bound to the verified subject ({id, isAdmin} —
+ *   emails are not unique across the Admin and WhitelistUser tables):
+ *   'outcomeUnknown' from the moment a code is dispatched until the server's
+ *   answer is known (a rejected fetch or a 5xx may have committed
+ *   server-side), 'serverVerified' once a 2xx was observed. Either state
+ *   makes the next submit retry the session sync FIRST instead of re-sending
+ *   a code — for backup codes a resend would burn a second code or fail on
+ *   the consumed one. The dispatched token is remembered so an unknown
+ *   outcome never auto-resends the same code. The outcome survives
+ *   `invalidateTwoFactorFlow` so a user bounced back into the flow can still
+ *   recover; it holds a short-lived one-time code (never E2EE key material)
+ *   and is cleared when the flow completes or definitively fails.
+ */
+
+export interface VerifySubject {
+  id: string
+  isAdmin: boolean
+}
+
+export type VerifyOutcome = 'idle' | 'outcomeUnknown' | 'serverVerified'
+
+let leaseSeq = 0
+let activeLease: number | null = null
+
+let outcome: VerifyOutcome = 'idle'
+let outcomeSubjectKey: string | null = null
+let dispatchedToken: string | null = null
+
+function subjectKey(subject: VerifySubject): string {
+  return `${subject.isAdmin ? 'admin' : 'user'}:${subject.id}`
+}
+
+export function tryAcquireTwoFactorLease(): number | null {
+  // Client-only: a server-side lease would be shared across every request
+  // handled by the Node process.
+  if (typeof window === 'undefined') return null
+  if (activeLease !== null) return null
+  activeLease = ++leaseSeq
+  return activeLease
+}
+
+export function isTwoFactorLeaseOwner(lease: number | null): boolean {
+  return lease !== null && activeLease === lease
+}
+
+export function releaseTwoFactorLease(lease: number | null): void {
+  if (isTwoFactorLeaseOwner(lease)) {
+    activeLease = null
+  }
+}
+
+export function invalidateTwoFactorFlow(): void {
+  // Leaving the verify flow ends any transaction: surviving closures lose
+  // ownership and their continuations become no-ops. The recovery outcome is
+  // intentionally kept (see module doc).
+  activeLease = null
+}
+
+/** True when `path`'s path portion is inside the verify flow. */
+export function isVerifyFlowPath(path: string): boolean {
+  const pathOnly = path.split(/[?#]/)[0]
+  return (
+    pathOnly === '/auth/verify-2fa' || pathOnly.startsWith('/auth/verify-2fa/')
+  )
+}
+
+/** Owner-only: a code was sent; the server's answer is not known yet. */
+export function markVerifyDispatched(
+  lease: number | null,
+  subject: VerifySubject,
+  token: string,
+): void {
+  if (!isTwoFactorLeaseOwner(lease)) return
+  outcome = 'outcomeUnknown'
+  outcomeSubjectKey = subjectKey(subject)
+  dispatchedToken = token
+}
+
+/** Owner-only: a 2xx was observed — the server committed the verification. */
+export function markVerifyServerVerified(
+  lease: number | null,
+  subject: VerifySubject,
+): void {
+  if (!isTwoFactorLeaseOwner(lease)) return
+  outcome = 'serverVerified'
+  outcomeSubjectKey = subjectKey(subject)
+}
+
+/** Owner-only: the flow completed or the server definitively rejected. */
+export function markVerifyIdle(lease: number | null): void {
+  if (!isTwoFactorLeaseOwner(lease)) return
+  outcome = 'idle'
+  outcomeSubjectKey = null
+  dispatchedToken = null
+}
+
+export function getVerifyOutcome(subject: VerifySubject): VerifyOutcome {
+  if (outcome === 'idle' || outcomeSubjectKey !== subjectKey(subject)) {
+    return 'idle'
+  }
+  return outcome
+}
+
+/** True when `token` is the code whose dispatch produced the current outcome. */
+export function wasVerifyTokenDispatched(
+  subject: VerifySubject,
+  token: string,
+): boolean {
+  return (
+    outcome !== 'idle' &&
+    outcomeSubjectKey === subjectKey(subject) &&
+    dispatchedToken === token
+  )
+}


### PR DESCRIPTION
## 背景

再監査(#214 系列、2026-07-14 round2)で確定した Medium finding「2FA リダイレクトで URL fragment(= グループの E2EE 暗号鍵)が失われる」の修正。「セキュリティ最優先で順次」の PR-2。schema 変更なし。

`PRIVATE_INSTANCE` + 2FA 有効ユーザーが鍵付き共有リンク `/groups/<id>#<key>` を開くと、`TwoFactorGuard` が `/auth/verify-2fa?callbackUrl=/groups/<id>`(path のみ)へリダイレクトして fragment を破棄し、検証成功後は鍵なしでグループに着地して鍵入力画面になる。`EncryptionProvider` は 2FA 完了までガードが children を出さないため mount されず、localStorage 復旧も走らない。

## 修正内容

client-only の module store `src/lib/pending-fragment.ts`(`reimbursement-prefill.ts` と同じパターン・同じトレードオフ)を追加し、guard が fragment を退避 → 検証成功時に再付着する。

- **`two-factor-guard.tsx`**: `requiresTwoFactor` 分岐内・`router.push` 前に `setPendingFragment(pathname, window.location.hash.slice(1))`。fragment は **callbackUrl に載せない**(query string はナビゲーションのサーバ fetch に載る = E2EE 不変条件違反)。sessionStorage も不採用(鍵が at-rest で残る)
- **`verify-2fa/page.tsx` / `backup/page.tsx`**: 成功ハンドラの `router.replace(callbackUrl)` を `router.replace(restorePendingFragment(callbackUrl))` に変更。verify ↔ backup 間の Link 遷移は excluded route 上のクライアント遷移なので store は保持される
- **検証 transaction の排他 lease 化**(レビュー指摘 High ×2 対応): 検証成功後の `update()` が `requiresTwoFactor: false` を反映すると redirect-away effect が `replace('/')` を発火し、成功側の `replace(callback#fragment)` と競合して one-shot の fragment を取り逃がし得た。同一ページ内だけでなく、**fetch 中に TOTP↔backup を切り替えた場合**(閉包は unmount 後も生存)にも同じ race が成立するため、per-component ref ではなく **module-level の排他 lease**(`src/lib/two-factor-verify-flow.ts`)で解決:
  - `tryAcquire` は奪取禁止 — 先行 transaction 実行中の後発 submit は **no-op で join**(POST の二重発行なし)
  - 各 `await` 後(fetch / update / error body parse)に owner を再確認。**非 owner は update・fragment 消費・navigation を一切行わない**
  - lease はページ unmount では解放せず、**TwoFactorGuard が flow 外への commit 時に `useLayoutEffect` で同期的に invalidate**(microtask 再開より先行)。redirect-away effect の navigation 自体も `tryAcquire` 成功が条件(= 発火は最大 1 回)
- **update-first recovery**(subject = `{id, isAdmin}` 束縛、email は Admin/WhitelistUser 間で非 unique のため不使用): code 送信の瞬間から `outcomeUnknown`、2xx 観測(または ALREADY_VERIFIED)で `serverVerified` を記録。**4xx のみ idle に戻し、5xx / fetch reject は結果不明として保持**(server は backup code 消費後に 5xx を返し得る)。再試行はまず `update()` のみを実行し、成功条件は「同一 subject かつ `requiresTwoFactor === false`」の厳密判定(truthy では不十分)。200 の body は parse しない(parse 失敗で commit 済み結果を破棄しない)
- **backup code 消費の server 側 CAS 化**(root cause 対応): codes 配列の read-modify-write を `updateMany` の WHERE に「その試行で観測した暗号 blob」を含める optimistic concurrency で直列化。競合(`count === 0`)時は最新 blob を再読込・再復号して**ちょうど 1 回だけ retry**、再競合は 503(rate-limit 非消費)。code 消費と timestamp は引き続き単一 write。これにより並行消費の lost update / code 復活が **cross-tab・reload・proxy 5xx を含む全経路で** server 側で防止される
- **RETRY_SYNC(409、機械可読)**: code が見つからず `lastTwoFactorVerifiedAt` が 5 分窓内の場合(= 本人の先行 attempt が commit 済みで応答だけ喪失: fetch reject・proxy 5xx・reload 後の再送)、401 でなく `RETRY_SYNC` を返す(rate-limit は record も clear もしない)。クライアントは ALREADY_VERIFIED と同様に成功系(session sync → callback+fragment)で完遂。通常 401 + 失敗記録は「初回読込から code 不在かつ fresh verification なし」のみ
- **別 code / 同一 code の再送規則**: fall-through は `update()` が「同一 subject かつ `requiresTwoFactor === true`」を明示返却した場合のみ(null・欠損・別 subject は outcome 維持 + error)。**backup は同一 code の手動再送も許可**(CAS + RETRY_SYNC により安全で、最後の 1 枚が応答喪失した場合の固着を防ぐ)。TOTP は `lastAttemptedTokenRef` + dispatch 済み token ゲートを維持(自律ループ防止)。クライアント側 transport-unsettled 機構は CAS により不要となり撤去
- **subject 帰属の保証**: request body に `{subjectId, subjectIsAdmin}` を含め、server が session subject と照合(不一致は 401・副作用ゼロ)。これにより 2xx / ALREADY_VERIFIED の帰属が cookie 切替(同一 email の Admin/WhitelistUser)でも安全。**ALREADY_VERIFIED(機械可読 code 付き 400)は成功系として処理**し、callback+fragment で完遂。error body parse(await)後にも owner 再確認
- **pending fragment の subject 束縛**(鍵の cross-account 再付着防止): slot を `{id, isAdmin}` に束縛し、**異 subject の take は slot を破壊**(fail-closed)、同一 subject の path 不一致は保持(fail-safe)。破棄 bounce(`/` 行き)・signed-out 着地でも破壊。lease も subject-aware(同一 subject は join、**異 subject / logout の acquire は既存 lease を同期 invalidate**)
- **lost wakeup 解消**: store に version + subscribe を実装し、両ページが `useSyncExternalStore` で lease 変化を購読(bounce/recovery effect の deps に version を明示)。tryAcquire に一度負けても解放時に再駆動される
- **path 正規化**: `isVerifyFlowPath` は WHATWG URL で dot segment(`%2e%2e`・`.%2e`・`%2e.` 含む)を解決してから判定
- **server 側の部分 commit 解消**: backup code の消費と `lastTwoFactorVerifiedAt` を**単一の Prisma update に統合**(片方だけ commit されると code だけ消費されて 5 分窓が得られない)。TOTP 経路の timestamp write は従来どおり
- **verify-flow 宛 callbackUrl の正規化**: `/auth/verify-2fa...` への callback は `/` に正規化(flow 内に着地すると lease が invalidate されず空画面固定になるため)
- **session flip 時の完了処理**: redirect-away effect は、subject 一致の recovery outcome が残っている場合は `/` へ bounce せず callback + fragment で検証を完遂する

### store の契約(設計上の要点)
- **単一 slot・one-shot**: 完了し得る interception は最新の 1 件のみ。take で即クリアし、鍵素材のコピーをプロセスメモリに 1 つ以上残さない
- **捕獲元 path に束縛**: `takePendingFragment(path)` は捕獲時の path と完全一致した場合のみ返す。2FA 未完のまま別ページへ遷移して検証を完了しても、**古い鍵が別グループの URL に再付着することはない**(不一致は fragment なしへ fail-safe)
- **空書き込みは無視**: `router.push` が address bar から hash を剥がした後に effect が再実行されても、直前の捕獲を消せない(StrictMode の effect replay too)
- **callbackUrl に既存 hash がある場合は置換**: その hash は query string を往復した = サーバ可視であり、guard が捕獲した鍵ではあり得ない
- サーバでは書き込み no-op(共有プロセスメモリへの鍵混入 = cross-tenant を遮断)

### 劣化パターン(意図的な許容)
- 検証中にハードリロードすると store が消え、従来どおり鍵なしで着地(鍵入力画面)。プライバシー優先のトレードオフで、修正前より悪化する経路はない
- **cross-tab 完了**: 別タブが先に検証を完了した場合、このタブの recovery outcome はタブ間非共有のため、fragment なしの着地(または `/` bounce)になり得る。鍵はタブ内 slot から漏れず(subject 束縛 + 破棄時クリア)、グループへ再ナビゲーションすれば回復する利便性劣化のみ

## スコープ外(理由付き)
- **signin ページ経由の fragment 喪失**: proxy が signin へ誘導するのは `/groups/create` と `/admin`(鍵を持たない route)のみで、共有グループページは shared route のため signin を経由しない。また signin は `signIn()` のサーバ往復(`window.location.href = data.url`)を挟むため本 store では保持できず、別機構が必要。到達可能な影響経路が未確認のため本 PR では扱わない

## テスト
- `pending-fragment.test.ts`: one-shot round-trip / path 不一致で渡さず保持 / 空書き込み無視 / 最新 interception 優先 / restore の hash 置換・非 pending 時は既存 hash 含め素通し / query 付き callbackUrl は不一致(かつ非消費)
- `pending-fragment.server.test.ts`(node env): サーバ書き込み no-op
- `two-factor-guard-fragment.test.tsx`: 捕獲値が store に入り**リダイレクト URL に鍵が含まれない**(全 push call を検査)/ 空 hash で既存捕獲を保持 / StrictMode replay で単一コピー(実 store 統合、mock なし)
- `verify-2fa/page.test.tsx` + `backup/page.test.tsx`: stateful session mock(`update()` 解決で `requiresTwoFactor` 反転)で race を決定化し、成功時 `replace(callback#KEY)` ちょうど 1 回・`replace('/')` 0 回を双方で固定。update() の null / truthy-but-true / 別 subject を全て失敗扱い(非遷移・fragment 非消費)。4xx は idle 復帰(同一 code 再送可)、5xx・fetch reject は update-first recovery(追加 fetch 0)、200 + body parse 失敗は成功継続、長さエラーで lease 解放、直接訪問 bounce(StrictMode 込みで 1 回)、recovery outcome あり時は callback#fragment で完遂、verify-flow 宛 callback の `/` 正規化
- `verify-flow-integration.test.tsx`(新規、クロスページ): fetch 中のページ切替後も transaction が完遂(navigation・fragment 消費 各 1 回・`/` bounce 0)/ 後発 submit の join(全体 fetch 1 回)/ flow 離脱で非 owner 化(update 未実行・fragment 残存)/ 旧 POST 中に session が false へ flip しても新ページが `/` を発火しない / StrictMode が他 owner の lease を解除しない
- `two-factor-verify-flow.test.ts` + `.server.test.ts`(新規): lease 排他(奪取不可・owner-only release・invalidate 後も outcome 残存)、outcome の `{id, isAdmin}` 束縛(同一 email 別 ID/role は idle)、lease-aware 書き込み、path 境界判定(`/auth/verify-2fa-evil` 不一致)、server では lease 不発行
- `two-factor-guard-fragment.test.tsx`(追記): flow 外 commit で lease を同期 invalidate / flow 内・StrictMode replay では他 owner の lease を解除しない
- `two-factor-verify-pre-auth.test.ts`(更新): backup 成功時の **単一 DB write**(code + timestamp 同梱・1 回)、TOTP 成功時は timestamp のみ 1 回を固定
- **mutation 検証**: (1) redirect-away effect の lease ゲート除去 → クロスページ race テスト fail、(2) await 後の owner 再確認除去 → flow 離脱テスト fail、(3) join ゲート除去 → 二重 POST テスト fail — をそれぞれ確認して復元済み

## 検証
- jest full suite: 58 suites / 681 passed, 1 skipped(ハングなし・forceExit 不要・act 警告 0)
- mutation 検証: fall-through の健全性ゲート除去 / fragment の subject 照合除去 / bounce effect の version dep 除去(安定 session mock で dep 混同を排除)/ **CAS WHERE の blob 条件除去**(競合系 3 テストが fail)— いずれも対応テストが失敗することを確認して復元
- CAS 契約のテスト: 観測 blob での WHERE(1 回目・retry それぞれ)/ retry は最新 blob 再復号で**並行消費された 2 code が最終配列から両方消える** / 正確に 2 回で停止して 503(rate-limit 非消費)/ 競合後 code 消滅 + fresh → RETRY_SYNC / 初回不在 + fresh → RETRY_SYNC / 初回不在 + stale のみ通常 401 + 失敗記録 / Admin・WhitelistUser 両テーブル
- `tsc --noEmit`: 0 エラー / `eslint .`: 0 エラー(warning 11 は既存)/ `prettier -c src`: クリーン
- `next build`(Turbopack): 成功(CI と同一の dummy env 変数で実 node_modules 環境にて確認)

## 関連
- 親: #214(2026-07-14 round2 findings)。先行: PR #243(PR-1 認証ゲート堅牢化)
- 後続予定(別 PR): アカウント単位 2FA timestamp のセッション束縛(schema)、private-mode 共有リンク・backup code 並行消費・auto-delete race、refactor/hygiene
