### PR TITLE
fix(ci): migrate to pnpm 11 for the retired npm audit endpoint

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,9 +11,12 @@
     // },
 
     // Use 'postCreateCommand' to run commands after the container is created.
-    "postCreateCommand": "cp container.env.example .env && npm install",
+    // corepack enable needs root (/usr/local/bin); the devcontainer node user
+    // has passwordless sudo. pnpm is pinned to the same version as
+    // package.json's packageManager and the Dockerfile.
+    "postCreateCommand": "cp container.env.example .env && sudo corepack enable && corepack prepare pnpm@11.13.0 --activate && pnpm install",
     "postAttachCommand": {
-    	"npm": "npm run dev"
+    	"pnpm": "pnpm run dev"
     },
 
     // Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   app:
-    image: mcr.microsoft.com/devcontainers/typescript-node:latest
+    image: mcr.microsoft.com/devcontainers/typescript-node:22
 
     volumes:
       - ../..:/workspaces:cached

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -63,12 +63,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -94,12 +94,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-engine-strict=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,15 +3,15 @@
 # Multi-stage build for Next.js with pnpm
 # ===========================================
 
-FROM node:21-alpine AS base
+FROM node:22-alpine AS base
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
 WORKDIR /usr/app
 
 # Copy package files
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY prisma ./prisma
 
 # Install dependencies (--ignore-scripts skips postinstall which requires DB)
@@ -36,13 +36,13 @@ RUN pnpm build && rm -rf .next/cache
 # ===========================================
 # Runtime dependencies stage
 # ===========================================
-FROM node:21-alpine AS runtime-deps
+FROM node:22-alpine AS runtime-deps
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
 WORKDIR /usr/app
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY prisma ./prisma
 
 RUN pnpm install --frozen-lockfile --prod --ignore-scripts && \
@@ -51,9 +51,9 @@ RUN pnpm install --frozen-lockfile --prod --ignore-scripts && \
 # ===========================================
 # Runner stage
 # ===========================================
-FROM node:21-alpine AS runner
+FROM node:22-alpine AS runner
 
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@11.13.0 --activate
 
 EXPOSE 3000/tcp
 WORKDIR /usr/app

--- a/docs/deployment/local.md
+++ b/docs/deployment/local.md
@@ -4,7 +4,7 @@ Set up anon-spliit for local development.
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/) 22.13+
+- [Node.js](https://nodejs.org/) 22.13+ (22.x)
 - [pnpm](https://pnpm.io/) 11 package manager (installed automatically if you use corepack)
 - [Docker](https://www.docker.com/) or [Podman](https://podman.io/) (for PostgreSQL)
 

--- a/docs/deployment/local.md
+++ b/docs/deployment/local.md
@@ -4,8 +4,8 @@ Set up anon-spliit for local development.
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/) 18+
-- [pnpm](https://pnpm.io/) package manager
+- [Node.js](https://nodejs.org/) 22.13+
+- [pnpm](https://pnpm.io/) 11 package manager (installed automatically if you use corepack)
 - [Docker](https://www.docker.com/) or [Podman](https://podman.io/) (for PostgreSQL)
 
 ## Quick Start

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Anonymous bill splitting with end-to-end encryption. A privacy-focused fork of Spliit.",
   "private": true,
-  "packageManager": "pnpm@9.15.9",
+  "packageManager": "pnpm@11.13.0",
   "author": "sora-grayscale",
   "license": "MIT",
   "repository": {
@@ -11,8 +11,8 @@
     "url": "https://github.com/sora-grayscale/anon-spliit"
   },
   "engines": {
-    "node": ">=20",
-    "pnpm": ">=9.15.9 <10"
+    "node": ">=22.13.0 <23",
+    "pnpm": ">=11 <12"
   },
   "scripts": {
     "dev": "next dev",
@@ -118,15 +118,5 @@
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.3.3"
-  },
-  "pnpm": {
-    "overrides": {
-      "@babel/core": "^7.29.6",
-      "defu": "6.1.5",
-      "effect": "^3.20.0",
-      "picomatch@<2.3.2": "2.3.2",
-      "picomatch@>=4.0.0 <4.0.4": "4.0.4",
-      "postcss": "^8.5.16"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
-# pnpm settings (pnpm 10+ no longer reads the package.json "pnpm" field or
+# pnpm settings (pnpm 11+ no longer reads the package.json "pnpm" field or
 # non-auth settings from .npmrc; this file is their new home).
 engineStrict: true
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,11 @@
+# pnpm settings (pnpm 10+ no longer reads the package.json "pnpm" field or
+# non-auth settings from .npmrc; this file is their new home).
+engineStrict: true
+
+overrides:
+  '@babel/core': ^7.29.6
+  defu: 6.1.5
+  effect: ^3.20.0
+  'picomatch@<2.3.2': 2.3.2
+  'picomatch@>=4.0.0 <4.0.4': 4.0.4
+  postcss: ^8.5.16


### PR DESCRIPTION
## 背景

npm レジストリが 2026-07-15 に旧 quick-audit エンドポイントを恒久廃止し、`pnpm audit` が全 run で 410 を返すため、lint-and-typecheck ジョブ(Audit production dependencies ステップ)が main を含む全 PR で失敗する。`pnpm audit` が新しい bulk advisory エンドポイントを使うのは **pnpm v11 以降**で、pnpm 11 は **Node >=22.13** を要求するため、pnpm と Node をセットで更新する。

- pnpm 側 issue: pnpm/pnpm#11265 / npm 側告知: GitHub community discussion #192768

## 修正内容

- **package.json**: `packageManager: pnpm@11.13.0`、`engines.node: ">=22.13.0 <23"`(Vercel の Node 選択が 24 に流れないよう上限を明示)、`engines.pnpm: ">=11 <12"`。`pnpm.overrides` フィールドは削除(pnpm 11 は package.json の `pnpm` フィールドを読まない)
- **pnpm-workspace.yaml(新規)**: overrides 6 件と `engineStrict: true` の移行先。pnpm 11 は非認証設定を `.npmrc` から読まないため、`engine-strict=true` だけだった **`.npmrc` は削除**(黙殺による既存ポリシー喪失を防ぐ)
- **.github/workflows/ci.yml**: `pnpm/action-setup` v4 → **v6**(pnpm 11 向け bootstrap 実装済み。v4 は Node 20 で動き setup-node より先に走るため pnpm 11 を導入できない)、`node-version` '20' → '22'(3 ジョブ)。cd.yml は pnpm / node 非依存のため変更なし
- **Dockerfile**: `node:21-alpine`(EOL)→ `node:22-alpine`(3 ステージ)、`corepack prepare pnpm@latest` → **`pnpm@11.13.0` に固定**(3 箇所。runner は `pnpm start` を実行するため、将来の pnpm 12 混入や起動時の追加ダウンロードを防ぐ)、base / runtime-deps に `pnpm-workspace.yaml` を COPY(frozen install が lockfile 記録の overrides と照合するため必須)
- **docs/deployment/local.md**: 前提を Node 18+ → Node 22.13+ / pnpm 11 に更新

## 検証(Node 22.23.1 実バイナリ上)

- `pnpm@11.13.0 audit --prod --audit-level=high`: **No known vulnerabilities found**(exit 0、bulk エンドポイント使用)
- `pnpm@11.13.0 install --frozen-lockfile --ignore-scripts --lockfile-only`: 通過、**pnpm-lock.yaml はバイト単位で無変更**(overrides 移行が lockfile 記録と一致)
- jest full suite: 51 suites / 598 passed, 1 skipped / `tsc --noEmit`: 0 エラー / `next build`: 成功(CI と同一の dummy env)
- Docker smoke はローカルに docker がないため CI の docker-smoke-build ジョブで確認

## merge 前の確認事項(Vercel)

Vercel の公式対応表は pnpm 10 までのため、**Preview / Production に `ENABLE_EXPERIMENTAL_COREPACK=1` が設定済みであること**と、本 PR の Vercel ビルドログで **Node 22.x / pnpm 11.13.0** が実際に使われていることを確認してから merge する。

## 後続

merge 後、PR #244 ブランチへ最新 main を取り込んで push し、新しい pull_request run で全ジョブを検証する(既存 run の Re-run は旧 workflow / pnpm 9 のままのため不可)。
